### PR TITLE
Fix spark sql queries with metadata field

### DIFF
--- a/mr/src/main/java/org/elasticsearch/hadoop/cfg/InternalConfigurationOptions.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/cfg/InternalConfigurationOptions.java
@@ -34,4 +34,8 @@ public interface InternalConfigurationOptions extends ConfigurationOptions {
     String INTERNAL_ES_VERSION = "es.internal.es.version";
     // used for isolating connection pools of multiple spark streaming jobs in the same app.
     String INTERNAL_TRANSPORT_POOLING_KEY = "es.internal.transport.pooling.key";
+
+    // don't fetch _source field during scroll queries
+    String INTERNAL_ES_EXCLUDE_SOURCE = "es.internal.exclude.source";
+    String INTERNAL_ES_EXCLUDE_SOURCE_DEFAULT = "false";
 }

--- a/mr/src/main/java/org/elasticsearch/hadoop/cfg/Settings.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/cfg/Settings.java
@@ -152,6 +152,10 @@ public abstract class Settings {
         return getProperty(INTERNAL_ES_TARGET_FIELDS);
     }
 
+    public boolean getExcludeSource() {
+        return Booleans.parseBoolean(getProperty(INTERNAL_ES_EXCLUDE_SOURCE, INTERNAL_ES_EXCLUDE_SOURCE_DEFAULT));
+    }
+
     public String getSerializerValueWriterClassName() {
         return getProperty(ES_SERIALIZATION_WRITER_VALUE_CLASS);
     }

