### PR TITLE
prefer Map serialization over Iterable

### DIFF
--- a/src/main/java/org/elasticsearch/hadoop/serialization/JdkValueWriter.java
+++ b/src/main/java/org/elasticsearch/hadoop/serialization/JdkValueWriter.java
@@ -79,13 +79,6 @@ public class JdkValueWriter implements ValueWriter<Object> {
             }
             generator.writeEndArray();
         }
-        else if (value instanceof Iterable) {
-            generator.writeBeginArray();
-            for (Object o : (Iterable<?>) value) {
-                write(o, generator);
-            }
-            generator.writeEndArray();
-        }
         else if (value instanceof Map) {
             generator.writeBeginObject();
             for (Entry<?, ?> entry : ((Map<?, ?>) value).entrySet()) {
@@ -93,6 +86,13 @@ public class JdkValueWriter implements ValueWriter<Object> {
                 write(entry.getValue(), generator);
             }
             generator.writeEndObject();
+        }
+        else if (value instanceof Iterable) {
+            generator.writeBeginArray();
+            for (Object o : (Iterable<?>) value) {
+                write(o, generator);
+            }
+            generator.writeEndArray();
         }
         else if (value instanceof Date) {
             throw new UnsupportedOperationException();


### PR DESCRIPTION
clojure's persistent Map implementations implement both java.util.Map and java.lang.Iterable, so they get serialised as JSON arrays

this patch prioritises Map serialization over Iterable serialization and fixes the problem : geoJSON can now be sent
