### PR TITLE
Use javadoc of Cascading 2.6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -287,7 +287,7 @@ allprojects { project ->
                 "http://pig.apache.org/docs/r0.14.0/api/",
                 // r0.13.1 is invalid as it does not provide the package list
                 "http://hive.apache.org/javadocs/r0.12.0/api/",
-                "http://docs.cascading.org/cascading/2.5/javadoc/",
+                "http://docs.cascading.org/cascading/2.6/javadoc/",
                 "http://spark.apache.org/docs/latest/api/java/",
                 "http://storm.apache.org/apidocs/"
             ]


### PR DESCRIPTION
since you use Cascading 2.6.3 as a dependency, it should also point to the correct javadoc.