### PR TITLE
Throw clean exception if query is not well formed

### DIFF
--- a/mr/src/main/java/org/elasticsearch/hadoop/rest/QueryUtils.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/rest/QueryUtils.java
@@ -85,6 +85,9 @@ abstract class QueryUtils {
             try {
                 // must be a resource
                 InputStream in = settings.loadResource(query);
+                if (in == null) {
+                    throw new IOException();
+                }
                 // peek the stream
                 int first = in.read();
                 if (Integer.valueOf('?').equals(first)) {


### PR DESCRIPTION
- [x] I have signed the [Contributor License Agreement (CLA)][]

[Contributor License Agreement (CLA)]: https://www.elastic.co/contributor-agreement/

To avoid "NullPointerException" if query is not a valid ressource, could help people to understand whats happened.