### PR TITLE
Added ability to exclude fields from the es mapping via 'es.mapping.exclude' config to ScalaValueWriter and SchemaRDDValueWriter             

### DIFF
--- a/spark/src/itest/java/org/elasticsearch/spark/integration/AbstractJavaEsSparkSQLTest.java
+++ b/spark/src/itest/java/org/elasticsearch/spark/integration/AbstractJavaEsSparkSQLTest.java
@@ -94,6 +94,16 @@ public class AbstractJavaEsSparkSQLTest implements Serializable {
 		assertThat(RestUtils.exists(target + "/1"), is(true));
 	}
 
+    @Test
+    public void testEsSchemaRDD1WriteWithMappingExclude() throws Exception {
+        JavaSchemaRDD schemaRDD = artistsAsSchemaRDD();
+
+        String target = "sparksql-test/scala-basic-write-exclude-mapping";
+        JavaEsSparkSQL.saveToEs(schemaRDD, target,ImmutableMap.of(ES_MAPPING_EXCLUDE, "url"));
+        assertTrue(RestUtils.exists(target));
+        assertThat(RestUtils.get(target + "/_search?"), not(containsString("url")));
+    }
+
 	@Test
 	public void testEsSchemaRDD2Read() throws Exception {
 		String target = "sparksql-test/scala-basic-write";

--- a/spark/src/itest/java/org/elasticsearch/spark/integration/AbstractJavaEsSparkTest.java
+++ b/spark/src/itest/java/org/elasticsearch/spark/integration/AbstractJavaEsSparkTest.java
@@ -139,6 +139,22 @@ public class AbstractJavaEsSparkTest implements Serializable {
         String results = RestUtils.get(target + "/_search?");
         assertThat(results, containsString("SFO"));
     }
+
+    @Test
+    public void testEsRDDWriteWithMappingExclude() throws Exception {
+        Map<String, ?> doc1 = ImmutableMap.of("reason", "business", "airport", "SFO");
+        Map<String, ?> doc2 = ImmutableMap.of("participants", 2, "airport", "OTP");
+
+        String target = "spark-test/java-exclude-write";
+
+        JavaRDD<Map<String, ?>> javaRDD = sc.parallelize(ImmutableList.of(doc1, doc2));
+        JavaEsSpark.saveToEs(javaRDD, target, ImmutableMap.of(ES_MAPPING_EXCLUDE, "airport"));
+
+        assertTrue(RestUtils.exists(target));
+        assertThat(RestUtils.get(target + "/_search?"), containsString("business"));
+        assertThat(RestUtils.get(target + "/_search?"), containsString("participants"));
+        assertThat(RestUtils.get(target + "/_search?"), not(containsString("airport")));
+    }
     
 	@Test
     public void testEsMultiIndexRDDWrite() throws Exception {

--- a/spark/src/itest/scala/org/elasticsearch/spark/integration/AbstractScalaEsSparkSQL.scala
+++ b/spark/src/itest/scala/org/elasticsearch/spark/integration/AbstractScalaEsSparkSQL.scala
@@ -38,6 +38,7 @@ import org.elasticsearch.spark.sql._
 import org.elasticsearch.spark.sql.sqlContextFunctions
 import org.hamcrest.Matchers.containsString
 import org.hamcrest.Matchers.is
+import org.hamcrest.Matchers.not
 import org.junit.AfterClass
 import org.junit.Assert._
 import org.junit.BeforeClass
@@ -104,10 +105,11 @@ class AbstractScalaEsScalaSparkSQL extends Serializable {
       val schemaRDD = artistsAsSchemaRDD
 
       val target = "sparksql-test/scala-basic-write-id-mapping"
-      schemaRDD.saveToEs(target, Map(ES_MAPPING_ID -> "id"))
+      schemaRDD.saveToEs(target, Map(ES_MAPPING_ID -> "id", ES_MAPPING_EXCLUDE -> "url"))
       assertTrue(RestUtils.exists(target))
       assertThat(RestUtils.get(target + "/_search?"), containsString("345"))
       assertThat(RestUtils.exists(target + "/1"), is(true))
+      assertThat(RestUtils.get(target + "/_search?"), not(containsString("url")))
     }
 
     @Test

--- a/spark/src/main/scala/org/elasticsearch/spark/serialization/ScalaValueWriter.scala
+++ b/spark/src/main/scala/org/elasticsearch/spark/serialization/ScalaValueWriter.scala
@@ -33,10 +33,12 @@ class ScalaValueWriter(writeUnknownTypes: Boolean = false) extends JdkValueWrite
       case m: Map[_, AnyRef] => {
         generator.writeBeginObject()
         for ((k, v) <- m) {
-          generator.writeFieldName(k.toString())
-          val result = doWrite(v, generator, false)
-          if (!result.isSuccesful()) {
-            return result
+          if (shouldKeep(generator.getParentPath(), k.toString())) {
+            generator.writeFieldName(k.toString())
+            val result = doWrite(v, generator, false)
+            if (!result.isSuccesful()) {
+              return result
+            }
           }
         }
         generator.writeEndObject()


### PR DESCRIPTION
This is partially referenced in issues#381; however this fix will not work when using saveJsonToEs.