### PR TITLE
ignore nested mapping and return the contents of nested type as map

### DIFF
--- a/src/main/java/org/elasticsearch/hadoop/rest/dto/mapping/Field.java
+++ b/src/main/java/org/elasticsearch/hadoop/rest/dto/mapping/Field.java
@@ -103,12 +103,18 @@ public class Field implements Serializable {
         if (value instanceof Map) {
             Map<String, Object> content = (Map<String, Object>) value;
 
+            FieldType fieldType = null;
             // check type first
             Object type = content.get("type");
             if (type instanceof String) {
                 String typeString = type.toString();
-                FieldType fieldType = FieldType.parse(typeString);
+                fieldType = FieldType.parse(typeString);
+                if(fieldType == FieldType.NESTED){
+                    fieldType = null; //ignore nested type and just return the object
+                }
+            }
 
+            if (fieldType != null) {
                 // handle multi_field separately
                 if (FieldType.MULTI_FIELD == fieldType) {
                     // get fields

--- a/src/main/java/org/elasticsearch/hadoop/serialization/FieldType.java
+++ b/src/main/java/org/elasticsearch/hadoop/serialization/FieldType.java
@@ -77,7 +77,7 @@ public enum FieldType {
             return false;
         }
 
-        if (IP == fieldType || NESTED == fieldType ||
+        if (IP == fieldType ||
                 GEO_POINT == fieldType || GEO_SHAPE == fieldType ||
                 POINT == fieldType || LINESTRING == fieldType || POLYGON == fieldType ||
                 MULTIPOINT == fieldType || MULTIPOLYGON == fieldType || ENVELOPE == fieldType) {


### PR DESCRIPTION
ignore nested mapping and return the contents of nested type as map.

When you have an ES index with NESTED Mappings, you can now read these indices.
