### PR TITLE
Make the project compilable when it's added as a git submodule

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -110,6 +110,16 @@ if (rootProject == project) {
 def File gitBranch() {
     // parse the git files to find out the revision
     File gitHead =  file("$rootDir/.git/HEAD")
+    if (gitHead != null && !gitHead.exists()) {
+      // Try as a sub module
+      subModuleGit = file("$rootDir/.git")
+      if (subModuleGit != null && subModuleGit.exists()) {
+        String content = subModuleGit.text.trim()
+        if (content.startsWith("gitdir:")) {
+            gitHead = file("$rootDir/" + content.replace('gitdir: ','') + "/HEAD")
+        }
+      }
+    }
 
     if (gitHead != null && gitHead.exists()) {
         String content = gitHead.text.trim()


### PR DESCRIPTION
The previous gitBranch() function only search '$rootDir/.git/HEAD' file.
But, when the project is added as a git sub module, the '$rootDir/.git'
is a file, not a directory. The file stores the module git repository
directory. So the change is to help finding the submodule local git
repository.

Signed-off-by: Zhang Wei <weiz@lambdacloud.com>