### PR TITLE
Throw clean exception if query is not well formed

### DIFF
--- a/mr/src/main/java/org/elasticsearch/hadoop/rest/query/QueryUtils.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/rest/query/QueryUtils.java
@@ -42,6 +42,9 @@ public abstract class QueryUtils {
             try {
                 // must be a resource
                 InputStream in = settings.loadResource(query);
+                if (in == null) {
+                    throw new IOException();
+                }
                 query = IOUtils.asString(in);
             } catch (IOException ex) {
                 throw new EsHadoopIllegalArgumentException(


### PR DESCRIPTION
- [x] I have signed the [Contributor License Agreement (CLA)][]

As discussed at https://github.com/elastic/elasticsearch-hadoop/pull/864#issuecomment-252745629, to avoid "NullPointerException" if query is not a valid ressource, could help people to understand whats really happened.