### PR TITLE
Adding possibility to backup indexes into hdfs authorized by kerberos.

### DIFF
--- a/repository-hdfs/src/itest/resources/elasticsearch.yml
+++ b/repository-hdfs/src/itest/resources/elasticsearch.yml
@@ -10,5 +10,8 @@ repositories:
         concurrent_streams: "2"
         compress: "true"
         chunk_size: "1mb"
+        conf.kerberos_config: "/etc/krb5.conf"
+        conf.hdfs_config: "/etc/hadoop/hdfs-site.xml"
+        conf.hadoop_config: "/etc/hadoop/core-site.xml"
 
 

--- a/repository-hdfs/src/main/java/org/elasticsearch/repositories/hdfs/HdfsRepository.java
+++ b/repository-hdfs/src/main/java/org/elasticsearch/repositories/hdfs/HdfsRepository.java
@@ -113,18 +113,18 @@ public class HdfsRepository extends BlobStoreRepository {
         }
     }
 
-  private void initAuthorization(RepositorySettings repositorySettings, Configuration cfg) {
-    String authenticationType = repositorySettings.settings().get("authentication_type");
-    if ("kerberos".equals(authenticationType)) {
-      System.setProperty("java.security.krb5.conf", cfg.get("kerberos_config"));
-      cfg.addResource(new Path(cfg.get("hdfs_config")));
-      cfg.addResource(new Path(cfg.get("hadoop_config")));
-      cfg.set("hadoop.security.authentication", authenticationType);
-      UserGroupInformation.setConfiguration(cfg);
-    }
-  }
+    private void initAuthorization(RepositorySettings repositorySettings, Configuration cfg) {
+        String authenticationType = repositorySettings.settings().get("authentication_type");
+        if ("kerberos".equals(authenticationType)) {
+            System.setProperty("java.security.krb5.conf", cfg.get("kerberos_config"));
+            cfg.addResource(new Path(cfg.get("hdfs_config")));
+            cfg.addResource(new Path(cfg.get("hadoop_config")));
+            cfg.set("hadoop.security.authentication", authenticationType);
+            UserGroupInformation.setConfiguration(cfg);
+        }
+      }
 
-  private void addConfigLocation(Configuration cfg, String confLocation) {
+    private void addConfigLocation(Configuration cfg, String confLocation) {
         URL cfgURL = null;
         // it's an URL
         if (!confLocation.contains(":")) {


### PR DESCRIPTION
Adding possibility to backup indexes into hdfs authorized by kerberos.

Configuration of kerberos and hdfs can be set into elasticsearch.yml
repository:
  hdfs: 
     conf.kerberos_config: "/etc/krb5.conf"
      conf.hdfs_config: "/etc/hadoop/hdfs-site.xml"
      conf.hadoop_config: "/etc/hadoop/core-site.xml"
