### PR TITLE
Fixed parsing of ES mapping with OBJECT field named 'properties'

### DIFF
--- a/mr/src/main/java/org/elasticsearch/hadoop/serialization/dto/mapping/Field.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/serialization/dto/mapping/Field.java
@@ -145,7 +145,7 @@ public class Field implements Serializable {
             for (Entry<String, Object> e : content.entrySet()) {
                 if (e.getValue() instanceof Map) {
                     Field fl = parseField(e, key);
-                    if (fl != null && fl.type == FieldType.OBJECT && "properties".equals(fl.name)) {
+                    if (fl != null && fl.type == FieldType.OBJECT && "properties".equals(fl.name) && !isFieldNamedProperties(e.getValue())) {
                         // use the enclosing field (as it might be nested)
                         return new Field(key, fieldType, fl.properties);
                     }
@@ -159,6 +159,16 @@ public class Field implements Serializable {
 
 
         throw new EsHadoopIllegalArgumentException("invalid map received " + entry);
+    }
+
+
+    private static boolean isFieldNamedProperties(Object fieldValue){
+        if(fieldValue instanceof Map){
+            Map<String,Object> fieldValueAsMap = ((Map<String, Object>)fieldValue);
+            if((fieldValueAsMap.containsKey("type") && fieldValueAsMap.get("type") instanceof String)
+                    || (fieldValueAsMap.containsKey("properties") && !isFieldNamedProperties(fieldValueAsMap.get("properties")))) return true;
+        }
+        return false;
     }
 
     @Override

--- a/mr/src/test/java/org/elasticsearch/hadoop/serialization/dto/mapping/FieldTest.java
+++ b/mr/src/test/java/org/elasticsearch/hadoop/serialization/dto/mapping/FieldTest.java
@@ -175,4 +175,36 @@ public class FieldTest {
         assertEquals("name", nestedProps[0].name());
         assertEquals(FieldType.LONG, nestedProps[1].type());
     }
+
+    @Test
+    public void testMappingWithFieldsNamedPropertiesAndType() throws Exception {
+        Map value = new ObjectMapper().readValue(getClass().getResourceAsStream("mapping_with_fields_named_properties_and_type.json"), Map.class);
+        Field fl = Field.parseField(value);
+        assertEquals("es_type_name", fl.name());
+        assertEquals(FieldType.OBJECT, fl.type());
+        assertEquals("field1", fl.properties()[0].name());
+        assertEquals(FieldType.STRING, fl.properties()[0].type());
+        assertEquals("properties", fl.properties()[1].name());
+        assertEquals(FieldType.OBJECT, fl.properties()[1].type());
+        assertEquals("subfield1", fl.properties()[1].properties()[0].name());
+        assertEquals(FieldType.STRING, fl.properties()[1].properties()[0].type());
+        assertEquals("subfield2", fl.properties()[1].properties()[1].name());
+        assertEquals(FieldType.STRING, fl.properties()[1].properties()[1].type());
+        assertEquals("field2", fl.properties()[2].name());
+        assertEquals(FieldType.OBJECT, fl.properties()[2].type());
+        assertEquals("subfield3", fl.properties()[2].properties()[0].name());
+        assertEquals(FieldType.STRING, fl.properties()[2].properties()[0].type());
+        assertEquals("properties", fl.properties()[2].properties()[1].name());
+        assertEquals(FieldType.STRING, fl.properties()[2].properties()[1].type());
+        assertEquals("type", fl.properties()[2].properties()[2].name());
+        assertEquals(FieldType.OBJECT, fl.properties()[2].properties()[2].type());
+        assertEquals("properties", fl.properties()[2].properties()[2].properties()[0].name());
+        assertEquals(FieldType.STRING, fl.properties()[2].properties()[2].properties()[1].type());
+        assertEquals("subfield5", fl.properties()[2].properties()[2].properties()[1].name());
+        assertEquals(FieldType.OBJECT, fl.properties()[2].properties()[2].properties()[0].type());
+        assertEquals("properties", fl.properties()[2].properties()[2].properties()[0].properties()[0].name());
+        assertEquals(FieldType.STRING, fl.properties()[2].properties()[2].properties()[0].properties()[0].type());
+        assertEquals("subfield4", fl.properties()[2].properties()[2].properties()[0].properties()[1].name());
+        assertEquals(FieldType.STRING, fl.properties()[2].properties()[2].properties()[0].properties()[1].type());
+    }
 }

--- a/mr/src/test/resources/org/elasticsearch/hadoop/serialization/dto/mapping/mapping_with_fields_named_properties_and_type.json
+++ b/mr/src/test/resources/org/elasticsearch/hadoop/serialization/dto/mapping/mapping_with_fields_named_properties_and_type.json
@@ -1,0 +1,50 @@
+{
+  "es_index_name" : {
+    "mappings" : {
+      "es_type_name" : {
+        "properties" : {
+          "field1" : {
+            "type" : "string"
+          },
+          "properties" : {
+            "properties" : {
+              "subfield1" : {
+                "type" : "string"
+              },
+              "subfield2" : {
+                "type" : "string"
+              }
+            }
+          },
+          "field2" : {
+            "properties" : {
+              "subfield3" : {
+                "type" : "string"
+              },
+              "properties" : {
+                "type" : "string"
+              },
+              "type" : {
+                "properties" : {
+                  "properties" : {
+                    "properties" : {
+                      "properties" : {
+                        "type" : "string"
+                      },
+                      "subfield4" : {
+                        "type" : "string"
+                      }
+                    }
+                  },
+                  "subfield5" : {
+                    "type" : "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Created method to distinguish between 'properties' ES key (used to define child fields) and user-defined object field named 'properties' when parsing mapping.
Closes [#809](https://github.com/elastic/elasticsearch-hadoop/issues/809)

- [X] I have signed the [Contributor License Agreement (CLA)][]

[Contributor License Agreement (CLA)]: https://www.elastic.co/contributor-agreement/

