### PR TITLE
Restores the ability to prefer local nodes when creating a PartitionReader

### DIFF
--- a/mr/src/main/java/org/elasticsearch/hadoop/mr/EsInputFormat.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/mr/EsInputFormat.java
@@ -81,8 +81,7 @@ public class EsInputFormat<K, V> extends InputFormat<K, V> implements org.apache
 
         @Override
         public String[] getLocations() {
-            // TODO: check whether the host name needs to be used instead
-            return new String[] {};
+            return partition.getHostNames();
         }
 
         @Override

--- a/mr/src/main/java/org/elasticsearch/hadoop/rest/InitializationUtils.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/rest/InitializationUtils.java
@@ -54,7 +54,7 @@ public abstract class InitializationUtils {
         }
     }
 
-    public static boolean discoverNodesIfNeeded(Settings settings, Log log) {
+    public static List<NodeInfo> discoverNodesIfNeeded(Settings settings, Log log) {
         if (settings.getNodesDiscovery()) {
             RestClient bootstrap = new RestClient(settings);
 
@@ -65,13 +65,13 @@ public abstract class InitializationUtils {
                 }
 
                 SettingsUtils.addDiscoveredNodes(settings, discoveredNodes);
+                return discoveredNodes;
             } finally {
                 bootstrap.close();
             }
-            return true;
         }
 
-        return false;
+        return null;
     }
 
     public static void filterNonClientNodesIfNeeded(Settings settings, Log log) {

--- a/mr/src/main/java/org/elasticsearch/hadoop/rest/NetworkUtils.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/rest/NetworkUtils.java
@@ -1,0 +1,47 @@
+package org.elasticsearch.hadoop.rest;
+
+import java.net.InetAddress;
+import java.net.NetworkInterface;
+import java.net.SocketException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public abstract class NetworkUtils {
+    private NetworkUtils() {
+    }
+
+    /** Helper for getInterfaces, recursively adds subinterfaces to {@code target} */
+    private static void addAllInterfaces(List<NetworkInterface> target, List<NetworkInterface> level) {
+        if (!level.isEmpty()) {
+            target.addAll(level);
+            for (NetworkInterface intf : level) {
+                addAllInterfaces(target, Collections.list(intf.getSubInterfaces()));
+            }
+        }
+    }
+
+    /** Return all interfaces (and subinterfaces) on the system */
+    static List<NetworkInterface> getInterfaces() throws SocketException {
+        List<NetworkInterface> all = new ArrayList<NetworkInterface>();
+        addAllInterfaces(all, Collections.list(NetworkInterface.getNetworkInterfaces()));
+        return all;
+    }
+
+    /** Returns all global scope addresses for interfaces that are up. */
+    static InetAddress[] getGlobalInterfaces() throws SocketException {
+        List<InetAddress> list = new ArrayList<InetAddress> ();
+        for (NetworkInterface intf : getInterfaces()) {
+            if (intf.isUp()) {
+                for (InetAddress address : Collections.list(intf.getInetAddresses())) {
+                    if (address.isLoopbackAddress() == false &&
+                            address.isSiteLocalAddress() == false &&
+                            address.isLinkLocalAddress() == false) {
+                        list.add(address);
+                    }
+                }
+            }
+        }
+        return list.toArray(new InetAddress[list.size()]);
+    }
+}

--- a/mr/src/main/java/org/elasticsearch/hadoop/rest/SearchRequestBuilder.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/rest/SearchRequestBuilder.java
@@ -64,6 +64,7 @@ public class SearchRequestBuilder {
     private final List<QueryBuilder> filters = new ArrayList<QueryBuilder> ();
     private String routing;
     private Slice slice;
+    private boolean local = false;
 
     public SearchRequestBuilder(EsMajorVersion version, boolean includeVersion) {
         this.version = version;
@@ -144,6 +145,11 @@ public class SearchRequestBuilder {
         return this;
     }
 
+    public SearchRequestBuilder local(boolean value) {
+        this.local = value;
+        return this;
+    }
+
     private String assemble() {
         if (limit > 0) {
             if (size > limit) {
@@ -183,6 +189,12 @@ public class SearchRequestBuilder {
         if (StringUtils.hasText(shard)) {
             pref.append("_shards:");
             pref.append(shard);
+        }
+        if (local) {
+            if (pref.length() > 0) {
+                pref.append(";");
+            }
+            pref.append("_local");
         }
 
         if (pref.length() > 0) {

--- a/mr/src/main/java/org/elasticsearch/hadoop/util/StringUtils.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/util/StringUtils.java
@@ -51,6 +51,7 @@ public abstract class StringUtils {
     public static final String PATH_CURRENT = ".";
     public static final String SOURCE_ROOT = "hits.hits._source.";
     public static final String FIELDS_ROOT = "hits.hits.fields.";
+    public static final String[] EMPTY_ARRAY = new String[0];
 
     private static final boolean HAS_JACKSON_CLASS = ObjectUtils.isClassPresent("org.codehaus.jackson.io.JsonStringEncoder", StringUtils.class.getClassLoader());
 

--- a/mr/src/test/java/org/elasticsearch/hadoop/rest/RestServiceTest.java
+++ b/mr/src/test/java/org/elasticsearch/hadoop/rest/RestServiceTest.java
@@ -18,19 +18,18 @@
  */
 package org.elasticsearch.hadoop.rest;
 
+import org.elasticsearch.hadoop.serialization.dto.ShardInfo;
+import org.junit.Before;
+import org.junit.Test;
+
 import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.elasticsearch.hadoop.serialization.dto.ShardInfo;
-import org.junit.Before;
-import org.junit.Test;
-
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
-
-import static org.hamcrest.Matchers.is;
 
 public class RestServiceTest {
 
@@ -76,12 +75,12 @@ public class RestServiceTest {
 
         ShardInfo sh6 = new ShardInfo(info);
 
-        pd1 = new PartitionDefinition(sh1.getIndex(), sh1.getName(), null, null);
-        pd2 = new PartitionDefinition(sh2.getIndex(), sh2.getName(), null, null);
-        pd3 = new PartitionDefinition(sh3.getIndex(), sh3.getName(), null, null);
-        pd4 = new PartitionDefinition(sh4.getIndex(), sh4.getName(), null, null);
-        pd5 = new PartitionDefinition(sh5.getIndex(), sh5.getName(), null, null);
-        pd6 = new PartitionDefinition(sh6.getIndex(), sh6.getName(), null, null);
+        pd1 = new PartitionDefinition(null, null, sh1.getIndex(), sh1.getName());
+        pd2 = new PartitionDefinition(null, null, sh2.getIndex(), sh2.getName());
+        pd3 = new PartitionDefinition(null, null, sh3.getIndex(), sh3.getName());
+        pd4 = new PartitionDefinition(null, null, sh4.getIndex(), sh4.getName());
+        pd5 = new PartitionDefinition(null, null, sh5.getIndex(), sh5.getName());
+        pd6 = new PartitionDefinition(null, null, sh6.getIndex(), sh6.getName());
 
         pds = Arrays.asList(pd1, pd2, pd3, pd4, pd5, pd6);
     }

--- a/spark/core/main/scala/org/elasticsearch/spark/rdd/AbstractEsRDD.scala
+++ b/spark/core/main/scala/org/elasticsearch/spark/rdd/AbstractEsRDD.scala
@@ -33,7 +33,8 @@ private[spark] abstract class AbstractEsRDD[T: ClassTag](
   }
 
   override def getPreferredLocations(split: Partition): Seq[String] = {
-    Nil
+    val esSplit = split.asInstanceOf[EsPartition]
+    esSplit.esPartition.getHostNames
   }
 
   override def checkpoint() {


### PR DESCRIPTION
In Hadoop and Spark it is possible to set the list of hostnames/ips that should be preferred when a task is launched.
This change restores the heuristic that prefers ES nodes that are local to the task when a partition reader is created.
This means that if an ES node is on the same machine than an Hadoop/Spark worker and this node contains the targeted index/shardId then the PartitionReader will request this node in priority.

Closes #814 