### PR TITLE
Fix import of JavaEsSparkSQL

### DIFF
--- a/docs/src/reference/asciidoc/core/spark.adoc
+++ b/docs/src/reference/asciidoc/core/spark.adoc
@@ -697,7 +697,7 @@ In a similar fashion, for Java usage the dedicated package +org.elasticsearch.sp
 [source,java]
 ----
 import org.apache.spark.sql.api.java.*;                      <1>
-import org.elasticsearch.spark.sql.java.api.JavaEsSpark SQL;  <2>
+import org.elasticsearch.spark.sql.api.java.JavaEsSparkSQL;  <2>
 ...
 
 DataFrame people = ...


### PR DESCRIPTION
Thank you for submitting a pull request! 

Please make sure you have signed our [Contributor License Agreement (CLA)][].  
We are not asking you to assign copyright to us, but to give us the right to distribute your code without restriction. We ask this of all contributors in order to assure our users of the origin and continuing existence of the code.  
You only need to sign the CLA once.

- [x] I have signed the [Contributor License Agreement (CLA)][]

[Contributor License Agreement (CLA)]: https://www.elastic.co/contributor-agreement/

In version 5.0.0-alpha5 of the elasticsearch-hadoop connector, we have:
From: org.elasticsearch.spark.sql.java.api.JavaEsSpark SQL  => To: import org.elasticsearch.spark.sql.api.java.JavaEsSparkSQL