### PR TITLE
Clarify that "index" write operation replaces data

### DIFF
--- a/docs/src/reference/asciidoc/core/configuration.adoc
+++ b/docs/src/reference/asciidoc/core/configuration.adoc
@@ -121,7 +121,7 @@ integration for more details about using JSON directly.
 
 `es.write.operation` (default index)::
 The write operation {eh} should peform - can be any of:
-`index` (default);; new data is added while existing data (based on its id) is updated.
+`index` (default);; new data is added while existing data (based on its id) is replaced.
 `create`;; adds new data - if the data already exists (based on its id), an exception is thrown.
 `update`;; updates existing data (based on its id). If no data is found, an exception is thrown.
 `upsert`;; known as _merge_ or insert if the data does not exist, updates if the data exists (based on its id).


### PR DESCRIPTION
The "index" write operation replaces documents based on ID, it does not update them. The single word change helps distinguish from upsert.
