### PR TITLE
Do not route MapReduce reads and writes through non-data nodes

### DIFF
--- a/cascading/src/main/java/org/elasticsearch/hadoop/cascading/CascadingUtils.java
+++ b/cascading/src/main/java/org/elasticsearch/hadoop/cascading/CascadingUtils.java
@@ -61,6 +61,7 @@ public abstract class CascadingUtils {
 
         InitializationUtils.discoverNodesIfNeeded(settings, log);
         InitializationUtils.filterNonClientNodesIfNeeded(settings, log);
+        InitializationUtils.filterNonDataNodesIfNeeded(settings, log);
         InitializationUtils.discoverEsVersion(settings, log);
 
         InitializationUtils.setValueWriterIfNotSet(settings, CascadingValueWriter.class, log);

--- a/docs/src/reference/asciidoc/core/configuration.adoc
+++ b/docs/src/reference/asciidoc/core/configuration.adoc
@@ -301,6 +301,10 @@ Whether to discovery the nodes within the {es} cluster or only to use the ones g
 `es.nodes.client.only` (default false)::
 Whether to use {es} {ref}/modules-node.html[client nodes] (or _load-balancers_). When enabled, {eh} will route _all_ its requests (after nodes discovery, if enabled) through the _client_ nodes within the cluster. Note this typically significantly reduces the node parallelism and thus it is disabled by default.
 
+`es.nodes.data.only` (default true)::
+Whether to use {es} {ref}/modules-node.html[data nodes] only. When enabled, {eh} will route _all_ its requests (after nodes discovery, if enabled) through the _data_ nodes within the cluster. The purpose of this configuration setting is to avoid overwhelming non-data nodes as these tend to be "smaller" nodes. This is enabled by default.
+
+added[2.2]
 `es.http.timeout` (default 1m)::
 Timeout for HTTP/REST connections to {es}.
 

--- a/mr/src/main/java/org/elasticsearch/hadoop/cfg/ConfigurationOptions.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/cfg/ConfigurationOptions.java
@@ -51,6 +51,10 @@ public interface ConfigurationOptions {
     String ES_NODES_CLIENT_ONLY = "es.nodes.client.only";
     String ES_NODES_CLIENT_ONLY_DEFAULT = "false";
 
+    /** Data only */
+    String ES_NODES_DATA_ONLY = "es.nodes.data.only";
+    String ES_NODES_DATA_ONLY_DEFAULT = "true";
+
     /** Elasticsearch batch size given in bytes */
     String ES_BATCH_SIZE_BYTES = "es.batch.size.bytes";
     String ES_BATCH_SIZE_BYTES_DEFAULT = "1mb";

--- a/mr/src/main/java/org/elasticsearch/hadoop/cfg/Settings.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/cfg/Settings.java
@@ -61,6 +61,10 @@ public abstract class Settings {
         return Booleans.parseBoolean(getProperty(ES_NODES_CLIENT_ONLY, ES_NODES_CLIENT_ONLY_DEFAULT));
     }
 
+    public boolean getNodesDataOnly() {
+        return Booleans.parseBoolean(getProperty(ES_NODES_DATA_ONLY, ES_NODES_DATA_ONLY_DEFAULT));
+    }
+
     public long getHttpTimeout() {
         return TimeValue.parseTimeValue(getProperty(ES_HTTP_TIMEOUT, ES_HTTP_TIMEOUT_DEFAULT)).getMillis();
     }

--- a/mr/src/main/java/org/elasticsearch/hadoop/rest/RestClient.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/rest/RestClient.java
@@ -283,6 +283,19 @@ public class RestClient implements Closeable, StatsAware {
         return nodes;
     }
 
+    public List<String> getHttpDataNodes() {
+        Map<String, Map<String, Object>> nodesData = get("_nodes/http", "nodes");
+        List<String> nodes = new ArrayList<String>();
+
+        for (Entry<String, Map<String, Object>> entry : nodesData.entrySet()) {
+            Node node = new Node(entry.getKey(), entry.getValue());
+            if (node.isData() && node.hasHttp()) {
+                nodes.add(node.getInet());
+            }
+        }
+        return nodes;
+    }
+
     @SuppressWarnings("unchecked")
     public Map<String, Object> getMapping(String query) {
         return (Map<String, Object>) get(query, null);

--- a/mr/src/main/java/org/elasticsearch/hadoop/rest/RestService.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/rest/RestService.java
@@ -226,6 +226,7 @@ public abstract class RestService implements Serializable {
 
         InitializationUtils.discoverNodesIfNeeded(settings, log);
         InitializationUtils.filterNonClientNodesIfNeeded(settings, log);
+        InitializationUtils.filterNonDataNodesIfNeeded(settings, log);
         InitializationUtils.discoverEsVersion(settings, log);
 
         String savedSettings = settings.save();
@@ -371,6 +372,7 @@ public abstract class RestService implements Serializable {
 
         InitializationUtils.discoverNodesIfNeeded(settings, log);
         InitializationUtils.filterNonClientNodesIfNeeded(settings, log);
+        InitializationUtils.filterNonDataNodesIfNeeded(settings, log);
         InitializationUtils.discoverEsVersion(settings, log);
 
         List<String> nodes = SettingsUtils.discoveredOrDeclaredNodes(settings);

--- a/mr/src/main/java/org/elasticsearch/hadoop/serialization/dto/Node.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/serialization/dto/Node.java
@@ -30,6 +30,7 @@ public class Node implements Serializable {
     private int httpPort;
     private Map<String, Object> attributes;
     private boolean isClient = false;
+    private boolean isData = true;
 
     public Node(String id, Map<String, Object> data) {
         this.id = id;
@@ -40,6 +41,10 @@ public class Node implements Serializable {
         attributes = (Map<String, Object>) data.get("attributes");
         if (attributes != null) {
             isClient = ("false".equals(attributes.get("data")) && "false".equals(attributes.get("master")));
+        }
+
+        if (attributes != null) {
+            isData = !"false".equals((attributes.get("data")));
         }
 
         if (!hasHttp) {
@@ -59,6 +64,10 @@ public class Node implements Serializable {
 
     public boolean isClient() {
         return isClient;
+    }
+
+    public boolean isData() {
+        return isData;
     }
 
     public String getId() {


### PR DESCRIPTION
This commit adds a configuration option `es.nodes.data.only` for managing whether or not reads using `EsInputFormat` and writes using `EsOutputFormat` in Hadoop MapReduce jobs route through non-data nodes. The reason for wanting to avoid routing through non-data nodes is because these nodes are usually resource-constrainted relative to data nodes. This configuration option is enabled by default.

Closes #512