--- a/mr/src/main/java/org/elasticsearch/hadoop/rest/RestService.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/rest/RestService.java
@@ -447,7 +447,8 @@ public abstract class RestService implements Serializable {
                         .fields(SettingsUtils.determineSourceFields(settings))
                         .filters(QueryUtils.parseFilters(settings))
                         .shard(Integer.toString(partition.getShardId()))
-                        .local(true);
+                        .local(true)
+                        .excludeSource(settings.getExcludeSource());
         if (partition.getSlice() != null && partition.getSlice().max > 1) {
             requestBuilder.slice(partition.getSlice().id, partition.getSlice().max);
         }

--- a/mr/src/main/java/org/elasticsearch/hadoop/rest/SearchRequestBuilder.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/rest/SearchRequestBuilder.java
@@ -66,6 +66,7 @@ public class SearchRequestBuilder {
     private String routing;
     private Slice slice;
     private boolean local = false;
+    private boolean excludeSource = false;
 
     public SearchRequestBuilder(EsMajorVersion version, boolean includeVersion) {
         this.version = version;
@@ -151,6 +152,11 @@ public class SearchRequestBuilder {
         return this;
     }
 
+    public SearchRequestBuilder excludeSource(boolean value) {
+        this.excludeSource = value;
+        return this;
+    }
+
     private String assemble() {
         if (limit > 0) {
             if (size > limit) {
@@ -184,6 +190,8 @@ public class SearchRequestBuilder {
         // override fields
         if (StringUtils.hasText(fields)) {
             uriParams.put("_source", HttpEncodingTools.concatenateAndUriEncode(StringUtils.tokenize(fields), StringUtils.DEFAULT_DELIMITER));
+        } else if (excludeSource) {
+            uriParams.put("_source", "false");
         }
 
         // set shard preference

--- a/mr/src/main/java/org/elasticsearch/hadoop/rest/SearchRequestBuilder.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/rest/SearchRequestBuilder.java
@@ -123,6 +123,7 @@ public class SearchRequestBuilder {
     }
 
     public SearchRequestBuilder fields(String fieldsCSV) {
+        Assert.isFalse(this.excludeSource, "Fields can't be requested because _source section is excluded");
         this.fields = fieldsCSV;
         return this;
     }
@@ -153,6 +154,9 @@ public class SearchRequestBuilder {
     }
 
     public SearchRequestBuilder excludeSource(boolean value) {
+        if (value) {
+            Assert.hasNoText(this.fields, String.format("_source section can't be excluded if fields [%s] are requested", this.fields));
+        }
         this.excludeSource = value;
         return this;
     }

--- a/mr/src/main/java/org/elasticsearch/hadoop/serialization/ScrollReader.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/serialization/ScrollReader.java
@@ -475,6 +475,10 @@ public class ScrollReader {
         }
         else {
             if (readMetadata) {
+                if (parsingCallback != null) {
+                    parsingCallback.excludeSource();
+                }
+
                 data = reader.createMap();
                 reader.addToMap(data, reader.wrapString(metadataField), metadata);
             }

--- a/mr/src/main/java/org/elasticsearch/hadoop/serialization/builder/ValueParsingCallback.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/serialization/builder/ValueParsingCallback.java
@@ -34,6 +34,8 @@ public interface ValueParsingCallback {
 	
 	void endSource();
 
+	void excludeSource();
+
 	void beginTrailMetadata();
 	
 	void endTrailMetadata();

--- a/mr/src/main/java/org/elasticsearch/hadoop/util/Assert.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/util/Assert.java
@@ -35,6 +35,16 @@ public abstract class Assert {
         hasText(sequence, "[Assertion failed] - this CharSequence argument must have text; it must not be null, empty, or blank");
     }
 
+    public static void hasNoText(CharSequence sequence, String message) {
+        if (StringUtils.hasText(sequence)) {
+            throw new EsHadoopIllegalArgumentException(message);
+        }
+    }
+
+    public static void hasNoText(CharSequence sequence) {
+        hasNoText(sequence, "[Assertion failed] - this CharSequence argument must be empty");
+    }
+
     public static void notNull(Object object, String message) {
         if (object == null) {
             throw new EsHadoopIllegalArgumentException(message);
@@ -53,5 +63,15 @@ public abstract class Assert {
 
     public static void isTrue(Boolean object) {
         isTrue(object, "[Assertion failed] - this argument must be true");
+    }
+
+    public static void isFalse(Boolean object, String message) {
+        if (!Boolean.FALSE.equals(object)) {
+            throw new EsHadoopIllegalArgumentException(message);
+        }
+    }
+
+    public static void isFalse(Boolean object) {
+        isFalse(object, "[Assertion failed] - this argument must be false");
     }
 }

--- a/mr/src/test/java/org/elasticsearch/hadoop/rest/QueryTest.java
+++ b/mr/src/test/java/org/elasticsearch/hadoop/rest/QueryTest.java
@@ -18,26 +18,48 @@
  */
 package org.elasticsearch.hadoop.rest;
 
-import org.elasticsearch.hadoop.cfg.Settings;
+import org.elasticsearch.hadoop.EsHadoopIllegalArgumentException;
 import org.elasticsearch.hadoop.util.EsMajorVersion;
 import org.elasticsearch.hadoop.util.TestSettings;
 import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 
 public class QueryTest {
-
-    private Settings cfg = new TestSettings();
+    private TestSettings cfg;
+    private SearchRequestBuilder builder;
 
     @Before
     public void setup() {
         cfg = new TestSettings();
+        builder = new SearchRequestBuilder(EsMajorVersion.V_5_X, true);
     }
 
     @Test
     public void testSimpleQuery() {
         cfg.setResourceRead("foo/bar");
-        assertTrue(new SearchRequestBuilder(EsMajorVersion.V_5_X, true).indices("foo").types("bar").toString().contains("foo/bar"));
+        assertTrue(builder.indices("foo").types("bar").toString().contains("foo/bar"));
+    }
+
+    @Test
+    public void testExcludeSourceTrue() {
+        assertTrue(builder.excludeSource(true).toString().contains("_source=false"));
+    }
+
+    @Test
+    public void testExcludeSourceFalse() {
+        assertFalse(builder.fields("a,b").excludeSource(false).toString().contains("_source=false"));
+    }
+
+    @Test(expected=EsHadoopIllegalArgumentException.class)
+    public void testExcludeSourceAndGetFields() {
+        builder.fields("a,b").excludeSource(true);
+    }
+
+    @Test(expected=EsHadoopIllegalArgumentException.class)
+    public void testGetFieldsAndExcludeSource() {
+        builder.excludeSource(true).fields("a,b");
     }
 }

--- a/spark/sql-13/src/main/scala/org/elasticsearch/spark/sql/DefaultSource.scala
+++ b/spark/sql-13/src/main/scala/org/elasticsearch/spark/sql/DefaultSource.scala
@@ -163,8 +163,9 @@ private[sql] case class ElasticsearchRelation(parameters: Map[String, String], @
     paramWithScan += (Utils.DATA_SOURCE_REQUIRED_COLUMNS -> requiredCSV)
 
     // If the only field requested by user is metadata, we don't want to fetch the whole document source
-    if (requiredCSV == cfg.getReadMetadataField())
-    paramWithScan += (InternalConfigurationOptions.INTERNAL_ES_EXCLUDE_SOURCE -> "true")
+    if (requiredCSV == cfg.getReadMetadataField()) {
+      paramWithScan += (InternalConfigurationOptions.INTERNAL_ES_EXCLUDE_SOURCE -> "true")
+    }
     
     if (filters != null && filters.size > 0) {
       if (Utils.isPushDown(cfg)) {

--- a/spark/sql-13/src/main/scala/org/elasticsearch/spark/sql/DefaultSource.scala
+++ b/spark/sql-13/src/main/scala/org/elasticsearch/spark/sql/DefaultSource.scala
@@ -154,9 +154,17 @@ private[sql] case class ElasticsearchRelation(parameters: Map[String, String], @
       }
     }
 
-    paramWithScan += (InternalConfigurationOptions.INTERNAL_ES_TARGET_FIELDS ->
-                      StringUtils.concatenate(filteredColumns.asInstanceOf[Array[Object]], StringUtils.DEFAULT_DELIMITER))
+    // Set fields to scroll over (_metadata is excluded, because it isn't a part of _source)
+    val sourceCSV = StringUtils.concatenate(filteredColumns.asInstanceOf[Array[Object]], StringUtils.DEFAULT_DELIMITER)
+    paramWithScan += (InternalConfigurationOptions.INTERNAL_ES_TARGET_FIELDS -> sourceCSV)
 
+    // Keep the order of fields requested by user (we don't exclude _metadata here)
+    val requiredCSV = StringUtils.concatenate(requiredColumns.asInstanceOf[Array[Object]], StringUtils.DEFAULT_DELIMITER)
+    paramWithScan += (Utils.DATA_SOURCE_REQUIRED_COLUMNS -> requiredCSV)
+
+    // If the only field requested by user is metadata, we don't want to fetch the whole document source
+    if (requiredCSV == cfg.getReadMetadataField())
+    paramWithScan += (InternalConfigurationOptions.INTERNAL_ES_EXCLUDE_SOURCE -> "true")
     
     if (filters != null && filters.size > 0) {
       if (Utils.isPushDown(cfg)) {

--- a/spark/sql-13/src/main/scala/org/elasticsearch/spark/sql/ScalaEsRowValueReader.scala
+++ b/spark/sql-13/src/main/scala/org/elasticsearch/spark/sql/ScalaEsRowValueReader.scala
@@ -133,6 +133,8 @@ class ScalaRowValueReader extends ScalaValueReader with RowValueReader with Valu
 
   def endSource(): Unit = {}
 
+  def excludeSource(): Unit = { rootLevel = true; sparkRowField = Utils.ROOT_LEVEL_NAME }
+
   def beginTrailMetadata(): Unit = {}
 
   def endTrailMetadata(): Unit = {}

--- a/spark/sql-13/src/main/scala/org/elasticsearch/spark/sql/SchemaUtils.scala
+++ b/spark/sql-13/src/main/scala/org/elasticsearch/spark/sql/SchemaUtils.scala
@@ -277,17 +277,16 @@ private[sql] object SchemaUtils {
     val requiredFields = settings.getProperty(Utils.DATA_SOURCE_REQUIRED_COLUMNS)
     val sourceFields = SettingsUtils.determineSourceFields(settings)
 
-    // In case when user selected specific fields (we want to keep the same order in a spark sql row)
-    if (StringUtils.hasText(requiredFields))
+    if (StringUtils.hasText(requiredFields)) {
+      // In case when user selected specific fields (we want to keep the same order in a spark sql row)
       rowInfo._1.setProperty(ROOT_LEVEL_NAME, requiredFields)
-
-    // In case when we read all fields including metadata
-    else if (StringUtils.hasText(sourceFields) && settings.getReadMetadata)
+    } else if (StringUtils.hasText(sourceFields) && settings.getReadMetadata) {
+      // In case when we read all fields including metadata
       rowInfo._1.setProperty(ROOT_LEVEL_NAME, sourceFields + StringUtils.DEFAULT_DELIMITER + settings.getReadMetadataField)
-
-    // In case when we read all fields without metadata
-    else if (StringUtils.hasText(sourceFields))
+    } else if (StringUtils.hasText(sourceFields)) {
+      // In case when we read all fields without metadata
       rowInfo._1.setProperty(ROOT_LEVEL_NAME, sourceFields)
+    }
     rowInfo
   }
 

--- a/spark/sql-13/src/main/scala/org/elasticsearch/spark/sql/SchemaUtils.scala
+++ b/spark/sql-13/src/main/scala/org/elasticsearch/spark/sql/SchemaUtils.scala
@@ -273,16 +273,21 @@ private[sql] object SchemaUtils {
     val rowInfo = (new Properties, new Properties)
 
     doDetectInfo(rowInfo, ROOT_LEVEL_NAME, struct)
-    val csv = SettingsUtils.determineSourceFields(settings)
-    // if a projection is applied (filtering or projection) use that instead
-    if (StringUtils.hasText(csv)) {
-      if (settings.getReadMetadata) {
-        rowInfo._1.setProperty(ROOT_LEVEL_NAME, csv + StringUtils.DEFAULT_DELIMITER + settings.getReadMetadataField)
-      }
-      else {
-        rowInfo._1.setProperty(ROOT_LEVEL_NAME, csv)
-      }
-    }
+
+    val requiredFields = settings.getProperty(Utils.DATA_SOURCE_REQUIRED_COLUMNS)
+    val sourceFields = SettingsUtils.determineSourceFields(settings)
+
+    // In case when user selected specific fields (we want to keep the same order in a spark sql row)
+    if (StringUtils.hasText(requiredFields))
+      rowInfo._1.setProperty(ROOT_LEVEL_NAME, requiredFields)
+
+    // In case when we read all fields including metadata
+    else if (StringUtils.hasText(sourceFields) && settings.getReadMetadata)
+      rowInfo._1.setProperty(ROOT_LEVEL_NAME, sourceFields + StringUtils.DEFAULT_DELIMITER + settings.getReadMetadataField)
+
+    // In case when we read all fields without metadata
+    else if (StringUtils.hasText(sourceFields))
+      rowInfo._1.setProperty(ROOT_LEVEL_NAME, sourceFields)
     rowInfo
   }
 

--- a/spark/sql-13/src/main/scala/org/elasticsearch/spark/sql/SchemaUtils.scala
+++ b/spark/sql-13/src/main/scala/org/elasticsearch/spark/sql/SchemaUtils.scala
@@ -271,22 +271,13 @@ private[sql] object SchemaUtils {
   def detectRowInfo(settings: Settings, struct: StructType): (Properties, Properties) = {
     // tuple - 1 = columns (in simple names) for each row, 2 - what fields (in absolute names) are arrays
     val rowInfo = (new Properties, new Properties)
-
     doDetectInfo(rowInfo, ROOT_LEVEL_NAME, struct)
 
     val requiredFields = settings.getProperty(Utils.DATA_SOURCE_REQUIRED_COLUMNS)
-    val sourceFields = SettingsUtils.determineSourceFields(settings)
-
     if (StringUtils.hasText(requiredFields)) {
-      // In case when user selected specific fields (we want to keep the same order in a spark sql row)
       rowInfo._1.setProperty(ROOT_LEVEL_NAME, requiredFields)
-    } else if (StringUtils.hasText(sourceFields) && settings.getReadMetadata) {
-      // In case when we read all fields including metadata
-      rowInfo._1.setProperty(ROOT_LEVEL_NAME, sourceFields + StringUtils.DEFAULT_DELIMITER + settings.getReadMetadataField)
-    } else if (StringUtils.hasText(sourceFields)) {
-      // In case when we read all fields without metadata
-      rowInfo._1.setProperty(ROOT_LEVEL_NAME, sourceFields)
     }
+
     rowInfo
   }
 

--- a/spark/sql-13/src/main/scala/org/elasticsearch/spark/sql/Utils.java
+++ b/spark/sql-13/src/main/scala/org/elasticsearch/spark/sql/Utils.java
@@ -41,6 +41,10 @@ abstract class Utils {
 
     static final String DATA_SOURCE_PUSH_DOWN = "es.internal.spark.sql.pushdown";
     static final String DATA_SOURCE_PUSH_DOWN_STRICT = "es.internal.spark.sql.pushdown.strict";
+
+    // columns selected by Spark SQL query
+    static final String DATA_SOURCE_REQUIRED_COLUMNS = "es.internal.spark.sql.required.columns";
+
     // double filtering (run Spark filters) or not
     static final String DATA_SOURCE_KEEP_HANDLED_FILTERS = "es.internal.spark.sql.pushdown.keep.handled.filters";
 

--- a/spark/sql-20/src/itest/java/org/elasticsearch/spark/integration/AbstractJavaEsSparkSQLTest.java
+++ b/spark/sql-20/src/itest/java/org/elasticsearch/spark/integration/AbstractJavaEsSparkSQLTest.java
@@ -152,6 +152,21 @@ public class AbstractJavaEsSparkSQLTest implements Serializable {
 		assertEquals(10, nameRDD.count());
 	}
 
+	@Test
+	public void testEsDatasetReadMetadata() throws Exception {
+		String target = "sparksql-test/scala-basic-write";
+
+		Dataset<Row> dataset = sqc.read().format("es").option("es.read.metadata", "true").load(target).where("id = 1");
+
+		// Since _metadata field isn't a part of _source,
+		// we want to check that it could be fetched in any position.
+		assertEquals("sparksql-test", dataset.selectExpr("_metadata['_index']").takeAsList(1).get(0).get(0));
+		assertEquals("sparksql-test", dataset.selectExpr("_metadata['_index']", "name").takeAsList(1).get(0).get(0));
+		assertEquals("MALICE MIZER", dataset.selectExpr("_metadata['_index']", "name").takeAsList(1).get(0).get(1));
+		assertEquals("MALICE MIZER", dataset.selectExpr("name", "_metadata['_index']").takeAsList(1).get(0).get(0));
+		assertEquals("sparksql-test", dataset.selectExpr("name", "_metadata['_index']").takeAsList(1).get(0).get(1));
+	}
+
     private Dataset<Row> artistsAsDataset() throws Exception {
         // don't use the sc.textFile as it pulls in the Hadoop madness (2.x vs 1.x)
         Path path = Paths.get(TestUtils.sampleArtistsDatUri());

--- a/spark/sql-20/src/main/scala/org/elasticsearch/spark/sql/DefaultSource.scala
+++ b/spark/sql-20/src/main/scala/org/elasticsearch/spark/sql/DefaultSource.scala
@@ -165,8 +165,9 @@ private[sql] case class ElasticsearchRelation(parameters: Map[String, String], @
     paramWithScan += (Utils.DATA_SOURCE_REQUIRED_COLUMNS -> requiredCSV)
 
     // If the only field requested by user is metadata, we don't want to fetch the whole document source
-    if (requiredCSV == cfg.getReadMetadataField())
+    if (requiredCSV == cfg.getReadMetadataField()) {
       paramWithScan += (InternalConfigurationOptions.INTERNAL_ES_EXCLUDE_SOURCE -> "true")
+    }
     
     if (filters != null && filters.size > 0) {
       if (Utils.isPushDown(cfg)) {

--- a/spark/sql-20/src/main/scala/org/elasticsearch/spark/sql/DefaultSource.scala
+++ b/spark/sql-20/src/main/scala/org/elasticsearch/spark/sql/DefaultSource.scala
@@ -156,9 +156,20 @@ private[sql] case class ElasticsearchRelation(parameters: Map[String, String], @
       }
     }
 
-    paramWithScan += (InternalConfigurationOptions.INTERNAL_ES_TARGET_FIELDS ->
-                      StringUtils.concatenate(filteredColumns.asInstanceOf[Array[Object]], StringUtils.DEFAULT_DELIMITER))
+    // Set fields to scroll over (_metadata is excluded, because it isn't a part of _source)
+    val sourceCSV = StringUtils.concatenate(filteredColumns.asInstanceOf[Array[Object]], StringUtils.DEFAULT_DELIMITER)
+    val requiredCSV = StringUtils.concatenate(requiredColumns.asInstanceOf[Array[Object]], StringUtils.DEFAULT_DELIMITER)
+    if (requiredCSV == cfg.getReadMetadataField)
+      // This is a small hack to avoid reading _source fields in case if only _metadata field is requested.
+      // By default, SearchRequestBuilder includes all fields, if INTERNAL_ES_TARGET_FIELDS is empty.
+      // To prevent us from querying useless data, we set _id field,
+      // which isn't a part of _source, but is allowed by SearchRequestBuilder
+      paramWithScan += (InternalConfigurationOptions.INTERNAL_ES_TARGET_FIELDS -> "_id")
+    else
+      paramWithScan += (InternalConfigurationOptions.INTERNAL_ES_TARGET_FIELDS -> sourceCSV)
 
+    // Keep the order of fields requested by user (we don't exclude _metadata here)
+    paramWithScan += (Utils.DATA_SOURCE_REQUIRED_COLUMNS -> requiredCSV)
     
     if (filters != null && filters.size > 0) {
       if (Utils.isPushDown(cfg)) {

--- a/spark/sql-20/src/main/scala/org/elasticsearch/spark/sql/ScalaEsRowValueReader.scala
+++ b/spark/sql-20/src/main/scala/org/elasticsearch/spark/sql/ScalaEsRowValueReader.scala
@@ -133,6 +133,8 @@ class ScalaRowValueReader extends ScalaValueReader with RowValueReader with Valu
 
   def endSource(): Unit = {}
 
+  def excludeSource(): Unit = { rootLevel = true; sparkRowField = Utils.ROOT_LEVEL_NAME }
+
   def beginTrailMetadata(): Unit = {}
 
   def endTrailMetadata(): Unit = {}

--- a/spark/sql-20/src/main/scala/org/elasticsearch/spark/sql/SchemaUtils.scala
+++ b/spark/sql-20/src/main/scala/org/elasticsearch/spark/sql/SchemaUtils.scala
@@ -19,9 +19,9 @@
 package org.elasticsearch.spark.sql
 
 import java.util.ArrayList
-import java.util.{LinkedHashSet => JHashSet}
-import java.util.{List => JList}
-import java.util.{Map => JMap}
+import java.util.{ LinkedHashSet => JHashSet }
+import java.util.{ List => JList }
+import java.util.{ Map => JMap }
 import java.util.Properties
 
 import scala.collection.JavaConverters.asScalaBufferConverter

--- a/spark/sql-20/src/main/scala/org/elasticsearch/spark/sql/SchemaUtils.scala
+++ b/spark/sql-20/src/main/scala/org/elasticsearch/spark/sql/SchemaUtils.scala
@@ -272,17 +272,16 @@ private[sql] object SchemaUtils {
     val requiredFields = settings.getProperty(Utils.DATA_SOURCE_REQUIRED_COLUMNS)
     val sourceFields = SettingsUtils.determineSourceFields(settings)
 
-    // In case when user selected specific fields (we want to keep the same order in a spark sql row)
-    if (StringUtils.hasText(requiredFields))
+    if (StringUtils.hasText(requiredFields)) {
+      // In case when user selected specific fields (we want to keep the same order in a spark sql row)
       rowInfo._1.setProperty(ROOT_LEVEL_NAME, requiredFields)
-
-    // In case when we read all fields including metadata
-    else if (StringUtils.hasText(sourceFields) && settings.getReadMetadata)
+    } else if (StringUtils.hasText(sourceFields) && settings.getReadMetadata) {
+      // In case when we read all fields including metadata
       rowInfo._1.setProperty(ROOT_LEVEL_NAME, sourceFields + StringUtils.DEFAULT_DELIMITER + settings.getReadMetadataField)
-
-    // In case when we read all fields without metadata
-    else if (StringUtils.hasText(sourceFields))
+    } else if (StringUtils.hasText(sourceFields)) {
+      // In case when we read all fields without metadata
       rowInfo._1.setProperty(ROOT_LEVEL_NAME, sourceFields)
+    }
     rowInfo
   }
 

--- a/spark/sql-20/src/main/scala/org/elasticsearch/spark/sql/SchemaUtils.scala
+++ b/spark/sql-20/src/main/scala/org/elasticsearch/spark/sql/SchemaUtils.scala
@@ -266,22 +266,13 @@ private[sql] object SchemaUtils {
   def detectRowInfo(settings: Settings, struct: StructType): (Properties, Properties) = {
     // tuple - 1 = columns (in simple names) for each row, 2 - what fields (in absolute names) are arrays
     val rowInfo = (new Properties, new Properties)
-
     doDetectInfo(rowInfo, ROOT_LEVEL_NAME, struct)
 
     val requiredFields = settings.getProperty(Utils.DATA_SOURCE_REQUIRED_COLUMNS)
-    val sourceFields = SettingsUtils.determineSourceFields(settings)
-
     if (StringUtils.hasText(requiredFields)) {
-      // In case when user selected specific fields (we want to keep the same order in a spark sql row)
       rowInfo._1.setProperty(ROOT_LEVEL_NAME, requiredFields)
-    } else if (StringUtils.hasText(sourceFields) && settings.getReadMetadata) {
-      // In case when we read all fields including metadata
-      rowInfo._1.setProperty(ROOT_LEVEL_NAME, sourceFields + StringUtils.DEFAULT_DELIMITER + settings.getReadMetadataField)
-    } else if (StringUtils.hasText(sourceFields)) {
-      // In case when we read all fields without metadata
-      rowInfo._1.setProperty(ROOT_LEVEL_NAME, sourceFields)
     }
+
     rowInfo
   }
 

--- a/spark/sql-20/src/main/scala/org/elasticsearch/spark/sql/Utils.java
+++ b/spark/sql-20/src/main/scala/org/elasticsearch/spark/sql/Utils.java
@@ -44,6 +44,9 @@ abstract class Utils {
     // double filtering (run Spark filters) or not
     static final String DATA_SOURCE_KEEP_HANDLED_FILTERS = "es.internal.spark.sql.pushdown.keep.handled.filters";
 
+    // columns selected by Spark SQL query
+    static final String DATA_SOURCE_REQUIRED_COLUMNS = "es.internal.spark.sql.required.columns";
+
     static boolean isPushDown(Settings cfg) {
         return Booleans.parseBoolean(cfg.getProperty(DATA_SOURCE_PUSH_DOWN), true);
     }


### PR DESCRIPTION
The PR solves `scala.MatchError` in Spark SQL queries with `_metadata` field inside.
More details on the issue: https://github.com/elastic/elasticsearch-hadoop/issues/924

I was trying to update integration tests with that case,
but I am getting failed tests even for the current code in branch `5.1`.

[x] I have signed the [Contributor License Agreement (CLA)][]

[Contributor License Agreement (CLA)]: https://www.elastic.co/contributor-agreement/