### PR TITLE
Fix a couple typos in docs

### DIFF
--- a/docs/src/reference/asciidoc/core/mr.adoc
+++ b/docs/src/reference/asciidoc/core/mr.adoc
@@ -3,7 +3,7 @@
 
 For low-level or performance-sensitive environments, {eh} provides dedicated `InputFormat` and `OutputFormat` implementations that can read and write data to {es}.
 In {mr}, the ++Mapper++s and ++Reducer++s are reading and writing `Writable` objects, a Hadoop specific interface optimized for serialization. As such {eh} `InputFormat` and `OutputFormat` will return and expect a `MapWritable` objects, that is a map for each document being read or written. The map itself can have any type of internal structure as long as its objects are also `Writable` - it can hold nested maps, numbers or strings in their `Writable` representation.
-Internally {eh} automatically convert the `Map` of `Writable` to JSON documents and vice-versa so you do not have to deal with the low-level parsing or conversion to and from JSON. More-over, if the data sent to {es} is already in JSON format, it can be streamed in directly without any conversion to `Writable` objects.
+Internally {eh} automatically convert the `Map` of `Writable` to JSON documents and vice-versa so you do not have to deal with the low-level parsing or conversion to and from JSON. Moreover, if the data sent to {es} is already in JSON format, it can be streamed in directly without any conversion to `Writable` objects.
 Read the rest of the chapter to find out more.
 
 [float]
@@ -95,7 +95,7 @@ public class MyMapper extends MapReduceBase implements Mapper {
 ==== Writing existing JSON to {es}
 
 For cases where the job output data is already in JSON, {eh} allows direct indexing _without_ applying any transformation; the data is taken as is and sent directly to {es}. In such cases, one needs to indicate the json input by setting
-the `es.input.json` parameter. As such, in this case {eh} expects either a `Text` or `BytesWritable` (preffered as it requires no `String` conversion) object as output; if these types are not used, the library will simply fall back to the `toString` representation of the target object.
+the `es.input.json` parameter. As such, in this case {eh} expects either a `Text` or `BytesWritable` (preferred as it requires no `String` conversion) object as output; if these types are not used, the library will simply fall back to the `toString` representation of the target object.
 
 .`Writable` to use for JSON representation
 


### PR DESCRIPTION
This fixes a couple typos in the docs that I noticed while reading...
