### PR TITLE
`detectHostPortAddress` should return address is not blank

### DIFF
--- a/src/main/java/org/elasticsearch/hadoop/util/ConfigUtils.java
+++ b/src/main/java/org/elasticsearch/hadoop/util/ConfigUtils.java
@@ -23,7 +23,7 @@ public abstract class ConfigUtils {
 
     public static String detectHostPortAddress(Configuration cfg) {
         String address = cfg.get(ESConfigConstants.ES_ADDRESS);
-        return StringUtils.isBlank(address) ? address : detectHostPortAddress(null, 0, cfg);
+        return !StringUtils.isBlank(address) ? address : detectHostPortAddress(null, 0, cfg);
     }
 
     public static String detectHostPortAddress(String host, int port, Configuration cfg) {


### PR DESCRIPTION
& not the other way round?
