### PR TITLE
Fix `es.output.json` for Hive

### DIFF
--- a/hive/src/itest/java/org/elasticsearch/hadoop/integration/hive/AbstractHiveReadJsonTest.java
+++ b/hive/src/itest/java/org/elasticsearch/hadoop/integration/hive/AbstractHiveReadJsonTest.java
@@ -37,7 +37,9 @@ import java.util.List;
 
 import static org.elasticsearch.hadoop.integration.hive.HiveSuite.provisionEsLib;
 import static org.elasticsearch.hadoop.integration.hive.HiveSuite.server;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 @SuppressWarnings("Duplicates")
 @RunWith(Parameterized.class)

--- a/hive/src/itest/java/org/elasticsearch/hadoop/integration/hive/AbstractHiveReadJsonTest.java
+++ b/hive/src/itest/java/org/elasticsearch/hadoop/integration/hive/AbstractHiveReadJsonTest.java
@@ -1,0 +1,172 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.hadoop.integration.hive;
+
+import org.apache.hive.service.cli.HiveSQLException;
+import org.elasticsearch.hadoop.QueryTestParams;
+import org.elasticsearch.hadoop.cfg.ConfigurationOptions;
+import org.elasticsearch.hadoop.mr.RestUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import static org.elasticsearch.hadoop.integration.hive.HiveSuite.provisionEsLib;
+import static org.elasticsearch.hadoop.integration.hive.HiveSuite.server;
+import static org.junit.Assert.*;
+
+@SuppressWarnings("Duplicates")
+@RunWith(Parameterized.class)
+public class AbstractHiveReadJsonTest {
+
+    private static int testInstance = 0;
+    private final boolean readMetadata;
+
+    @Parameters
+    public static Collection<Object[]> queries() {
+        return QueryTestParams.params();
+    }
+
+    private final String query;
+
+    public AbstractHiveReadJsonTest(String query, boolean readMetadata) {
+        this.query = query;
+        this.readMetadata = readMetadata;
+    }
+
+    @Before
+    public void before() throws Exception {
+        provisionEsLib();
+        RestUtils.refresh("json-hive");
+    }
+
+    @After
+    public void after() throws Exception {
+        testInstance++;
+        HiveSuite.after();
+    }
+
+    @Test
+    public void basicLoad() throws Exception {
+
+        String create = "CREATE EXTERNAL TABLE jsonartistsread" + testInstance + " (data INT, garbage INT, garbage2 STRING) "
+                + tableProps("json-hive/artists", "'es.output.json' = 'true'", "'es.mapping.names'='garbage2:refuse'");
+
+        String select = "SELECT * FROM jsonartistsread" + testInstance;
+
+        server.execute(create);
+        List<String> result = server.execute(select);
+        assertTrue("Hive returned null", containsNoNull(result));
+        assertContains(result, "Marilyn");
+        assertContains(result, "last.fm/music/MALICE");
+        assertContains(result, "last.fm/serve/252/5872875.jpg");
+    }
+
+    @Test
+    public void basicLoadWithNameMappings() throws Exception {
+
+        String create = "CREATE EXTERNAL TABLE jsonartistsread" + testInstance + " (refuse INT, garbage INT, data STRING) "
+                + tableProps("json-hive/artists", "'es.output.json' = 'true'", "'es.mapping.names'='data:boomSomethingYouWerentExpecting'");
+
+        String select = "SELECT * FROM jsonartistsread" + testInstance;
+
+        server.execute(create);
+        List<String> result = server.execute(select);
+        assertTrue("Hive returned null", containsNoNull(result));
+        assertContains(result, "Marilyn");
+        assertContains(result, "last.fm/music/MALICE");
+        assertContains(result, "last.fm/serve/252/5872875.jpg");
+    }
+
+    @Test(expected = HiveSQLException.class)
+    public void basicLoadWithNoGoodCandidateField() throws Exception {
+
+        String create = "CREATE EXTERNAL TABLE jsonartistsread" + testInstance + " (refuse INT, garbage INT) "
+                + tableProps("json-hive/artists", "'es.output.json' = 'true'");
+
+        String select = "SELECT * FROM jsonartistsread" + testInstance;
+
+        server.execute(create);
+        server.execute(select);
+
+        fail("Should have broken because there are no String fields in the table schema to place the JSON data.");
+    }
+
+    @Test
+    public void testMissingIndex() throws Exception {
+        String create = "CREATE EXTERNAL TABLE jsonmissingread" + testInstance + " (data STRING) "
+                + tableProps("foobar/missing", "'es.index.read.missing.as.empty' = 'true'", "'es.output.json' = 'true'");
+
+        String select = "SELECT * FROM jsonmissingread" + testInstance;
+
+        server.execute(create);
+        List<String> result = server.execute(select);
+        assertEquals(0, result.size());
+    }
+
+    @Test
+    public void testParentChild() throws Exception {
+        String create = "CREATE EXTERNAL TABLE jsonchildread" + testInstance + " (data STRING) "
+                + tableProps("json-hive/child", "'es.index.read.missing.as.empty' = 'true'", "'es.output.json' = 'true'");
+
+        String select = "SELECT * FROM jsonchildread" + testInstance;
+
+        System.out.println(server.execute(create));
+        List<String> result = server.execute(select);
+        assertTrue("Hive returned null", containsNoNull(result));
+        assertTrue(result.size() > 1);
+        assertContains(result, "Marilyn");
+        assertContains(result, "last.fm/music/MALICE");
+        assertContains(result, "last.fm/serve/252/2181591.jpg");
+    }
+
+    private static boolean containsNoNull(List<String> str) {
+        for (String string : str) {
+            if (string.contains("NULL")) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static void assertContains(List<String> str, String content) {
+        for (String string : str) {
+            if (string.contains(content)) {
+                return;
+            }
+        }
+        fail(String.format("'%s' not found in %s", content, str));
+    }
+
+
+    private String tableProps(String resource, String... params) {
+        List<String> copy = new ArrayList(Arrays.asList(params));
+        copy.add("'" + ConfigurationOptions.ES_READ_METADATA + "'='" + readMetadata + "'");
+        return HiveSuite.tableProps(resource, query, copy.toArray(new String[copy.size()]));
+    }
+}

--- a/hive/src/itest/java/org/elasticsearch/hadoop/integration/hive/HiveSuite.java
+++ b/hive/src/itest/java/org/elasticsearch/hadoop/integration/hive/HiveSuite.java
@@ -37,8 +37,9 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
 @RunWith(Suite.class)
-@Suite.SuiteClasses({ AbstractHiveSaveTest.class, AbstractHiveSaveJsonTest.class, AbstractHiveSearchTest.class, AbstractHiveSearchJsonTest.class, AbstractHiveExtraTests.class})
+@Suite.SuiteClasses({ AbstractHiveSaveTest.class, AbstractHiveSaveJsonTest.class, AbstractHiveSearchTest.class, AbstractHiveSearchJsonTest.class, AbstractHiveReadJsonTest.class, AbstractHiveExtraTests.class})
 //@Suite.SuiteClasses({ AbstractHiveSaveJsonTest.class, AbstractHiveSearchJsonTest.class })
+//@Suite.SuiteClasses({ AbstractHiveSaveJsonTest.class, AbstractHiveReadJsonTest.class })
 //@Suite.SuiteClasses({ AbstractHiveSaveTest.class })
 public class HiveSuite {
 

--- a/hive/src/main/java/org/elasticsearch/hadoop/hive/EsHiveInputFormat.java
+++ b/hive/src/main/java/org/elasticsearch/hadoop/hive/EsHiveInputFormat.java
@@ -102,7 +102,10 @@ public class EsHiveInputFormat extends EsInputFormat<Text, Writable> {
         Log log = LogFactory.getLog(getClass());
         // move on to initialization
         InitializationUtils.setValueReaderIfNotSet(settings, HiveValueReader.class, log);
-        settings.setProperty(InternalConfigurationOptions.INTERNAL_ES_TARGET_FIELDS, StringUtils.concatenate(HiveUtils.columnToAlias(settings), ","));
+        if (settings.getOutputAsJson() == false) {
+            // Only set the fields if we aren't asking for raw JSON
+            settings.setProperty(InternalConfigurationOptions.INTERNAL_ES_TARGET_FIELDS, StringUtils.concatenate(HiveUtils.columnToAlias(settings), ","));
+        }
         // set read resource
         settings.setResourceRead(settings.getResourceRead());
         HiveUtils.init(settings, log);


### PR DESCRIPTION
If `es.output.json` is enabled, instead of deserializing JSON data into a map object ES-Hadoop will simply return the raw JSON string to the user. This is returned from the Hadoop RecordReader as a `Text` object containing the string data. When the Hive integration receives data from a RecordReader, it automatically assumes that the data is a Map object. This leads to a cast exception when it receives a Text object instead.

In order for Hive to correctly accept the data, it must conform structurally to Hive's table schema. Instead of requiring the user to name their string field a certain way, the code now checks if it is expecting raw JSON data and selects an appropriate schema field from the table definition to place the information into. All other fields will be left as nulls.

This relates to issue #896.