### PR TITLE
Fix nested type serialization

### DIFF
--- a/mr/src/main/java/org/elasticsearch/hadoop/mr/WritableValueReader.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/mr/WritableValueReader.java
@@ -83,6 +83,7 @@ public class WritableValueReader extends JdkValueReader {
             arrayType = BytesWritable.class;
             break;
         case OBJECT:
+        case NESTED:
             arrayType = LinkedMapWritable.class;
             break;
         // everything else gets translated to String


### PR DESCRIPTION
It seems that we are getting nested type serialized as `Text` by default as it wasn't explicitly handled.
