### PR TITLE
Fixing NPE on close in RestRepository

### DIFF
--- a/mr/src/main/java/org/elasticsearch/hadoop/rest/RestRepository.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/rest/RestRepository.java
@@ -250,16 +250,16 @@ public class RestRepository implements Closeable, StatsAware {
             }
         }
 
-        if (requiresRefreshAfterBulk && executedBulkWrite) {
-            // refresh batch
-            client.refresh(resourceW);
-
-            if (log.isDebugEnabled()) {
-                log.debug(String.format("Refreshing index [%s]", resourceW));
-            }
-        }
-
         if (client != null) {
+            if (requiresRefreshAfterBulk && executedBulkWrite) {
+                // refresh batch
+                client.refresh(resourceW);
+
+                if (log.isDebugEnabled()) {
+                    log.debug(String.format("Refreshing index [%s]", resourceW));
+                }
+            }
+
             client.close();
             stats.aggregate(client.stats());
             client = null;


### PR DESCRIPTION
See Issue: https://github.com/elastic/elasticsearch-hadoop/issues/487

In the class `org.elasticsearch.hadoop.rest.RestRepository`, if you call `close()` multiple times in a row (which happens occasionally in our libs because of chained close calls), every time after the first will 
throw a NullPointerException if `requiresRefreshAfterBulk && executedBulkWrite` evaluates to true:

### RestRepository.java (snippet)
(See source here: 
https://github.com/elastic/elasticsearch-hadoop/blob/master/mr/src/main/java/org/elasticsearch/hadoop/rest/RestRepository.java#L255)
```java

public void close() {
    ...
    if (requiresRefreshAfterBulk && executedBulkWrite) {
        // refresh batch
        client.refresh(resourceW); // THIS THROWS THE NPE BECAUSE 
                                   // IT GETS SET TO NULL BELOW

        if (log.isDebugEnabled()) {
            log.debug(String.format("Refreshing index [%s]", resourceW));
        }
    }

    if (client != null) {
        client.close();
        stats.aggregate(client.stats());
        client = null; // THIS FIRES THE FIRST TIME THROUGH AND MAKES THE REST FAIL
    }
}
```

Popping the refresh logic into the `client != null` block seems like the most correct solution.