### PR TITLE
if nodeIp has '/' and the form <host>/<ip>, just return <host>.

### DIFF
--- a/mr/src/main/java/org/elasticsearch/hadoop/mr/EsInputFormat.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/mr/EsInputFormat.java
@@ -459,7 +459,18 @@ public class EsInputFormat<K, V> extends InputFormat<K, V> implements org.apache
 
         int index = 0;
         for (PartitionDefinition part : partitions) {
-            splits[index++] = new ShardInputSplit(part.nodeIp, part.nodePort, part.nodeId, part.nodeName, part.shardId,
+        	
+        	String nodeIp = part.nodeIp;        	
+        	
+        	// if nodeIp has '/' and the form <host>/<ip>, just return <host>.
+        	if(nodeIp.indexOf("/") != -1)
+        	{
+        		String[] nodeIpTokens = nodeIp.split("/");
+        		
+        		nodeIp = nodeIpTokens[0];        	
+        	}
+        	
+            splits[index++] = new ShardInputSplit(nodeIp, part.nodePort, part.nodeId, part.nodeName, part.shardId,
                     part.onlyNode, part.serializedMapping, part.serializedSettings);
         }
         log.info(String.format("Created [%d] shard-splits", splits.length));


### PR DESCRIPTION
If I run the mr job which reads data from ES and writes parquet files on HDFS, I got the following errors:
...
java.lang.IllegalArgumentException: Network location name contains /: my-host01/10.xxx.xxx.xxx
        at org.apache.hadoop.net.NodeBase.set(NodeBase.java:87)
        at org.apache.hadoop.net.NodeBase.<init>(NodeBase.java:65)
        at org.apache.hadoop.yarn.util.RackResolver.coreResolve(RackResolver.java:111)
        at org.apache.hadoop.yarn.util.RackResolver.resolve(RackResolver.java:95)
...

I noticed that nodeIp from PartitionDefinition has such form like <host>/<ip>.
After removing slash and ip part of nodeIp, and just returning hostname, my mr job works fine.
I am not sure if it happened to my case.
