### PR TITLE
Add automatic field detection to EsHadoopScheme and EsTap.

### DIFF
--- a/cascading/src/itest/java/org/elasticsearch/hadoop/integration/cascading/AbstractCascadingHadoopSearchTest.java
+++ b/cascading/src/itest/java/org/elasticsearch/hadoop/integration/cascading/AbstractCascadingHadoopSearchTest.java
@@ -96,6 +96,18 @@ public class AbstractCascadingHadoopSearchTest {
     }
 
     @Test
+    public void testReadFromESWithoutFields() throws Exception {
+        Tap in = new EsTap("cascading-hadoop/artists", query);
+        Pipe pipe = new Pipe("copy");
+        pipe = new Each(pipe, AssertionLevel.STRICT, new AssertSizeEquals(3));
+        pipe = new Each(pipe, AssertionLevel.STRICT, new AssertNotNull());
+
+        // print out
+        Tap out = new HadoopPrintStreamTap(Stream.NULL);
+        build(cfg(), in, out, pipe);
+    }
+
+    @Test
     public void testReadFromESAliasedField() throws Exception {
         Tap in = new EsTap("cascading-hadoop/alias", query, new Fields("address"));
         Pipe pipe = new Pipe("copy");

--- a/cascading/src/main/java/org/elasticsearch/hadoop/cascading/EsHadoopScheme.java
+++ b/cascading/src/main/java/org/elasticsearch/hadoop/cascading/EsHadoopScheme.java
@@ -20,10 +20,13 @@ package org.elasticsearch.hadoop.cascading;
 
 import java.io.IOException;
 import java.util.Collection;
+import java.util.Iterator;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
+import org.apache.commons.io.IOUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.io.Text;
@@ -37,6 +40,7 @@ import org.elasticsearch.hadoop.mr.EsInputFormat;
 import org.elasticsearch.hadoop.mr.EsOutputFormat;
 import org.elasticsearch.hadoop.mr.HadoopCfgUtils;
 import org.elasticsearch.hadoop.rest.InitializationUtils;
+import org.elasticsearch.hadoop.rest.RestClient;
 import org.elasticsearch.hadoop.serialization.builder.JdkValueReader;
 import org.elasticsearch.hadoop.util.FieldAlias;
 import org.elasticsearch.hadoop.util.SettingsUtils;
@@ -50,6 +54,9 @@ import cascading.tap.Tap;
 import cascading.tuple.Fields;
 import cascading.tuple.Tuple;
 import cascading.tuple.TupleEntry;
+
+import org.codehaus.jackson.JsonNode;
+import org.codehaus.jackson.map.ObjectMapper;
 
 /**
  * Cascading Scheme handling
@@ -117,6 +124,46 @@ class EsHadoopScheme extends Scheme<JobConf, RecordReader, OutputCollector, Obje
         super.sinkCleanup(flowProcess, sinkCall);
 
         sinkCall.setContext(null);
+    }
+
+    @Override
+    public Fields retrieveSourceFields(final FlowProcess<JobConf> flowProcess, final Tap tap) {
+        if (getSourceFields() == Fields.UNKNOWN) {
+            log.info("resource: " + index);
+            String[] parts = index.split("/");
+            if (parts.length == 2) {
+                String myIndex = parts[0];
+                String docType = parts[1];
+                log.info("index: " + myIndex + ", type: " + docType);
+
+                String mappingsUrl = "/" + myIndex + "/_mapping/" + docType;
+                log.info("mapping URL: " + mappingsUrl);
+                Settings settings = loadSettings(flowProcess.getConfigCopy(), false);
+                RestClient client = new RestClient(settings);
+                try {
+                    String responseBody = IOUtils.toString(client.getRaw(mappingsUrl));
+
+                    // extract fields from the response body
+                    JsonNode mappingsObj = new ObjectMapper().readTree(responseBody)
+                        .path(myIndex).path("mappings")
+                        .path(docType).path("properties");
+                    Iterator<String> fieldsIterator = mappingsObj.getFieldNames();
+                    List<String> fieldList = new ArrayList<String>();
+                    while (fieldsIterator.hasNext())
+                        fieldList.add(fieldsIterator.next());
+                    String[] fieldNames = new String[fieldList.size()];
+                    fieldList.toArray(fieldNames);
+                    Fields fields = new Fields(fieldNames);
+                    log.info("fields: " + fieldNames);
+                    setSourceFields(fields);
+                } catch (IOException e) {
+                    log.info("no fields found in the mapping");
+                } finally {
+                    client.close();
+                }
+            }
+        }
+        return getSourceFields();
     }
 
     @Override

--- a/cascading/src/main/java/org/elasticsearch/hadoop/cascading/EsHadoopScheme.java
+++ b/cascading/src/main/java/org/elasticsearch/hadoop/cascading/EsHadoopScheme.java
@@ -128,7 +128,8 @@ class EsHadoopScheme extends Scheme<JobConf, RecordReader, OutputCollector, Obje
 
     @Override
     public Fields retrieveSourceFields(final FlowProcess<JobConf> flowProcess, final Tap tap) {
-        if (getSourceFields() == Fields.UNKNOWN) {
+        Settings settings = loadSettings(flowProcess.getConfigCopy(), false);
+        if (getSourceFields() == Fields.UNKNOWN && settings.getFieldDetection()) {
             log.info("resource: " + index);
             String[] parts = index.split("/");
             if (parts.length == 2) {
@@ -138,7 +139,6 @@ class EsHadoopScheme extends Scheme<JobConf, RecordReader, OutputCollector, Obje
 
                 String mappingsUrl = "/" + myIndex + "/_mapping/" + docType;
                 log.info("mapping URL: " + mappingsUrl);
-                Settings settings = loadSettings(flowProcess.getConfigCopy(), false);
                 RestClient client = new RestClient(settings);
                 try {
                     String responseBody = IOUtils.toString(client.getRaw(mappingsUrl));

--- a/cascading/src/main/java/org/elasticsearch/hadoop/cascading/EsTap.java
+++ b/cascading/src/main/java/org/elasticsearch/hadoop/cascading/EsTap.java
@@ -141,6 +141,12 @@ public class EsTap extends Tap<Object, Object, Object> {
     }
 
     @Override
+    public Fields retrieveSourceFields(FlowProcess<Object> flowProcess) {
+        initInnerTapIfNotSetFromFlowProcess(flowProcess);
+        return actualTap.retrieveSourceFields(flowProcess);
+    }
+
+    @Override
     public TupleEntryCollector openForWrite(FlowProcess<Object> flowProcess, Object output) throws IOException {
         initInnerTapIfNotSetFromFlowProcess(flowProcess);
         return actualTap.openForWrite(flowProcess, output);

--- a/mr/src/main/java/org/elasticsearch/hadoop/cfg/ConfigurationOptions.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/cfg/ConfigurationOptions.java
@@ -121,6 +121,8 @@ public interface ConfigurationOptions {
     /** Field options **/
     String ES_FIELD_READ_EMPTY_AS_NULL = "es.field.read.empty.as.null";
     String ES_FIELD_READ_EMPTY_AS_NULL_DEFAULT = "yes";
+    String ES_AUTO_DETECT_FIELDS = "es.field.auto.detect";
+    String ES_AUTO_DETECT_FIELDS_DEFAULT = "false";
 
     String ES_FIELD_READ_VALIDATE_PRESENCE = "es.field.read.validate.presence";
     String ES_FIELD_READ_VALIDATE_PRESENCE_DEFAULT = "warn";

--- a/mr/src/main/java/org/elasticsearch/hadoop/cfg/Settings.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/cfg/Settings.java
@@ -142,6 +142,10 @@ public abstract class Settings {
         return Booleans.parseBoolean(getProperty(ES_OUTPUT_JSON, ES_OUTPUT_JSON_DEFAULT));
     }
 
+    public boolean getFieldDetection() {
+        return Booleans.parseBoolean(getProperty(ES_AUTO_DETECT_FIELDS, ES_AUTO_DETECT_FIELDS_DEFAULT));
+    }
+
     public String getOperation() {
         return getProperty(ES_WRITE_OPERATION, ES_WRITE_OPERATION_DEFAULT).toLowerCase(Locale.ENGLISH);
     }

--- a/mr/src/main/java/org/elasticsearch/hadoop/rest/RestClient.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/rest/RestClient.java
@@ -118,6 +118,10 @@ public class RestClient implements Closeable, StatsAware {
         return parseContent(execute(GET, q), string);
     }
 
+    public InputStream getRaw(String q) {
+        return execute(GET, q);
+    }
+
     @SuppressWarnings("unchecked")
     private <T> T parseContent(InputStream content, String string) {
         Map<String, Object> map = Collections.emptyMap();


### PR DESCRIPTION
This feature branch overrides the retrieveSourceFields method in EsHadoopScheme. Note that it involves a REST query to extract the field names from elasticsearch, and as such, RestClient needs a public GET method.
