### PR TITLE
SPARK_CLASSPATH is deprecated in Spark 1.0+.

### DIFF
--- a/docs/src/reference/asciidoc/core/spark.adoc
+++ b/docs/src/reference/asciidoc/core/spark.adoc
@@ -1320,7 +1320,7 @@ To wit, below is a snippet from the https://spark.apache.org/docs/1.5.1/programm
 
 [source, python]
 ----
-$ SPARK_CLASSPATH=/path/to/elasticsearch-hadoop.jar ./bin/pyspark
+$ ./bin/pyspark --driver-class-path=/path/to/elasticsearch-hadoop.jar
 >>> conf = {"es.resource" : "index/type"}   # assume Elasticsearch is running on localhost defaults
 >>> rdd = sc.newAPIHadoopRDD("org.elasticsearch.hadoop.mr.EsInputFormat",\
     "org.apache.hadoop.io.NullWritable", "org.elasticsearch.hadoop.mr.LinkedMapWritable", conf=conf)


### PR DESCRIPTION
SPARK_CLASSPATH is deprecated in Spark 1.0+. using --driver-class-path is prefered:

15/10/27 16:55:04 WARN SparkConf:
SPARK_CLASSPATH was detected (set to '/Users/poiuytrez/Documents/programs/spark-1.5.1/lib/elasticsearch-spark_2.11-2.1.1.jar').
This is deprecated in Spark 1.0+.
Please instead use:
 - ./spark-submit with --driver-class-path to augment the driver classpath
 - spark.executor.extraClassPath to augment the executor classpath