### PR TITLE
Resolve IP Address for spark.es.nodes param

### DIFF
--- a/mr/src/main/java/org/elasticsearch/hadoop/util/StringUtils.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/util/StringUtils.java
@@ -385,6 +385,15 @@ public abstract class StringUtils {
         return true;
     }
 
+    public static boolean hasLetter(CharSequence string) {
+        for (int index = 0; index < string.length(); index++) {
+            if (Character.isLetter(string.charAt(index))) {
+                return true;
+            }
+        }
+        return false;   
+    }
+
     public static String jsonEncoding(String rawString) {
         return new String(HAS_JACKSON_CLASS ? JacksonStringEncoder.jsonEncoding(rawString) : BackportedJsonStringEncoder.getInstance().quoteAsString(rawString));
     }


### PR DESCRIPTION
This request is a proposition to fix the following situation : 

With the parameters : 
es.nodes.discovery = false
es.nodes.client.only = false
es.nodes.data.only = true
es.nodes = abc.example.com

With abc.example.com resolving to 1.2.3.4

The data node on abc.example is incorrectly filtered because the InitializationUtils class performs a comparison between the ip extracted from "_nodes/http" and the hostname which resolves to that ip.

When enabling debug, you then get the following situation:

"DEBUG ScalaEsRDD: Found data nodes [1.2.3.4:9200]"
"DEBUG ScalaEsRDD: Filtered discovered only nodes [abc.example.com:9200] to data-only []"

Which raises an EsHadoopIllegalArgumentException : "No data nodes with HTTP-enabled available; node discovery is disabled and none of nodes specified fits the criterion [abc.example.com:9200]"

The proposed solution resolves the ip for the hostname when qualifying nodes which allows consistency for subsequent comparisons.

