### PR TITLE
added support for highlight section in the hit part

### DIFF
--- a/mr/src/main/java/org/elasticsearch/hadoop/util/StringUtils.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/util/StringUtils.java
@@ -52,6 +52,8 @@ public abstract class StringUtils {
     public static final String PATH_CURRENT = ".";
     public static final String SOURCE_ROOT = "hits.hits._source.";
     public static final String FIELDS_ROOT = "hits.hits.fields.";
+    public static final String HIGHLIGHT_ROOT = "hits.hits.highlight.";
+    public static final String[] KNOWN_ROOTS = new String[]{SOURCE_ROOT, FIELDS_ROOT, HIGHLIGHT_ROOT};
 
     private static final boolean HAS_JACKSON_CLASS = ObjectUtils.isClassPresent("org.codehaus.jackson.io.JsonStringEncoder", StringUtils.class.getClassLoader());
 
@@ -519,11 +521,10 @@ public abstract class StringUtils {
 
     public static String stripFieldNameSourcePrefix(String fieldName) {
         if (fieldName != null) {
-            if (fieldName.startsWith(SOURCE_ROOT)) {
-                return fieldName.substring(SOURCE_ROOT.length());
-            }
-            else if (fieldName.startsWith(FIELDS_ROOT)) {
-                return fieldName.substring(FIELDS_ROOT.length());
+            for (String knownRoot: KNOWN_ROOTS) {
+                if (fieldName.startsWith(knownRoot)) {
+                    return fieldName.substring(knownRoot.length());
+                }
             }
         }
         return fieldName;

--- a/mr/src/test/java/org/elasticsearch/hadoop/rest/ScrollReaderTest.java
+++ b/mr/src/test/java/org/elasticsearch/hadoop/rest/ScrollReaderTest.java
@@ -97,6 +97,30 @@ public class ScrollReaderTest {
     }
 
     @Test
+    public void testScrollWithHighlightedNestedFields() throws IOException {
+        InputStream stream = getClass().getResourceAsStream("scroll-source-with-highlighting-mapping.json");
+        Field fl = Field.parseField(new ObjectMapper().readValue(stream, Map.class));
+
+        scrollReaderConfig.rootField = fl;
+        reader = new ScrollReader(scrollReaderConfig);
+
+
+        stream = getClass().getResourceAsStream("scroll-source-with-highlighting.json");
+        List<Object[]> read = reader.read(stream).getHits();
+
+        assertEquals(2, read.size());
+        Object[] objects = read.get(0);
+        Map result = (Map) objects[1];
+        assertTrue(result.containsKey("Document__Body"));
+        if (readMetadata) {
+            //The highlight section is part of the hit data and should appear in the top level of the map
+            assertTrue(result.containsKey("highlight"));
+        }
+
+
+    }
+
+    @Test
     public void testScrollWithSource() throws IOException {
         reader = new ScrollReader(scrollReaderConfig);
         InputStream stream = getClass().getResourceAsStream("scroll-source.json");

--- a/mr/src/test/resources/org/elasticsearch/hadoop/rest/scroll-source-with-highlighting-mapping.json
+++ b/mr/src/test/resources/org/elasticsearch/hadoop/rest/scroll-source-with-highlighting-mapping.json
@@ -1,0 +1,30 @@
+{
+  "fts-english": {
+    "mappings": {
+      "Document": {
+        "properties": {
+          "Document__Body": {
+            "type": "string"
+          }
+        }
+      },
+      "lock": {
+        "properties": {
+          "host": {
+            "type": "string"
+          }
+        }
+      },
+      "system": {
+        "properties": {
+          "ftsIndexVersion": {
+            "type": "long"
+          },
+          "message": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/mr/src/test/resources/org/elasticsearch/hadoop/rest/scroll-source-with-highlighting.json
+++ b/mr/src/test/resources/org/elasticsearch/hadoop/rest/scroll-source-with-highlighting.json
@@ -1,0 +1,45 @@
+{
+  "_scroll_id" : "c2NhbjsxOzE6MjBLOXo0S1RTcktPNmtmSU44YjJZUTsxO3RvdGFsX2hpdHM6MTk2Ow==",
+  "took": 73,
+  "timed_out": false,
+  "_shards": {
+    "total": 195,
+    "successful": 195,
+    "failed": 0
+  },
+  "hits": {
+    "total": 2,
+    "max_score": 1.2188213,
+    "hits": [
+      {
+        "_index": "fts-english",
+        "_type": "Document",
+        "_id": "AVL4xra8T4Qk2Y2x3Hf6",
+        "_score": 1.2188213,
+        "_source": {
+          "Document__Body": "Breaking News Home + Live TV U.S. Edition + U.S. International Arabic Español Set edition preference: U.S. International U.S. Edition + U.S. International Arabic Español Set edition preference: U.S. International U.S. International Español Arabic Set edition preference: U.S. International U.S. Edition U.S. International Arabic Español Set edition preference Confirm"
+        },
+        "highlight": {
+          "Document__Body": [
+            "Breaking News Home + Live TV U.S. Edition + U.S. International <b>Arabic</b> Español Set edition preference: U.S. International U.S. Edition + U.S. International <b>Arabic</b> Español Set edition preference: U.S. International U.S. International Español <b>Arabic</b> Set edition preference: U.S. International U.S. Edition U.S. International <b>Arabic</b> Español Set edition preference Confirm"
+          ]
+        }
+      }
+    ,
+      {
+        "_index": "fts-english",
+        "_type": "Document",
+        "_id": "AVL4xrsNT4Qk2Y2x3Hf8",
+        "_score": 1.0876832,
+        "_source": {
+          "Document__Body": "Breaking News Home + Live TV U.S. Edition + U.S. International Arabic Español Set edition preference: U.S. International U.S. Edition + U.S. International Arabic Español Set edition preference: U.S. International U.S. International Español Arabic Set edition preference: U.S. International U.S. Edition U.S. International Arabic Español Set edition preference Confirm"
+        },
+        "highlight": {
+          "Document__Body": [
+            "Breaking News Home + Live TV U.S. Edition + U.S. International <b>Arabic</b> Español Set edition preference: U.S. International U.S. Edition + U.S. International <b>Arabic</b> Español Set edition preference: U.S. International U.S. International Español <b>Arabic</b> Set edition preference: U.S. International U.S. Edition U.S. International <b>Arabic</b> Español Set edition preference Confirm"
+          ]
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
I added support for retrieving highlighting data when a highlight query is used.
It partially solves https://github.com/elastic/elasticsearch-hadoop/issues/460 and also fixes the problem that was described in the following thread https://discuss.elastic.co/t/does-elasticsearch-for-hadoop-work-with-highlighting/896 .
The highlight section is located in the upper level of the map that is parsed from the JSON. 
I added tests to verify that it works.
