### PR TITLE
Explicitly specify `buildScan` return type

### DIFF
--- a/spark/sql-13/src/main/scala/org/elasticsearch/spark/sql/DefaultSource.scala
+++ b/spark/sql-13/src/main/scala/org/elasticsearch/spark/sql/DefaultSource.scala
@@ -117,7 +117,7 @@ private[sql] case class ElasticsearchRelation(parameters: Map[String, String], @
   def buildScan(requiredColumns: Array[String]): RDD[Row] = buildScan(requiredColumns, Array.empty)
 
   // PrunedFilteredScan
-  def buildScan(requiredColumns: Array[String], filters: Array[Filter]) = {
+  def buildScan(requiredColumns: Array[String], filters: Array[Filter]): RDD[Row] = {
     val paramWithScan = LinkedHashMap[String, String]() ++ parameters
 
     var filteredColumns = requiredColumns


### PR DESCRIPTION
Because of type inference, not explicitly providing providing a return type for:

`def buildScan(requiredColumns: Array[String], filters: Array[Filter])`

... gives it the return type `ScalaEsRowRDD` which is a compatible type with the overridden method but limits further overriding on which some transformation is performed by the means of Spark. e.g:

```scala
org.evilcorpt.spark.sql

class SomeNewClass(...) extends ElasticsearchRelation(...) {
...
    def buildScan(requiredColumns: Array[String], filters: Array[Filter]): RDD[Row] =
        super.buildScan(requiredColumns, filters).map(someTransformationFunction)
...
}
```