### PR TITLE
Fix NPE when es.nodes.discovery is set to false

### DIFF
--- a/mr/src/main/java/org/elasticsearch/hadoop/rest/RestService.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/rest/RestService.java
@@ -256,11 +256,10 @@ public abstract class RestService implements Serializable {
                 }
             }
             final Map<String, NodeInfo> nodesMap = new HashMap<String, NodeInfo>();
-            if (nodes == null){
-                nodes = client.getRestClient().getHttpNodes(false);
-            }
-            for (NodeInfo node : nodes) {
-                nodesMap.put(node.getId(), node);
+            if (nodes != null) {
+                for (NodeInfo node : nodes) {
+                    nodesMap.put(node.getId(), node);
+                }
             }
             final List<PartitionDefinition> partitions;
             if (version.onOrAfter(EsMajorVersion.V_5_X)) {

--- a/mr/src/main/java/org/elasticsearch/hadoop/rest/RestService.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/rest/RestService.java
@@ -256,6 +256,9 @@ public abstract class RestService implements Serializable {
                 }
             }
             final Map<String, NodeInfo> nodesMap = new HashMap<String, NodeInfo>();
+            if (nodes==null){
+                nodes = client.getRestClient().getHttpNodes(false);
+            }
             for (NodeInfo node : nodes) {
                 nodesMap.put(node.getId(), node);
             }

--- a/mr/src/main/java/org/elasticsearch/hadoop/rest/RestService.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/rest/RestService.java
@@ -256,7 +256,7 @@ public abstract class RestService implements Serializable {
                 }
             }
             final Map<String, NodeInfo> nodesMap = new HashMap<String, NodeInfo>();
-            if (nodes==null){
+            if (nodes == null){
                 nodes = client.getRestClient().getHttpNodes(false);
             }
             for (NodeInfo node : nodes) {


### PR DESCRIPTION
JavaEsSpark failed to initialise when we set discovery to false and throw an NPE
```
new SparkConf()
    .setAppName("test").setMaster("local[8]")
    .set("es.nodes", "localhost")
    .set("es.port", "9200")
    .set("es.nodes.discovery","false")
    .set("es.nodes.wan.only","true")
```
It was only working with discovery on:

```
new SparkConf()
    .setAppName("test").setMaster("local[8]")
    .set("es.nodes", "localhost")
    .set("es.port", "9200")
    .set("es.nodes.discovery","true")
    .set("es.nodes.wan.only","false")
```

This PR provides a workaround and populates the `nodes` list with the help of the client instead of discovery if discovery is off.