### PR TITLE
Fixing repository-hdfs link

### DIFF
--- a/docs/src/reference/asciidoc/index.adoc
+++ b/docs/src/reference/asciidoc/index.adoc
@@ -29,7 +29,7 @@
 
 {ey}:: run {es} on top of YARN - see <<es-yarn>>
 
-repository-hdfs:: use HDFS as a repository back-end; that is storage for doing snapshot/restore from/to {es}. For more information refer to its https://github.com/elasticsearch/elasticsearch-hadoop/tree/master/repository-hdfs[home page]
+repository-hdfs:: use HDFS as a back-end repository for doing snapshot/restore from/to {es}. For more information, refer to its https://www.elastic.co/guide/en/elasticsearch/plugins/master/repository-hdfs.html[home page]
 
 {eh} proper:: interact with {es} from within a Hadoop environment. If you are using {mr}, Cascading, Hive, Pig, {sp} or {st}, this project is for you.
 


### PR DESCRIPTION
Fixing repo hdfs link for 5.0 as its now in Elasticsearch proper