### PR TITLE
fix memory leak caused by re-wrapping DelegatedProtocol

### DIFF
--- a/mr/src/main/java/org/elasticsearch/hadoop/rest/commonshttp/CommonsHttpTransport.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/rest/commonshttp/CommonsHttpTransport.java
@@ -217,7 +217,7 @@ public class CommonsHttpTransport implements Transport, StatsAware {
         int port = 443;
         SecureProtocolSocketFactory sslFactory = new SSLSocketFactory(settings);
 
-        replaceProtocol(hostConfig, sslFactory, schema, port);
+        replaceProtocol(sslFactory, schema, port);
 
         return hostConfig;
     }
@@ -375,21 +375,24 @@ public class CommonsHttpTransport implements Transport, StatsAware {
             String schema = sslEnabled ? "https" : "http";
             int port = sslEnabled ? 443 : 80;
             SocksSocketFactory socketFactory = new SocksSocketFactory(proxyHost, proxyPort, proxyUser, proxyPass);
-            replaceProtocol(hostConfig, socketFactory, schema, port);
+            replaceProtocol(socketFactory, schema, port);
         }
 
         return hostConfig;
     }
 
-    private void replaceProtocol(HostConfiguration hostConfig, ProtocolSocketFactory socketFactory, String schema, int defaultPort) {
+    static void replaceProtocol(ProtocolSocketFactory socketFactory, String schema, int defaultPort) {
         //
         // switch protocol
         // due to how HttpCommons work internally this dance is best to be kept as is
         //
 
-        // NB: not really needed (see below that the protocol is reseted) but in place just in case
-        hostConfig = new ProtocolAwareHostConfiguration(hostConfig);
         Protocol directHttp = Protocol.getProtocol(schema);
+        if (directHttp instanceof DelegatedProtocol) {
+            // unwrap the original
+            directHttp = ((DelegatedProtocol)directHttp).getOriginal();
+            assert directHttp instanceof DelegatedProtocol == false;
+        }
         Protocol proxiedHttp = new DelegatedProtocol(socketFactory, directHttp, schema, defaultPort);
         // NB: register the new protocol since when using absolute URIs, HttpClient#executeMethod will override the configuration (#387)
         // NB: hence why the original/direct http protocol is saved - as otherwise the connection is not closed since it is considered different

--- a/mr/src/main/java/org/elasticsearch/hadoop/rest/commonshttp/DelegatedProtocol.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/rest/commonshttp/DelegatedProtocol.java
@@ -41,4 +41,8 @@ class DelegatedProtocol extends Protocol {
     public int hashCode() {
         return original.hashCode();
     }
+
+    Protocol getOriginal() {
+        return original;
+    }
 }

--- a/mr/src/test/java/org/elasticsearch/hadoop/rest/commonshttp/CommonsHttpTransportTests.java
+++ b/mr/src/test/java/org/elasticsearch/hadoop/rest/commonshttp/CommonsHttpTransportTests.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.hadoop.rest.commonshttp;
+
+import org.apache.commons.httpclient.ConnectTimeoutException;
+import org.apache.commons.httpclient.params.HttpConnectionParams;
+import org.apache.commons.httpclient.protocol.Protocol;
+import org.apache.commons.httpclient.protocol.ProtocolSocketFactory;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocketFactory;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.Socket;
+import java.net.UnknownHostException;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.sameInstance;
+
+public class CommonsHttpTransportTests {
+
+    private Protocol original;
+
+    @Before
+    public void setup() {
+        original = Protocol.getProtocol("https");
+    }
+
+    @After
+    public void reset() {
+        Protocol.registerProtocol("https", original);
+    }
+
+    @Test
+    public void testProtocolReplacement() throws Exception {
+        final ProtocolSocketFactory socketFactory = getSocketFactory();
+        CommonsHttpTransport.replaceProtocol(socketFactory, "https", 443);
+
+        Protocol protocol = Protocol.getProtocol("https");
+        assertThat(protocol, instanceOf(DelegatedProtocol.class));
+
+        DelegatedProtocol delegatedProtocol = (DelegatedProtocol) protocol;
+        assertThat(delegatedProtocol.getSocketFactory(), sameInstance(socketFactory));
+        assertThat(delegatedProtocol.getOriginal(), sameInstance(original));
+
+        // ensure we do not re-wrap a delegated protocol
+        CommonsHttpTransport.replaceProtocol(socketFactory, "https", 443);
+        protocol = Protocol.getProtocol("https");
+        assertThat(protocol, instanceOf(DelegatedProtocol.class));
+
+        delegatedProtocol = (DelegatedProtocol) protocol;
+        assertThat(delegatedProtocol.getSocketFactory(), sameInstance(socketFactory));
+        assertThat(delegatedProtocol.getOriginal(), sameInstance(original));
+    }
+
+    private ProtocolSocketFactory getSocketFactory() throws Exception {
+        final SSLSocketFactory delegate = SSLContext.getDefault().getSocketFactory();
+        return new ProtocolSocketFactory() {
+
+            @Override
+            public Socket createSocket(String host, int port, InetAddress localAddress, int localPort) throws IOException, UnknownHostException {
+                return delegate.createSocket(host, port, localAddress, localPort);
+            }
+
+            @Override
+            public Socket createSocket(String host, int port, InetAddress localAddress, int localPort, HttpConnectionParams params) throws IOException, UnknownHostException, ConnectTimeoutException {
+                return this.createSocket(host, port, localAddress, localPort);
+            }
+
+            @Override
+            public Socket createSocket(String host, int port) throws IOException, UnknownHostException {
+                return delegate.createSocket(host, port);
+            }
+        };
+    }
+}


### PR DESCRIPTION
When SSL is used to communicate with elasticsearch, we replace the Protocol for
`https` with a custom protocol that uses a custom created SSLSocketFactory. The
DelegatedProtocol we create wraps the existing protocol, which is fine if we only
wrap a single time. However if the http transport is instantiated multiple times,
the protocol that is wrapped will be the DelegatedProtocol that we created previously
and this causes the existing SSLSocketFactory to be retained indefinitely.

This change adds a check to see if the existing Protocol is a DelegatedProtocol and
if so the original Protocol is retrieved so that we do not retain a reference to the
DelegatedProtocol and its SSLSocketFactory.