### PR TITLE
Fix: Non empty BINARY fields are considered empty

### DIFF
--- a/spark/core/main/scala/org/elasticsearch/spark/serialization/ScalaValueReader.scala
+++ b/spark/core/main/scala/org/elasticsearch/spark/serialization/ScalaValueReader.scala
@@ -131,17 +131,10 @@ class ScalaValueReader extends ValueReader with SettingsAware {
   }
 
   def binaryValue(value: Array[Byte]) = {
-    if (value != null) {
-      if (emptyAsNull) {
-        nullValue()
-      }
-      else {
+    Option(value) collect {
+      case value: Array[Byte] if !emptyAsNull || !value.isEmpty =>
         parseBinary(value)
-      }
-    }
-    else {
-      nullValue()
-    }
+    } getOrElse nullValue()
   }
   protected def parseBinary(value: Array[Byte]) = { value }
 


### PR DESCRIPTION
Thank you for submitting a pull request! 

Please make sure you have signed our [Contributor License Agreement (CLA)][].  
We are not asking you to assign copyright to us, but to give us the right to distribute your code without restriction. We ask this of all contributors in order to assure our users of the origin and continuing existence of the code.  
You only need to sign the CLA once.

- [ ] I have signed the [Contributor License Agreement (CLA)][]

[Contributor License Agreement (CLA)]: https://www.elastic.co/contributor-agreement/

Prior to this PR, all values for BINARY mapped fields were considered as empty no matter what value they actually had. The problem is that the condition deciding how to manage empty values is incomplete:

```scala
def binaryValue(value: Array[Byte]) = {
    if (value != null) {
      if (emptyAsNull) { // This should be:  if (emptyAsNull && value.isEmpty)
        nullValue()
      }
      else {
        parseBinary(value)
      }
    }
    else {
      nullValue()
    }
  }
```

On the other hand,  this is not critical however, two paths of conditions returning the same value in an if-statement can become a source of bugs if there are changes in the code (what if someone changes the return value at the outer `else` but not when the `emptyAsNull && value.isEmpty` is satisfied?). For that, I've rephrased the checks in a more idiomatic Scala style which nullity check at the `Option` factory provide:

```scala
 Option(value) collect {
      case value: Array[Byte] if !emptyAsNull || !value.isEmpty =>
        parseBinary(value)
    } getOrElse nullValue()
```