### PR TITLE
write Date/Calendar/Timestamp values as long milliseconds-since-epoch values

### DIFF
--- a/src/main/java/org/elasticsearch/hadoop/serialization/JdkValueWriter.java
+++ b/src/main/java/org/elasticsearch/hadoop/serialization/JdkValueWriter.java
@@ -95,13 +95,14 @@ public class JdkValueWriter implements ValueWriter<Object> {
             generator.writeEndArray();
         }
         else if (value instanceof Date) {
-            throw new UnsupportedOperationException();
+            generator.writeNumber(((Date)value).getTime());
         }
         else if (value instanceof Calendar) {
+            generator.writeNumber(((Calendar)value).getTimeInMillis());
             throw new UnsupportedOperationException();
         }
         else if (value instanceof Timestamp) {
-            throw new UnsupportedOperationException();
+            generator.writeNumber(((Timestamp)value).getTime());
         }
         else {
             if (writeUnknownTypes) {


### PR DESCRIPTION
since ES Date fields can always be written as a long milliseconds-since-epoch value ( http://www.elasticsearch.org/guide/reference/mapping/core-types/ ), and Date/Calendar/Timestamp can all easily be converted to such a value, it makes sense to write them so
