### PR TITLE
Added `es.batch.write.ignore.existing` option

### DIFF
--- a/mr/src/main/java/org/elasticsearch/hadoop/cfg/ConfigurationOptions.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/cfg/ConfigurationOptions.java
@@ -75,6 +75,9 @@ public interface ConfigurationOptions {
     String ES_BATCH_WRITE_RETRY_POLICY_SIMPLE = "simple";
     String ES_BATCH_WRITE_RETRY_POLICY_DEFAULT = ES_BATCH_WRITE_RETRY_POLICY_SIMPLE;
 
+    String ES_BATCH_WRITE_IGNORE_EXISTING = "es.batch.write.ignore.existing";
+    String ES_BATCH_WRITE_IGNORE_EXISTING_DEFAULT = "false";
+
     /** HTTP connection timeout */
     String ES_HTTP_TIMEOUT = "es.http.timeout";
     String ES_HTTP_TIMEOUT_DEFAULT = "1m";
@@ -171,7 +174,6 @@ public interface ConfigurationOptions {
     String ES_UPDATE_SCRIPT_LANG = "es.update.script.lang";
     String ES_UPDATE_SCRIPT_PARAMS = "es.update.script.params";
     String ES_UPDATE_SCRIPT_PARAMS_JSON = "es.update.script.params.json";
-
 
     /** Network options */
     String ES_NET_PROXY_HTTP_HOST = "es.net.proxy.http.host";

--- a/mr/src/main/java/org/elasticsearch/hadoop/cfg/Settings.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/cfg/Settings.java
@@ -93,6 +93,10 @@ public abstract class Settings {
         return Booleans.parseBoolean(getProperty(ES_BATCH_FLUSH_MANUAL, ES_BATCH_FLUSH_MANUAL_DEFAULT));
     }
 
+    public boolean getBatchWriteIgnoreExisting() {
+        return Booleans.parseBoolean(getProperty(ES_BATCH_WRITE_IGNORE_EXISTING, ES_BATCH_WRITE_IGNORE_EXISTING_DEFAULT));
+    }
+
     public long getScrollKeepAlive() {
         return TimeValue.parseTimeValue(getProperty(ES_SCROLL_KEEPALIVE, ES_SCROLL_KEEPALIVE_DEFAULT)).getMillis();
     }


### PR DESCRIPTION
If `es.batch.write.ignore.existing` is set to `true` then es-hadoop will ignore existing documents during a `bulk create` operation (#307).
