### PR TITLE
Option to ignore version conflict errors on writes.

### DIFF
--- a/mr/src/main/java/org/elasticsearch/hadoop/cfg/ConfigurationOptions.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/cfg/ConfigurationOptions.java
@@ -232,6 +232,9 @@ public interface ConfigurationOptions {
     String ES_OPERATION_DELETE = "delete";
     String ES_WRITE_OPERATION_DEFAULT = ES_OPERATION_INDEX;
 
+    String ES_WRITE_CONFLICT_IGNORE = "es.write.conflict.ignore";
+    String ES_WRITE_CONFLICT_IGNORE_DEFAULT = "false";
+
     String ES_UPDATE_RETRY_ON_CONFLICT = "es.update.retry.on.conflict";
     String ES_UPDATE_RETRY_ON_CONFLICT_DEFAULT = "0";
 

--- a/mr/src/main/java/org/elasticsearch/hadoop/cfg/Settings.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/cfg/Settings.java
@@ -277,7 +277,13 @@ public abstract class Settings {
         return getProperty(ES_MAPPING_EXCLUDE, ES_MAPPING_EXCLUDE_DEFAULT);
     }
 
-    public String getIngestPipeline() { return getProperty(ES_INGEST_PIPELINE, ES_INGEST_PIPELINE_DEFAULT); }
+    public boolean getWriteConflictIgnore() {
+        return Boolean.parseBoolean(getProperty(ES_WRITE_CONFLICT_IGNORE, ES_WRITE_CONFLICT_IGNORE_DEFAULT));
+    }
+
+    public String getIngestPipeline() {
+        return getProperty(ES_INGEST_PIPELINE, ES_INGEST_PIPELINE_DEFAULT);
+    }
 
     public int getUpdateRetryOnConflict() {
         return Integer.parseInt(getProperty(ES_UPDATE_RETRY_ON_CONFLICT, ES_UPDATE_RETRY_ON_CONFLICT_DEFAULT));


### PR DESCRIPTION
This is useful for external_gt and external_gte version types when write conflicts don't need to be retried or logged.  Similar to #308 but works for all conflicts, not just `DocumentAlreadyExistsException`.

relates #613
