### PR TITLE
Gradle signing plugin breaks CI workflow

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,5 @@ jdk:
 before_install:
  - "chmod +x gradlew"
  - export JAVA_OPTS="-Xmx2048m -XX:MaxPermSize=386m"
+
+install: ./gradlew assemble -Pskip.signing

--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,8 @@ allprojects {
     apply from: "$rootDir/dist.gradle"
 }
 
+println "Building version [$version]"
+
 ext.hadoopClient = []
 ext.hadoopDistro = project.hasProperty("distro") ? project.getProperty("distro") : "hadoopStable"
 

--- a/dist.gradle
+++ b/dist.gradle
@@ -1,7 +1,9 @@
 apply plugin: "maven"
 apply plugin: "propdeps-maven"
 
-if (!version.endsWith("SNAPSHOT")) {
+ext.enableArtifactSigning = !version.endsWith("SNAPSHOT") && !project.hasProperty("skip.signing")
+
+if (enableArtifactSigning) {
   apply plugin: 'signing'
 
   signing {
@@ -102,7 +104,7 @@ uploadArchives {
             snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots/") {
                 authentication(userName: deployUsername(), password: deployPassword())
             }
-            if (!version.endsWith("SNAPSHOT")) {
+            if (enableArtifactSigning) {
                 beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
             }
         }
@@ -112,7 +114,7 @@ uploadArchives {
 install {
     repositories.mavenInstaller {
         customizePom(pom, project)
-        if (!version.endsWith("SNAPSHOT")) {
+        if (enableArtifactSigning) {
             beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
         }
     }


### PR DESCRIPTION
The `signing` plugin is enabled when a job is being built from anything other than a `SNAPSHOT` version. Travis CI does not pass when project version does not end in `SNAPSHOT`