### PR TITLE
Array support for Scala serialization

### DIFF
--- a/spark/core/main/scala/org/elasticsearch/spark/serialization/ScalaValueWriter.scala
+++ b/spark/core/main/scala/org/elasticsearch/spark/serialization/ScalaValueWriter.scala
@@ -52,6 +52,17 @@ class ScalaValueWriter(writeUnknownTypes: Boolean = false) extends JdkValueWrite
         generator.writeEndArray()
       }
 
+      case i: Array[_] => {
+        generator.writeBeginArray()
+        for (v <- i) {
+          val result = doWrite(v, generator, false)
+          if (!result.isSuccesful()) {
+            return result
+          }
+        }
+        generator.writeEndArray()
+      }
+
       case p: Product => {
         // handle case class
         if (RU.isCaseClass(p)) {

--- a/spark/core/test/scala/org/elasticsearch/spark/serialization/ScalaValueWriterTest.scala
+++ b/spark/core/test/scala/org/elasticsearch/spark/serialization/ScalaValueWriterTest.scala
@@ -1,0 +1,60 @@
+package org.elasticsearch.spark.serialization
+
+import org.elasticsearch.hadoop.serialization.json.JacksonJsonGenerator
+import org.junit.Assert._
+import org.junit.Test
+import org.junit.Assert._
+import org.hamcrest.Matchers._
+import java.io.ByteArrayOutputStream
+
+class ScalaValueWriterTest {
+
+  private def serialize(value: AnyRef): String = {
+    val out = new ByteArrayOutputStream()
+    val generator = new JacksonJsonGenerator(out)
+
+    val writer = new ScalaValueWriter()
+    writer.write(value, generator)
+    generator.flush()
+
+    new String(out.toByteArray)
+  }
+
+  case class SimpleCaseClass(s: String)
+
+  @Test
+  def testSimpleMap() {
+    assertEquals("""{"a":"b"}""", serialize(Map("a" -> "b")))
+  }
+
+  @Test
+  def testPrimitiveArray() {
+    assertEquals("""[1,2,3]""", serialize(Array(1,2,3)))
+  }
+
+  @Test
+  def testPrimitiveSeq() {
+    assertEquals("""[1,2,3]""", serialize(Seq(1,2,3)))
+  }
+
+  @Test
+  def testMapInArray() {
+    assertEquals("""[{"a":"b"}]""", serialize(Array(Map("a" -> "b"))))
+  }
+
+  @Test
+  def testMapInSeq() {
+    assertEquals("""[{"a":"b"}]""", serialize(Seq(Map("a" -> "b"))))
+  }
+
+  @Test
+  def testCaseClass(){
+    assertEquals("""{"s":"foo"}""", serialize(SimpleCaseClass("foo")))
+  }
+
+  @Test
+  def testNestedMap(){
+    assertEquals("""{"p":{"s":"bar"}}""", serialize(Map("p" -> SimpleCaseClass("bar"))))
+  }
+
+}


### PR DESCRIPTION
`ScalaValueWriter` can't serialize `Array` in elasticsearch-hadoop 2.1.0.
It had been possible until 2.1.0.Beta3, so we can't upgrade to elasticsearch-hadoop 2.1.0 from Beta3.

Attached testcase success with my fix, but array cases fails with elasticsearch-hadoop 2.1.0.