### PR TITLE
[SPARK] SparkContextFunctions.esRDD parameters

### DIFF
--- a/spark/core/main/scala/org/elasticsearch/spark/package.scala
+++ b/spark/core/main/scala/org/elasticsearch/spark/package.scala
@@ -21,12 +21,16 @@ package object spark {
     def esRDD(resource: String, query: String) = EsSpark.esRDD(sc, resource, query)
     def esRDD(cfg: scala.collection.Map[String, String]) = EsSpark.esRDD(sc, cfg)
     def esRDD(resource: String, cfg: scala.collection.Map[String, String]) = EsSpark.esRDD(sc, resource, cfg)
+    def esRDD(resource: String, query: String, cfg: scala.collection.Map[String, String]) =
+        EsSpark.esRDD(sc, resource, query, cfg)
 
     def esJsonRDD() = EsSpark.esJsonRDD(sc)
     def esJsonRDD(resource: String) = EsSpark.esJsonRDD(sc, resource)
     def esJsonRDD(resource: String, query: String) = EsSpark.esJsonRDD(sc, resource, query)
     def esJsonRDD(cfg: scala.collection.Map[String, String]) = EsSpark.esJsonRDD(sc, cfg)
     def esJsonRDD(resource: String, cfg: scala.collection.Map[String, String]) = EsSpark.esJsonRDD(sc, resource, cfg)
+    def esJsonRDD(resource: String, query: String, cfg: scala.collection.Map[String, String]) =
+        EsSpark.esJsonRDD(sc, resource, query, cfg)
   }
 
   implicit def sparkRDDFunctions[T : ClassTag](rdd: RDD[T]) = new SparkRDDFunctions[T](rdd)


### PR DESCRIPTION
Add an overload with all the three parameters available with
EsSpark.esRDD(..., resource, query, cfg).
Likewise for esJsonRDD.

This change makes `SparkContextFunctions.esRDD` more consistent with `SQLContextFunctions.esDF` which already has an overload taking all 3 parameters.

Implements #592.