### PR TITLE
Take Scala standard in spark support

### DIFF
--- a/spark/core/main/scala/org/elasticsearch/spark/package.scala
+++ b/spark/core/main/scala/org/elasticsearch/spark/package.scala
@@ -52,25 +52,25 @@ package object spark {
   implicit def sparkRDDFunctions[T : ClassTag](rdd: RDD[T]) = new SparkRDDFunctions[T](rdd)
 
   class SparkRDDFunctions[T : ClassTag](rdd: RDD[T]) extends Serializable {
-    def saveToEs(resource: String) { EsSpark.saveToEs(rdd, resource) }
-    def saveToEs(resource: String, cfg: scala.collection.Map[String, String]) { EsSpark.saveToEs(rdd, resource, cfg) }
-    def saveToEs(cfg: scala.collection.Map[String, String]) { EsSpark.saveToEs(rdd, cfg)    }
+    def saveToEs(resource: String): Unit = { EsSpark.saveToEs(rdd, resource) }
+    def saveToEs(resource: String, cfg: scala.collection.Map[String, String]): Unit = { EsSpark.saveToEs(rdd, resource, cfg) }
+    def saveToEs(cfg: scala.collection.Map[String, String]): Unit = { EsSpark.saveToEs(rdd, cfg)    }
   }
 
   implicit def sparkStringJsonRDDFunctions(rdd: RDD[String]) = new SparkJsonRDDFunctions[String](rdd)
   implicit def sparkByteArrayJsonRDDFunctions(rdd: RDD[Array[Byte]]) = new SparkJsonRDDFunctions[Array[Byte]](rdd)
 
   class SparkJsonRDDFunctions[T : ClassTag](rdd: RDD[T]) extends Serializable {
-    def saveJsonToEs(resource: String) { EsSpark.saveJsonToEs(rdd, resource) }
-    def saveJsonToEs(resource: String, cfg: scala.collection.Map[String, String]) { EsSpark.saveJsonToEs(rdd, resource, cfg) }
-    def saveJsonToEs(cfg: scala.collection.Map[String, String]) { EsSpark.saveJsonToEs(rdd, cfg) }
+    def saveJsonToEs(resource: String): Unit = { EsSpark.saveJsonToEs(rdd, resource) }
+    def saveJsonToEs(resource: String, cfg: scala.collection.Map[String, String]): Unit = { EsSpark.saveJsonToEs(rdd, resource, cfg) }
+    def saveJsonToEs(cfg: scala.collection.Map[String, String]): Unit = { EsSpark.saveJsonToEs(rdd, cfg) }
   }
 
   implicit def sparkPairRDDFunctions[K : ClassTag, V : ClassTag](rdd: RDD[(K,V)]) = new SparkPairRDDFunctions[K,V](rdd)
 
   class SparkPairRDDFunctions[K : ClassTag, V : ClassTag](rdd: RDD[(K,V)]) extends Serializable {
-    def saveToEsWithMeta[K,V](resource: String) { EsSpark.saveToEsWithMeta(rdd, resource) }
-    def saveToEsWithMeta[K,V](resource: String, cfg: Map[String, String]) { EsSpark.saveToEsWithMeta(rdd, resource, cfg) }
-    def saveToEsWithMeta[K,V](cfg: Map[String, String]) { EsSpark.saveToEsWithMeta(rdd, cfg) }
+    def saveToEsWithMeta[K,V](resource: String): Unit = { EsSpark.saveToEsWithMeta(rdd, resource) }
+    def saveToEsWithMeta[K,V](resource: String, cfg: Map[String, String]): Unit = { EsSpark.saveToEsWithMeta(rdd, resource, cfg) }
+    def saveToEsWithMeta[K,V](cfg: Map[String, String]): Unit = { EsSpark.saveToEsWithMeta(rdd, cfg) }
   }
 }

--- a/spark/core/main/scala/org/elasticsearch/spark/rdd/AbstractEsRDD.scala
+++ b/spark/core/main/scala/org/elasticsearch/spark/rdd/AbstractEsRDD.scala
@@ -41,13 +41,9 @@ private[spark] abstract class AbstractEsRDD[T: ClassTag](
   protected var logger = LogFactory.getLog(this.getClass())
 
   override def getPartitions: Array[Partition] = {
-    val sparkPartitions = new Array[Partition](esPartitions.size)
-    var idx: Int = 0
-    for (esPartition <- esPartitions) {
-      sparkPartitions(idx) = new EsPartition(id, idx, esPartition)
-      idx += 1
-    }
-    sparkPartitions
+    esPartitions.zipWithIndex.map { case(esPartition, idx) =>
+      new EsPartition(id, idx, esPartition)
+    }.toArray
   }
 
   override def getPreferredLocations(split: Partition): Seq[String] = {
@@ -62,7 +58,7 @@ private[spark] abstract class AbstractEsRDD[T: ClassTag](
   def esCount(): Long = {
     val repo = new RestRepository(esCfg)
     try {
-      return repo.count(true)
+      repo.count(true)
     } finally {
       repo.close()
     }

--- a/spark/core/main/scala/org/elasticsearch/spark/serialization/ScalaMapFieldExtractor.scala
+++ b/spark/core/main/scala/org/elasticsearch/spark/serialization/ScalaMapFieldExtractor.scala
@@ -47,6 +47,6 @@ class ScalaMapFieldExtractor extends MapFieldExtractor {
         }
       }
     }
-    return obj
+    obj
   }
 }

--- a/spark/core/main/scala/org/elasticsearch/spark/serialization/ScalaMetadataExtractor.scala
+++ b/spark/core/main/scala/org/elasticsearch/spark/serialization/ScalaMetadataExtractor.scala
@@ -32,12 +32,14 @@ private[spark] class ScalaMetadataExtractor extends PerEntityPoolingMetadataExtr
   override def getValue(metadata: InternalMetadata): AnyRef = {
     val sparkEnum = ScalaMetadataExtractor.toSparkEnum(metadata)
 
-    if (sparkEnum == null) return null
-
-    entity match {
-      case jmap: JMap[_, _] => jmap.asInstanceOf[JMap[SparkMetadata, AnyRef]].get(sparkEnum)
-      case smap: SMap[_, _] => smap.asInstanceOf[SMap[SparkMetadata, AnyRef]].getOrElse(sparkEnum, null)
-      case _                => if (sparkEnum == SparkMetadata.ID) entity else null;
+    if (sparkEnum == null){
+      null
+    } else {
+      entity match {
+        case jmap: JMap[_, _] => jmap.asInstanceOf[JMap[SparkMetadata, AnyRef]].get(sparkEnum)
+        case smap: SMap[_, _] => smap.asInstanceOf[SMap[SparkMetadata, AnyRef]].getOrElse(sparkEnum, null)
+        case _                => if (sparkEnum == SparkMetadata.ID) entity else null
+      }
     }
   }
 }

--- a/spark/core/main/scala/org/elasticsearch/spark/serialization/ScalaValueWriter.scala
+++ b/spark/core/main/scala/org/elasticsearch/spark/serialization/ScalaValueWriter.scala
@@ -39,7 +39,7 @@ class ScalaValueWriter(writeUnknownTypes: Boolean = false) extends JdkValueWrite
 
   private def doWrite(value: Any, generator: Generator, acceptsJavaBeans: Boolean): Result = {
     value match {
-      case null | None | Unit => generator.writeNull()
+      case null | None | () => generator.writeNull()
       case Nil =>
         generator.writeBeginArray(); generator.writeEndArray()
 

--- a/spark/sql-13/src/itest/scala/org/elasticsearch/spark/integration/AbstractScalaEsScalaSparkStreaming.scala
+++ b/spark/sql-13/src/itest/scala/org/elasticsearch/spark/integration/AbstractScalaEsScalaSparkStreaming.scala
@@ -59,13 +59,13 @@ object AbstractScalaEsScalaSparkStreaming {
   @transient var ssc: StreamingContext = null
 
   @BeforeClass
-  def setup() {
+  def setup(): Unit =  {
     conf.setAll(TestSettings.TESTING_PROPS)
     sc = new SparkContext(conf)
   }
 
   @AfterClass
-  def cleanup() {
+  def cleanup(): Unit =  {
     if (sc != null) {
       sc.stop
       // give jetty time to clean its act up
@@ -103,7 +103,7 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
   }
 
   @Test
-  def testEsRDDWriteIndexCreationDisabled() {
+  def testEsRDDWriteIndexCreationDisabled(): Unit = {
     val expecting = ExpectingToThrow(classOf[EsHadoopIllegalArgumentException]).from(ssc)
 
     val doc1 = Map("one" -> null, "two" -> Set("2"), "three" -> (".", "..", "..."))
@@ -119,7 +119,7 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
   }
 
   @Test
-  def testEsDataFrame1Write() {
+  def testEsDataFrame1Write(): Unit = {
     val doc1 = Map("one" -> null, "two" -> Set("2"), "three" ->(".", "..", "..."))
     val doc2 = Map("OTP" -> "Otopeni", "SFO" -> "San Fran")
 
@@ -135,7 +135,7 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
   }
 
   @Test
-  def testEsDataFrame1WriteSPECIALCHARACTER() {
+  def testEsDataFrame1WriteSPECIALCHARACTER(): Unit = {
     val doc1 = Map("one" -> null, "two" -> Set("2"), "three" ->(".", "..", "..."))
     val doc2 = Map("OTP" -> "Otopeni", "SFO" -> "San Fran")
 
@@ -151,7 +151,7 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
   }
 
   @Test
-  def testNestedUnknownCharacter() {
+  def testNestedUnknownCharacter(): Unit = {
     val expected = ExpectingToThrow(classOf[SparkException]).from(ssc)
     val doc = Map("itemId" -> "1", "map" -> Map("lat" -> 1.23, "lon" -> -70.12), "list" -> ("A", "B", "C"), "unknown" -> new Polygon())
     val batch = sc.makeRDD(Seq(doc))
@@ -160,7 +160,7 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
   }
 
   @Test
-  def testEsRDDWriteCaseClass() {
+  def testEsRDDWriteCaseClass(): Unit = {
     val javaBean = new Bean("bar", 1, true)
     val caseClass1 = Trip("OTP", "SFO")
     val caseClass2 = AbstractScalaEsScalaSpark.ModuleCaseClass(1, "OTP", "MUC")
@@ -181,7 +181,7 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
   }
 
   @Test
-  def testEsRDDWriteWithMappingId() {
+  def testEsRDDWriteWithMappingId(): Unit = {
     val doc1 = Map("one" -> null, "two" -> Set("2"), "three" -> (".", "..", "..."), "number" -> 1)
     val doc2 = Map("OTP" -> "Otopeni", "SFO" -> "San Fran", "number" -> 2)
 
@@ -198,7 +198,7 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
   }
 
   @Test
-  def testEsRDDWriteWithDynamicMapping() {
+  def testEsRDDWriteWithDynamicMapping(): Unit = {
     val doc1 = Map("one" -> null, "two" -> Set("2"), "three" -> (".", "..", "..."), "number" -> 1)
     val doc2 = Map("OTP" -> "Otopeni", "SFO" -> "San Fran", "number" -> 2)
 
@@ -217,7 +217,7 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
   }
 
   @Test
-  def testEsRDDWriteWithDynamicMapMapping() {
+  def testEsRDDWriteWithDynamicMapMapping(): Unit = {
     val doc1 = Map("one" -> null, "two" -> Set("2"), "three" -> (".", "..", "..."), "number" -> 1)
     val doc2 = Map("OTP" -> "Otopeni", "SFO" -> "San Fran", "number" -> 2)
 
@@ -240,7 +240,7 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
   }
 
   @Test
-  def testEsRDDWriteWithMappingExclude() {
+  def testEsRDDWriteWithMappingExclude(): Unit = {
     val trip1 = Map("reason" -> "business", "airport" -> "SFO")
     val trip2 = Map("participants" -> 5, "airport" -> "OTP")
 
@@ -256,7 +256,7 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
   }
 
   @Test
-  def testEsRDDIngest() {
+  def testEsRDDIngest(): Unit = {
     try {
       val versionTestingClient: RestUtils.ExtendedRestClient = new RestUtils.ExtendedRestClient
       try {
@@ -289,7 +289,7 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
 
 
   @Test
-  def testEsMultiIndexRDDWrite() {
+  def testEsMultiIndexRDDWrite(): Unit = {
     val trip1 = Map("reason" -> "business", "airport" -> "SFO")
     val trip2 = Map("participants" -> 5, "airport" -> "OTP")
 
@@ -305,7 +305,7 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
   }
 
   @Test
-  def testEsWriteAsJsonMultiWrite() {
+  def testEsWriteAsJsonMultiWrite(): Unit = {
     val json1 = "{\"reason\" : \"business\",\"airport\" : \"SFO\"}"
     val json2 = "{\"participants\" : 5,\"airport\" : \"OTP\"}"
 
@@ -329,7 +329,7 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
   }
 
   @Test
-  def testEsRDDWriteWithUpsertScriptUsingBothObjectAndRegularString() {
+  def testEsRDDWriteWithUpsertScriptUsingBothObjectAndRegularString(): Unit = {
     val mapping = """{
                     |  "contact": {
                     |    "properties": {
@@ -384,7 +384,7 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
   }
 
   @Test
-  def testNullAsEmpty() {
+  def testNullAsEmpty(): Unit = {
     val data = Seq(
       Map("field1" -> 5.4, "field2" -> "foo"),
       Map("field2" -> "bar"),

--- a/spark/sql-13/src/main/scala/org/elasticsearch/spark/sql/DataFrameFieldExtractor.scala
+++ b/spark/sql-13/src/main/scala/org/elasticsearch/spark/sql/DataFrameFieldExtractor.scala
@@ -41,6 +41,6 @@ class DataFrameFieldExtractor extends ScalaMapFieldExtractor {
         case _ => super.extractField(target)
       }
     }
-    return obj
+    obj
   }
 }

--- a/spark/sql-13/src/main/scala/org/elasticsearch/spark/sql/DataFrameValueWriter.scala
+++ b/spark/sql-13/src/main/scala/org/elasticsearch/spark/sql/DataFrameValueWriter.scala
@@ -70,7 +70,7 @@ class DataFrameValueWriter(writeUnknownTypes: Boolean = false) extends Filtering
     val row = value._1
     val schema = value._2
 
-    return writeStruct(schema, row, generator)
+    writeStruct(schema, row, generator)
   }
 
   private[spark] def writeStruct(schema: StructType, value: Any, generator: Generator): Result = {
@@ -110,12 +110,11 @@ class DataFrameValueWriter(writeUnknownTypes: Boolean = false) extends Filtering
 
   private[spark] def writeArray(schema: ArrayType, value: Any, generator: Generator): Result = {
     value match {
-      case a: Array[_] => return doWriteSeq(schema.elementType, a, generator)
-      case s: Seq[_]   => return doWriteSeq(schema.elementType, s, generator)
+      case a: Array[_] => doWriteSeq(schema.elementType, a, generator)
+      case s: Seq[_]   => doWriteSeq(schema.elementType, s, generator)
       // unknown array type
-      case _           => return handleUnknown(value, generator)
+      case _           => handleUnknown(value, generator)
     }
-    Result.SUCCESFUL()
   }
 
   private def doWriteSeq(schema: DataType, value: Seq[_], generator: Generator): Result = {
@@ -137,9 +136,8 @@ class DataFrameValueWriter(writeUnknownTypes: Boolean = false) extends Filtering
       case sm: SMap[_, _] => doWriteMap(schema, sm, generator)
       case jm: JMap[_, _] => doWriteMap(schema, jm.asScala, generator)
       // unknown map type
-      case _              => return handleUnknown(value, generator)
+      case _              => handleUnknown(value, generator)
     }
-    Result.SUCCESFUL()
   }
 
   private def doWriteMap(schema: MapType, value: SMap[_, _], generator: Generator): Result = {
@@ -192,10 +190,10 @@ class DataFrameValueWriter(writeUnknownTypes: Boolean = false) extends Filtering
   protected def handleUnknown(value: Any, generator: Generator): Result = {
     if (!writeUnknownTypes) {
       println("can't handle type " + value);
-      return Result.FAILED(value)
+      Result.FAILED(value)
+    } else {
+      generator.writeString(value.toString())
+      Result.SUCCESFUL()
     }
-
-    generator.writeString(value.toString())
-    Result.SUCCESFUL()
   }
 }

--- a/spark/sql-13/src/main/scala/org/elasticsearch/spark/sql/DefaultSource.scala
+++ b/spark/sql-13/src/main/scala/org/elasticsearch/spark/sql/DefaultSource.scala
@@ -182,42 +182,43 @@ private[sql] case class ElasticsearchRelation(parameters: Map[String, String], @
 
   // introduced in Spark 1.6
   override def unhandledFilters(filters: Array[Filter]): Array[Filter] = {
-    if (Utils.isKeepHandledFilters(cfg) || filters == null || filters.size == 0)
-      return filters;
+    if (Utils.isKeepHandledFilters(cfg) || filters == null || filters.size == 0) {
+      filters
+    } else {
+      // walk the filters (things like And / Or) and see whether we recognize all of them
+      // if we do, skip the filter, otherwise let it in there even though we might push some of it
+      def unhandled(filter: Filter): Boolean = {
+        filter match {
+          case EqualTo(_, _)                                                             => false
+          case GreaterThan(_, _)                                                         => false
+          case GreaterThanOrEqual(_, _)                                                  => false
+          case LessThan(_, _)                                                            => false
+          case LessThanOrEqual(_, _)                                                     => false
+          // In is problematic - see translate, don't filter it
+          case In(_, _)                                                                  => true
+          case IsNull(_)                                                                 => false
+          case IsNotNull(_)                                                              => false
+          case And(left, right)                                                          => unhandled(left) || unhandled(right)
+          case Or(left, right)                                                           => unhandled(left) || unhandled(right)
+          case Not(pred)                                                                 => unhandled(pred)
+          // Spark 1.3.1+
+          case f: Product if isClass(f, "org.apache.spark.sql.sources.StringStartsWith") => false
+          case f: Product if isClass(f, "org.apache.spark.sql.sources.StringEndsWith")   => false
+          case f: Product if isClass(f, "org.apache.spark.sql.sources.StringContains")   => false
+          // Spark 1.5+
+          case f: Product if isClass(f, "org.apache.spark.sql.sources.EqualNullSafe")    => false
 
-    // walk the filters (things like And / Or) and see whether we recognize all of them
-    // if we do, skip the filter, otherwise let it in there even though we might push some of it
-    def unhandled(filter: Filter): Boolean = {
-      filter match {
-        case EqualTo(_, _)                                                            => false
-        case GreaterThan(_, _)                                                        => false
-        case GreaterThanOrEqual(_, _)                                                 => false
-        case LessThan(_, _)                                                           => false
-        case LessThanOrEqual(_, _)                                                    => false
-        // In is problematic - see translate, don't filter it
-        case In(_, _)                                                                 => true
-        case IsNull(_)                                                                => false
-        case IsNotNull(_)                                                             => false
-        case And(left, right)                                                         => unhandled(left) || unhandled(right)
-        case Or(left, right)                                                          => unhandled(left) || unhandled(right)
-        case Not(pred)                                                                => unhandled(pred)
-        // Spark 1.3.1+
-        case f:Product if isClass(f, "org.apache.spark.sql.sources.StringStartsWith") => false
-        case f:Product if isClass(f, "org.apache.spark.sql.sources.StringEndsWith")   => false
-        case f:Product if isClass(f, "org.apache.spark.sql.sources.StringContains")   => false
-        // Spark 1.5+
-        case f:Product if isClass(f, "org.apache.spark.sql.sources.EqualNullSafe")    => false
-
-        // unknown
-        case _                                                                        => true
+          // unknown
+          case _                                                                         => true
+        }
       }
-    }
 
-    val filtered = filters.filter(unhandled)
-    if (Utils.LOGGER.isTraceEnabled()) {
-      Utils.LOGGER.trace(s"Unhandled filters from ${filters.mkString("[", ",", "]")} to ${filtered.mkString("[", ",", "]")}")
+      val filtered = filters.filter(unhandled)
+      if (Utils.LOGGER.isTraceEnabled()) {
+        Utils.LOGGER.trace(s"Unhandled filters from ${filters.mkString("[", ",", "]")} to ${filtered.mkString("[", ",", "]")}")
+      }
+      filtered
     }
-    filtered
   }
 
   private def createDSLFromFilters(filters: Array[Filter], strictPushDown: Boolean, isES50: Boolean) = {
@@ -334,8 +335,10 @@ private[sql] case class ElasticsearchRelation(parameters: Map[String, String], @
       // instead wildcard query is used, with the value lowercased (to match analyzed fields)
 
       case f:Product if isClass(f, "org.apache.spark.sql.sources.StringStartsWith") => {
-        var arg = f.productElement(1).toString()
-        if (!strictPushDown) { arg = arg.toLowerCase(Locale.ROOT) }
+        val arg = {
+          val x = f.productElement(1).toString()
+          if (!strictPushDown) x.toLowerCase(Locale.ROOT) else x
+        }
         if (isES50) {
           s"""{"wildcard":{"${f.productElement(0)}":"$arg*"}}"""
         }
@@ -345,8 +348,10 @@ private[sql] case class ElasticsearchRelation(parameters: Map[String, String], @
       }
 
       case f:Product if isClass(f, "org.apache.spark.sql.sources.StringEndsWith")   => {
-        var arg = f.productElement(1).toString()
-        if (!strictPushDown) { arg = arg.toLowerCase(Locale.ROOT) }
+        val arg = {
+          val x = f.productElement(1).toString()
+          if (!strictPushDown) x.toLowerCase(Locale.ROOT) else x
+        }
         if (isES50) {
           s"""{"wildcard":{"${f.productElement(0)}":"*$arg"}}"""
         }
@@ -356,8 +361,10 @@ private[sql] case class ElasticsearchRelation(parameters: Map[String, String], @
       }
 
       case f:Product if isClass(f, "org.apache.spark.sql.sources.StringContains")   => {
-        var arg = f.productElement(1).toString()
-        if (!strictPushDown) { arg = arg.toLowerCase(Locale.ROOT) }
+        val arg = {
+          val x = f.productElement(1).toString()
+          if (!strictPushDown) x.toLowerCase(Locale.ROOT) else x
+        }
         if (isES50) {
           s"""{"wildcard":{"${f.productElement(0)}":"*$arg*"}}"""
         }
@@ -369,7 +376,7 @@ private[sql] case class ElasticsearchRelation(parameters: Map[String, String], @
       // the filters below are available only from Spark 1.5.0
 
       case f:Product if isClass(f, "org.apache.spark.sql.sources.EqualNullSafe")    => {
-        var arg = extract(f.productElement(1))
+        val arg = extract(f.productElement(1))
         if (strictPushDown) s"""{"term":{"${f.productElement(0)}":$arg}}"""
         else {
           if (isES50) {
@@ -412,9 +419,8 @@ private[sql] case class ElasticsearchRelation(parameters: Map[String, String], @
 
     if (numbers.isEmpty) {
      if (strings.isEmpty) {
-       return StringUtils.EMPTY
-     }
-     return {
+       StringUtils.EMPTY
+     } else  {
        if (SettingsUtils.isEs50(cfg)) {
          s"""{"match":{"$attribute":${strings.mkString("\"", " ", "\"")}}}"""
        }
@@ -427,10 +433,10 @@ private[sql] case class ElasticsearchRelation(parameters: Map[String, String], @
     else {
       // translate the numbers into a terms query
       val str = s"""{"terms":{"$attribute":${numbers.mkString("[", ",", "]")}}}"""
-      if (strings.isEmpty) return str
+      if (strings.isEmpty) {
+        str
       // if needed, add the strings as a match query
-      else return str + 
-      {
+      } else str + {
         if (SettingsUtils.isEs50(cfg)) {
           s""",{"match":{"$attribute":${strings.mkString("\"", " ", "\"")}}}"""
         }
@@ -483,7 +489,7 @@ private[sql] case class ElasticsearchRelation(parameters: Map[String, String], @
     }
   }
 
-  def insert(data: DataFrame, overwrite: Boolean) {
+  def insert(data: DataFrame, overwrite: Boolean): Unit = {
     if (overwrite) {
       Utils.LOGGER.info(s"Overwriting data for ${cfg.getResourceWrite}")
 

--- a/spark/sql-13/src/main/scala/org/elasticsearch/spark/sql/DefaultSource.scala
+++ b/spark/sql-13/src/main/scala/org/elasticsearch/spark/sql/DefaultSource.scala
@@ -428,9 +428,7 @@ private[sql] case class ElasticsearchRelation(parameters: Map[String, String], @
          s"""{"query":{"match":{"$attribute":${strings.mkString("\"", " ", "\"")}}}}"""  
        }
      }
-     //s"""{"query":{"$attribute":${strings.mkString("\"", " ", "\"")}}}"""
-    }
-    else {
+    } else {
       // translate the numbers into a terms query
       val str = s"""{"terms":{"$attribute":${numbers.mkString("[", ",", "]")}}}"""
       if (strings.isEmpty) {

--- a/spark/sql-13/src/main/scala/org/elasticsearch/spark/sql/RowValueReader.scala
+++ b/spark/sql-13/src/main/scala/org/elasticsearch/spark/sql/RowValueReader.scala
@@ -56,9 +56,7 @@ private[sql] trait RowValueReader extends SettingsAware {
     val pos = esRow.rowOrder.indexOf(key.toString())
     if (pos < 0 || pos >= esRow.values.size) {
       // geo types allow fields which are ignored - need to skip these if they are not part of the schema
-      if (pos < 0 && currentFieldIsGeo) {
-        ()
-      } else {
+      if (pos >= 0 || !currentFieldIsGeo) {
         throw new EsHadoopIllegalStateException(s"Position for '$sparkRowField' not found in row; typically this is caused by a mapping inconsistency")
       }
     } else {

--- a/spark/sql-13/src/main/scala/org/elasticsearch/spark/sql/RowValueReader.scala
+++ b/spark/sql-13/src/main/scala/org/elasticsearch/spark/sql/RowValueReader.scala
@@ -52,15 +52,17 @@ private[sql] trait RowValueReader extends SettingsAware {
     }
   }
 
-  def addToBuffer(esRow: ScalaEsRow, key: AnyRef, value: Any) {
+  def addToBuffer(esRow: ScalaEsRow, key: AnyRef, value: Any): Unit = {
     val pos = esRow.rowOrder.indexOf(key.toString())
     if (pos < 0 || pos >= esRow.values.size) {
       // geo types allow fields which are ignored - need to skip these if they are not part of the schema
       if (pos < 0 && currentFieldIsGeo) {
-        return
+        ()
+      } else {
+        throw new EsHadoopIllegalStateException(s"Position for '$sparkRowField' not found in row; typically this is caused by a mapping inconsistency")
       }
-      throw new EsHadoopIllegalStateException(s"Position for '$sparkRowField' not found in row; typically this is caused by a mapping inconsistency")
+    } else {
+      esRow.values.update(pos, value)
     }
-    esRow.values.update(pos, value)
   }
 }

--- a/spark/sql-13/src/main/scala/org/elasticsearch/spark/sql/ScalaEsRowValueReader.scala
+++ b/spark/sql-13/src/main/scala/org/elasticsearch/spark/sql/ScalaEsRowValueReader.scala
@@ -100,8 +100,14 @@ class ScalaRowValueReader extends ScalaValueReader with RowValueReader with Valu
   override def addToArray(array: AnyRef, values: java.util.List[Object]): AnyRef = {
     // restore previous state
     array match {
-      case (pastInArray: Boolean, pastRowOrder: Seq[String]) => { inArray = pastInArray; currentArrayRowOrder = pastRowOrder }
-      case _                                                 => { inArray = false; currentArrayRowOrder = null}
+      case (pastInArray: Boolean, pastRowOrder: Seq[String @unchecked]) => {
+        inArray = pastInArray
+        currentArrayRowOrder = pastRowOrder
+      }
+      case _ => {
+        inArray = false
+        currentArrayRowOrder = null
+      }
     }
     super.addToArray(array, values)
   }
@@ -117,27 +123,27 @@ class ScalaRowValueReader extends ScalaValueReader with RowValueReader with Valu
     new Timestamp(value)
   }
 
-  def beginDoc() {}
+  def beginDoc(): Unit = {}
 
-  def beginLeadMetadata() { metadataMap = true }
+  def beginLeadMetadata(): Unit = { metadataMap = true }
 
-  def endLeadMetadata() {}
+  def endLeadMetadata(): Unit = {}
 
-  def beginSource() { rootLevel = true; sparkRowField = Utils.ROOT_LEVEL_NAME }
+  def beginSource(): Unit = { rootLevel = true; sparkRowField = Utils.ROOT_LEVEL_NAME }
 
-  def endSource() {}
+  def endSource(): Unit = {}
 
-  def beginTrailMetadata() {}
+  def beginTrailMetadata(): Unit = {}
 
-  def endTrailMetadata() {}
+  def endTrailMetadata(): Unit = {}
 
-  def endDoc() {}
+  def endDoc(): Unit = {}
   
-  def beginGeoField() {
+  def beginGeoField(): Unit = {
     currentFieldIsGeo = true
   }
   
-  def endGeoField() {
+  def endGeoField(): Unit = {
     currentFieldIsGeo = false
   }
 }

--- a/spark/sql-13/src/main/scala/org/elasticsearch/spark/sql/SchemaUtils.scala
+++ b/spark/sql-13/src/main/scala/org/elasticsearch/spark/sql/SchemaUtils.scala
@@ -112,7 +112,7 @@ private[sql] object SchemaUtils {
           // its presence is controlled through the dedicated config setting
           cfg.setProperty(InternalConfigurationOptions.INTERNAL_ES_TARGET_FIELDS, StringUtils.concatenate(Field.toLookupMap(field).keySet(), StringUtils.DEFAULT_DELIMITER))
         }
-        return (field, geoInfo)
+        (field, geoInfo)
       }
       else {
         throw new EsHadoopIllegalArgumentException(s"Cannot find mapping for ${cfg.getResourceRead} - one is required before using Spark SQL")
@@ -219,8 +219,7 @@ private[sql] object SchemaUtils {
 
     if (createArray) {
       // can't call createNestedArray for some reason...
-      var currentDepth = 0;
-      for (currentDepth <- 0 until matched.depth) {
+      for (_ <- 0 until matched.depth) {
         dataType = DataTypes.createArrayType(dataType)
       }
     }
@@ -228,9 +227,8 @@ private[sql] object SchemaUtils {
   }
   
   private def createNestedArray(elementType: DataType, depth: Int): DataType = {
-      var currentDepth = 0;
       var array = elementType
-      for (currentDepth <- 0 until depth) {
+      for (_ <- 0 until depth) {
         array = DataTypes.createArrayType(array)
       }
       array
@@ -288,7 +286,7 @@ private[sql] object SchemaUtils {
     rowInfo
   }
 
-  private def doDetectInfo(info: (Properties, Properties), level: String, dataType: DataType) {
+  private def doDetectInfo(info: (Properties, Properties), level: String, dataType: DataType): Unit = {
     dataType match {
       case s: StructType => {
         val fields = new java.util.ArrayList[String]
@@ -300,11 +298,7 @@ private[sql] object SchemaUtils {
       }
       case a: ArrayType => {
         val prop = info._2.getProperty(level)
-        var depth = 0
-        if (StringUtils.hasText(prop)) {
-          depth = Integer.parseInt(prop)
-        }
-        depth += 1
+        val depth = (if(StringUtils.hasText(prop)) Integer.parseInt(prop) else 0) + 1
         info._2.setProperty(level, String.valueOf(depth))
         doDetectInfo(info, level, a.elementType)
       }

--- a/spark/sql-13/src/main/scala/org/elasticsearch/spark/sql/package.scala
+++ b/spark/sql-13/src/main/scala/org/elasticsearch/spark/sql/package.scala
@@ -40,8 +40,8 @@ package object sql {
   implicit def sparkDataFrameFunctions(df: DataFrame) = new SparkDataFrameFunctions(df)
 
   class SparkDataFrameFunctions(df: DataFrame) extends Serializable {
-    def saveToEs(resource: String) { EsSparkSQL.saveToEs(df, resource) }
-    def saveToEs(resource: String, cfg: scala.collection.Map[String, String]) { EsSparkSQL.saveToEs(df, resource, cfg) }
-    def saveToEs(cfg: scala.collection.Map[String, String]) { EsSparkSQL.saveToEs(df, cfg)    }
+    def saveToEs(resource: String): Unit = { EsSparkSQL.saveToEs(df, resource) }
+    def saveToEs(resource: String, cfg: scala.collection.Map[String, String]): Unit = { EsSparkSQL.saveToEs(df, resource, cfg) }
+    def saveToEs(cfg: scala.collection.Map[String, String]): Unit = { EsSparkSQL.saveToEs(df, cfg)    }
   }
 }

--- a/spark/sql-13/src/main/scala/org/elasticsearch/spark/streaming/EsSparkStreaming.scala
+++ b/spark/sql-13/src/main/scala/org/elasticsearch/spark/streaming/EsSparkStreaming.scala
@@ -30,35 +30,35 @@ import scala.collection.Map
 object EsSparkStreaming {
 
   // Save methods
-  def saveToEs(ds: DStream[_], resource: String) {
+  def saveToEs(ds: DStream[_], resource: String): Unit = {
     saveToEs(ds, Map(ES_RESOURCE_WRITE -> resource))
   }
-  def saveToEs(ds: DStream[_], resource: String, cfg: Map[String, String]) {
+  def saveToEs(ds: DStream[_], resource: String, cfg: Map[String, String]): Unit = {
     saveToEs(ds, collection.mutable.Map(cfg.toSeq: _*) += (ES_RESOURCE_WRITE -> resource))
   }
-  def saveToEs(ds: DStream[_], cfg: Map[String, String]) {
+  def saveToEs(ds: DStream[_], cfg: Map[String, String]): Unit = {
     doSaveToEs(ds, cfg, hasMeta = false)
   }
 
   // Save with metadata
-  def saveToEsWithMeta[K,V](ds: DStream[(K,V)], resource: String) {
+  def saveToEsWithMeta[K,V](ds: DStream[(K,V)], resource: String): Unit = {
     saveToEsWithMeta(ds, Map(ES_RESOURCE_WRITE -> resource))
   }
-  def saveToEsWithMeta[K,V](ds: DStream[(K,V)], resource: String, cfg: Map[String, String]) {
+  def saveToEsWithMeta[K,V](ds: DStream[(K,V)], resource: String, cfg: Map[String, String]): Unit = {
     saveToEsWithMeta(ds, collection.mutable.Map(cfg.toSeq: _*) += (ES_RESOURCE_WRITE -> resource))
   }
-  def saveToEsWithMeta[K,V](ds: DStream[(K,V)], cfg: Map[String, String]) {
+  def saveToEsWithMeta[K,V](ds: DStream[(K,V)], cfg: Map[String, String]): Unit = {
     doSaveToEs(ds, cfg, hasMeta = true)
   }
 
   // Save as JSON
-  def saveJsonToEs(ds: DStream[_], resource: String) {
+  def saveJsonToEs(ds: DStream[_], resource: String): Unit = {
     saveToEs(ds, resource, Map(ES_INPUT_JSON -> true.toString))
   }
-  def saveJsonToEs(ds: DStream[_], resource: String, cfg: Map[String, String]) {
+  def saveJsonToEs(ds: DStream[_], resource: String, cfg: Map[String, String]): Unit = {
     saveToEs(ds, resource, collection.mutable.Map(cfg.toSeq: _*) += (ES_INPUT_JSON -> true.toString))
   }
-  def saveJsonToEs(ds: DStream[_], cfg: Map[String, String]) {
+  def saveJsonToEs(ds: DStream[_], cfg: Map[String, String]): Unit = {
     saveToEs(ds, collection.mutable.Map(cfg.toSeq: _*) += (ES_INPUT_JSON -> true.toString))
   }
 

--- a/spark/sql-13/src/main/scala/org/elasticsearch/spark/streaming/api/java/JavaEsSparkStreaming.scala
+++ b/spark/sql-13/src/main/scala/org/elasticsearch/spark/streaming/api/java/JavaEsSparkStreaming.scala
@@ -29,19 +29,19 @@ import org.elasticsearch.spark.streaming.EsSparkStreaming
 object JavaEsSparkStreaming {
 
   // specify the return types to make sure the bytecode is generated properly (w/o any scala.collections in it)
-  def saveToEs(ds: JavaDStream[_], resource: String) = EsSparkStreaming.saveToEs(ds.dstream, resource)
-  def saveToEs(ds: JavaDStream[_], resource: String, cfg: JMap[String, String]) = EsSparkStreaming.saveToEs(ds.dstream, resource, cfg.asScala)
-  def saveToEs(ds: JavaDStream[_], cfg: JMap[String, String]) = EsSparkStreaming.saveToEs(ds.dstream, cfg.asScala)
+  def saveToEs(ds: JavaDStream[_], resource: String): Unit = EsSparkStreaming.saveToEs(ds.dstream, resource)
+  def saveToEs(ds: JavaDStream[_], resource: String, cfg: JMap[String, String]): Unit = EsSparkStreaming.saveToEs(ds.dstream, resource, cfg.asScala)
+  def saveToEs(ds: JavaDStream[_], cfg: JMap[String, String]): Unit = EsSparkStreaming.saveToEs(ds.dstream, cfg.asScala)
 
-  def saveToEsWithMeta[K, V](ds: JavaPairDStream[K, V], resource: String) = EsSparkStreaming.saveToEsWithMeta(ds.dstream, resource)
-  def saveToEsWithMeta[K, V](ds: JavaPairDStream[K, V], resource: String, cfg: JMap[String, String]) = EsSparkStreaming.saveToEsWithMeta(ds.dstream, resource, cfg.asScala)
-  def saveToEsWithMeta[K, V](ds: JavaPairDStream[K, V], cfg: JMap[String, String]) = EsSparkStreaming.saveToEsWithMeta(ds.dstream, cfg.asScala)
+  def saveToEsWithMeta[K, V](ds: JavaPairDStream[K, V], resource: String): Unit = EsSparkStreaming.saveToEsWithMeta(ds.dstream, resource)
+  def saveToEsWithMeta[K, V](ds: JavaPairDStream[K, V], resource: String, cfg: JMap[String, String]): Unit = EsSparkStreaming.saveToEsWithMeta(ds.dstream, resource, cfg.asScala)
+  def saveToEsWithMeta[K, V](ds: JavaPairDStream[K, V], cfg: JMap[String, String]): Unit = EsSparkStreaming.saveToEsWithMeta(ds.dstream, cfg.asScala)
 
-  def saveJsonToEs(ds: JavaDStream[String], resource: String) = EsSparkStreaming.saveJsonToEs(ds.dstream, resource)
-  def saveJsonToEs(ds: JavaDStream[String], resource: String, cfg: JMap[String, String]) = EsSparkStreaming.saveJsonToEs(ds.dstream, resource, cfg.asScala)
-  def saveJsonToEs(ds: JavaDStream[String], cfg: JMap[String, String]) = EsSparkStreaming.saveJsonToEs(ds.dstream, cfg.asScala)
+  def saveJsonToEs(ds: JavaDStream[String], resource: String): Unit = EsSparkStreaming.saveJsonToEs(ds.dstream, resource)
+  def saveJsonToEs(ds: JavaDStream[String], resource: String, cfg: JMap[String, String]): Unit = EsSparkStreaming.saveJsonToEs(ds.dstream, resource, cfg.asScala)
+  def saveJsonToEs(ds: JavaDStream[String], cfg: JMap[String, String]): Unit = EsSparkStreaming.saveJsonToEs(ds.dstream, cfg.asScala)
 
-  def saveJsonByteArrayToEs(ds: JavaDStream[Array[Byte]], resource: String) = EsSparkStreaming.saveJsonToEs(ds.dstream, resource)
-  def saveJsonByteArrayToEs(ds: JavaDStream[Array[Byte]], resource: String, cfg: JMap[String, String]) = EsSparkStreaming.saveJsonToEs(ds.dstream, resource, cfg.asScala)
-  def saveJsonByteArrayToEs(ds: JavaDStream[Array[Byte]], cfg: JMap[String, String]) = EsSparkStreaming.saveJsonToEs(ds.dstream, cfg.asScala)
+  def saveJsonByteArrayToEs(ds: JavaDStream[Array[Byte]], resource: String): Unit = EsSparkStreaming.saveJsonToEs(ds.dstream, resource)
+  def saveJsonByteArrayToEs(ds: JavaDStream[Array[Byte]], resource: String, cfg: JMap[String, String]): Unit = EsSparkStreaming.saveJsonToEs(ds.dstream, resource, cfg.asScala)
+  def saveJsonByteArrayToEs(ds: JavaDStream[Array[Byte]], cfg: JMap[String, String]): Unit = EsSparkStreaming.saveJsonToEs(ds.dstream, cfg.asScala)
 }

--- a/spark/sql-13/src/main/scala/org/elasticsearch/spark/streaming/package.scala
+++ b/spark/sql-13/src/main/scala/org/elasticsearch/spark/streaming/package.scala
@@ -30,26 +30,26 @@ package object streaming {
   implicit def sparkDStreamFunctions(ds: DStream[_]): SparkDStreamFunctions = new SparkDStreamFunctions(ds)
 
   class SparkDStreamFunctions(ds: DStream[_]) extends Serializable {
-    def saveToEs(resource: String) { EsSparkStreaming.saveToEs(ds, resource) }
-    def saveToEs(resource: String, cfg: Map[String, String]) { EsSparkStreaming.saveToEs(ds, resource, cfg) }
-    def saveToEs(cfg: Map[String, String]) { EsSparkStreaming.saveToEs(ds, cfg) }
+    def saveToEs(resource: String): Unit = { EsSparkStreaming.saveToEs(ds, resource) }
+    def saveToEs(resource: String, cfg: Map[String, String]): Unit = { EsSparkStreaming.saveToEs(ds, resource, cfg) }
+    def saveToEs(cfg: Map[String, String]): Unit = { EsSparkStreaming.saveToEs(ds, cfg) }
   }
 
   implicit def sparkStringJsonDStreamFunctions(ds: DStream[String]): SparkJsonDStreamFunctions[String] = new SparkJsonDStreamFunctions[String](ds)
   implicit def sparkByteArrayJsonDStreamFunctions(ds: DStream[Array[Byte]]): SparkJsonDStreamFunctions[Array[Byte]] = new SparkJsonDStreamFunctions[Array[Byte]](ds)
 
   class SparkJsonDStreamFunctions[T : ClassTag](ds: DStream[T]) extends Serializable {
-    def saveJsonToEs(resource: String) { EsSparkStreaming.saveJsonToEs(ds, resource) }
-    def saveJsonToEs(resource: String, cfg: Map[String, String]) { EsSparkStreaming.saveJsonToEs(ds, resource, cfg) }
-    def saveJsonToEs(cfg: Map[String, String]) { EsSparkStreaming.saveJsonToEs(ds, cfg) }
+    def saveJsonToEs(resource: String): Unit = { EsSparkStreaming.saveJsonToEs(ds, resource) }
+    def saveJsonToEs(resource: String, cfg: Map[String, String]): Unit = { EsSparkStreaming.saveJsonToEs(ds, resource, cfg) }
+    def saveJsonToEs(cfg: Map[String, String]): Unit = { EsSparkStreaming.saveJsonToEs(ds, cfg) }
   }
 
   implicit def sparkPairDStreamFunctions[K : ClassTag, V : ClassTag](ds: DStream[(K,V)]): SparkPairDStreamFunctions[K,V] = new SparkPairDStreamFunctions[K,V](ds)
 
   class SparkPairDStreamFunctions[K : ClassTag, V : ClassTag](ds: DStream[(K, V)]) extends Serializable {
-    def saveToEsWithMeta(resource: String) { EsSparkStreaming.saveToEsWithMeta(ds, resource) }
-    def saveToEsWithMeta(resource: String, cfg: Map[String, String]) { EsSparkStreaming.saveToEsWithMeta(ds, resource, cfg) }
-    def saveToEsWithMeta(cfg: Map[String, String]) { EsSparkStreaming.saveToEsWithMeta(ds, cfg) }
+    def saveToEsWithMeta(resource: String): Unit = { EsSparkStreaming.saveToEsWithMeta(ds, resource) }
+    def saveToEsWithMeta(resource: String, cfg: Map[String, String]): Unit = { EsSparkStreaming.saveToEsWithMeta(ds, resource, cfg) }
+    def saveToEsWithMeta(cfg: Map[String, String]): Unit = { EsSparkStreaming.saveToEsWithMeta(ds, cfg) }
   }
 
 }

--- a/spark/sql-13/src/test/scala/org/elasticsearch/spark/sql/SchemaUtilsTest.scala
+++ b/spark/sql-13/src/test/scala/org/elasticsearch/spark/sql/SchemaUtilsTest.scala
@@ -41,12 +41,12 @@ class SchemaUtilsTest {
   var cfg: Settings = null
 
   @Before
-  def start() {
+  def start(): Unit = {
     cfg = new TestSettings
   }
 
   @Test
-  def testConvertToStructSimpleField() {
+  def testConvertToStructSimpleField(): Unit = {
     val mapping = """{
     |  "simple" : {
     |      "properties" : {
@@ -64,7 +64,7 @@ class SchemaUtilsTest {
   }
 
   @Test
-  def testConvertToStructWithObject() {
+  def testConvertToStructWithObject(): Unit = {
     val mapping = """{ "nested-array": {
     | "properties" : {
     |   "arr" : {
@@ -92,7 +92,7 @@ class SchemaUtilsTest {
   }
 
   @Test
-  def testConvertToStructWithSpecifiedArray() {
+  def testConvertToStructWithSpecifiedArray(): Unit = {
     val mapping = """{
     |  "simple" : {
     |      "properties" : {
@@ -116,7 +116,7 @@ class SchemaUtilsTest {
 
   
   @Test
-  def testConvertToStructWithSpecifiedArrayDepth() {
+  def testConvertToStructWithSpecifiedArrayDepth(): Unit = {
     val mapping = """{
     |  "simple" : {
     |      "properties" : {
@@ -150,7 +150,7 @@ class SchemaUtilsTest {
   }
 
   @Test
-  def testDetectRowInfoSimple() {
+  def testDetectRowInfoSimple(): Unit = {
     val mapping = """{ "array-mapping-top-level": {
     | "properties" : {
     |   "arr" : {
@@ -171,7 +171,7 @@ class SchemaUtilsTest {
   }
 
   @Test
-  def testDetectRowInfoWithOneNestedArray() {
+  def testDetectRowInfoWithOneNestedArray(): Unit = {
     val mapping = """{ "array-mapping-top-level": {
     | "properties" : {
     |   "arr" : {
@@ -195,7 +195,7 @@ class SchemaUtilsTest {
   }
 
   @Test
-  def testDetectRowInfoWithMultiDepthArray() {
+  def testDetectRowInfoWithMultiDepthArray(): Unit = {
     val mapping = """{ "array-mapping-top-level": {
     | "properties" : {
     |   "arr" : {

--- a/spark/sql-20/src/itest/scala/org/elasticsearch/spark/integration/AbstractScalaEsScalaSparkStreaming.scala
+++ b/spark/sql-20/src/itest/scala/org/elasticsearch/spark/integration/AbstractScalaEsScalaSparkStreaming.scala
@@ -59,13 +59,13 @@ object AbstractScalaEsScalaSparkStreaming {
   @transient var ssc: StreamingContext = null
 
   @BeforeClass
-  def setup() {
+  def setup(): Unit =  {
     conf.setAll(TestSettings.TESTING_PROPS)
     sc = new SparkContext(conf)
   }
 
   @AfterClass
-  def cleanup() {
+  def cleanup(): Unit =  {
     if (sc != null) {
       sc.stop
       // give jetty time to clean its act up
@@ -103,7 +103,7 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
   }
 
   @Test
-  def testEsRDDWriteIndexCreationDisabled() {
+  def testEsRDDWriteIndexCreationDisabled(): Unit = {
     val expecting = ExpectingToThrow(classOf[EsHadoopIllegalArgumentException]).from(ssc)
 
     val doc1 = Map("one" -> null, "two" -> Set("2"), "three" -> (".", "..", "..."))
@@ -119,7 +119,7 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
   }
 
   @Test
-  def testEsDataFrame1Write() {
+  def testEsDataFrame1Write(): Unit = {
     val doc1 = Map("one" -> null, "two" -> Set("2"), "three" ->(".", "..", "..."))
     val doc2 = Map("OTP" -> "Otopeni", "SFO" -> "San Fran")
 
@@ -135,7 +135,7 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
   }
 
   @Test
-  def testNestedUnknownCharacter() {
+  def testNestedUnknownCharacter(): Unit = {
     val expected = ExpectingToThrow(classOf[SparkException]).from(ssc)
     val doc = Map("itemId" -> "1", "map" -> Map("lat" -> 1.23, "lon" -> -70.12), "list" -> ("A", "B", "C"), "unknown" -> new Polygon())
     val batch = sc.makeRDD(Seq(doc))
@@ -144,7 +144,7 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
   }
 
   @Test
-  def testEsRDDWriteCaseClass() {
+  def testEsRDDWriteCaseClass(): Unit = {
     val javaBean = new Bean("bar", 1, true)
     val caseClass1 = Trip("OTP", "SFO")
     val caseClass2 = AbstractScalaEsScalaSpark.ModuleCaseClass(1, "OTP", "MUC")
@@ -165,7 +165,7 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
   }
 
   @Test
-  def testEsRDDWriteWithMappingId() {
+  def testEsRDDWriteWithMappingId(): Unit = {
     val doc1 = Map("one" -> null, "two" -> Set("2"), "three" -> (".", "..", "..."), "number" -> 1)
     val doc2 = Map("OTP" -> "Otopeni", "SFO" -> "San Fran", "number" -> 2)
 
@@ -182,7 +182,7 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
   }
 
   @Test
-  def testEsRDDWriteWithDynamicMapping() {
+  def testEsRDDWriteWithDynamicMapping(): Unit = {
     val doc1 = Map("one" -> null, "two" -> Set("2"), "three" -> (".", "..", "..."), "number" -> 1)
     val doc2 = Map("OTP" -> "Otopeni", "SFO" -> "San Fran", "number" -> 2)
 
@@ -201,7 +201,7 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
   }
 
   @Test
-  def testEsRDDWriteWithDynamicMapMapping() {
+  def testEsRDDWriteWithDynamicMapMapping(): Unit = {
     val doc1 = Map("one" -> null, "two" -> Set("2"), "three" -> (".", "..", "..."), "number" -> 1)
     val doc2 = Map("OTP" -> "Otopeni", "SFO" -> "San Fran", "number" -> 2)
 
@@ -224,7 +224,7 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
   }
 
   @Test
-  def testEsRDDWriteWithMappingExclude() {
+  def testEsRDDWriteWithMappingExclude(): Unit = {
     val trip1 = Map("reason" -> "business", "airport" -> "SFO")
     val trip2 = Map("participants" -> 5, "airport" -> "OTP")
 
@@ -240,7 +240,7 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
   }
 
   @Test
-  def testEsRDDIngest() {
+  def testEsRDDIngest(): Unit = {
     try {
       val versionTestingClient: RestUtils.ExtendedRestClient = new RestUtils.ExtendedRestClient
       try {
@@ -273,7 +273,7 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
 
 
   @Test
-  def testEsMultiIndexRDDWrite() {
+  def testEsMultiIndexRDDWrite(): Unit = {
     val trip1 = Map("reason" -> "business", "airport" -> "SFO")
     val trip2 = Map("participants" -> 5, "airport" -> "OTP")
 
@@ -289,7 +289,7 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
   }
 
   @Test
-  def testEsWriteAsJsonMultiWrite() {
+  def testEsWriteAsJsonMultiWrite(): Unit = {
     val json1 = "{\"reason\" : \"business\",\"airport\" : \"SFO\"}"
     val json2 = "{\"participants\" : 5,\"airport\" : \"OTP\"}"
 
@@ -313,7 +313,7 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
   }
 
   @Test
-  def testEsRDDWriteWithUpsertScriptUsingBothObjectAndRegularString() {
+  def testEsRDDWriteWithUpsertScriptUsingBothObjectAndRegularString(): Unit = {
     val mapping = """{
                     |  "contact": {
                     |    "properties": {
@@ -368,7 +368,7 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
   }
 
   @Test
-  def testNullAsEmpty() {
+  def testNullAsEmpty(): Unit = {
     val data = Seq(
       Map("field1" -> 5.4, "field2" -> "foo"),
       Map("field2" -> "bar"),

--- a/spark/sql-20/src/main/scala/org/elasticsearch/spark/sql/DataFrameFieldExtractor.scala
+++ b/spark/sql-20/src/main/scala/org/elasticsearch/spark/sql/DataFrameFieldExtractor.scala
@@ -41,6 +41,6 @@ class DataFrameFieldExtractor extends ScalaMapFieldExtractor {
         case _ => super.extractField(target)
       }
     }
-    return obj
+    obj
   }
 }

--- a/spark/sql-20/src/main/scala/org/elasticsearch/spark/sql/DataFrameValueWriter.scala
+++ b/spark/sql-20/src/main/scala/org/elasticsearch/spark/sql/DataFrameValueWriter.scala
@@ -26,7 +26,8 @@ import scala.collection.JavaConverters.mapAsScalaMapConverter
 import scala.collection.{Map => SMap}
 import scala.collection.Seq
 import org.apache.spark.sql.Row
-import org.apache.spark.sql.types._
+import org.apache.spark.sql.types.ArrayType
+import org.apache.spark.sql.types.DataType
 import org.apache.spark.sql.types.DataTypes.BinaryType
 import org.apache.spark.sql.types.DataTypes.BooleanType
 import org.apache.spark.sql.types.DataTypes.ByteType
@@ -38,6 +39,8 @@ import org.apache.spark.sql.types.DataTypes.LongType
 import org.apache.spark.sql.types.DataTypes.ShortType
 import org.apache.spark.sql.types.DataTypes.StringType
 import org.apache.spark.sql.types.DataTypes.TimestampType
+import org.apache.spark.sql.types.MapType
+import org.apache.spark.sql.types.StructType
 import org.elasticsearch.hadoop.cfg.ConfigurationOptions.ES_SPARK_DATAFRAME_WRITE_NULL_VALUES_DEFAULT
 import org.elasticsearch.hadoop.cfg.Settings
 import org.elasticsearch.hadoop.serialization.EsHadoopSerializationException

--- a/spark/sql-20/src/main/scala/org/elasticsearch/spark/sql/DefaultSource.scala
+++ b/spark/sql-20/src/main/scala/org/elasticsearch/spark/sql/DefaultSource.scala
@@ -430,9 +430,7 @@ private[sql] case class ElasticsearchRelation(parameters: Map[String, String], @
          s"""{"query":{"match":{"$attribute":${strings.mkString("\"", " ", "\"")}}}}"""  
        }
      }
-     //s"""{"query":{"$attribute":${strings.mkString("\"", " ", "\"")}}}"""
-    }
-    else {
+    } else {
       // translate the numbers into a terms query
       val str = s"""{"terms":{"$attribute":${numbers.mkString("[", ",", "]")}}}"""
       if (strings.isEmpty){

--- a/spark/sql-20/src/main/scala/org/elasticsearch/spark/sql/DefaultSource.scala
+++ b/spark/sql-20/src/main/scala/org/elasticsearch/spark/sql/DefaultSource.scala
@@ -184,42 +184,43 @@ private[sql] case class ElasticsearchRelation(parameters: Map[String, String], @
 
   // introduced in Spark 1.6
   override def unhandledFilters(filters: Array[Filter]): Array[Filter] = {
-    if (Utils.isKeepHandledFilters(cfg) || filters == null || filters.size == 0)
-      return filters;
+    if (Utils.isKeepHandledFilters(cfg) || filters == null || filters.size == 0) {
+      filters
+    } else {
+      // walk the filters (things like And / Or) and see whether we recognize all of them
+      // if we do, skip the filter, otherwise let it in there even though we might push some of it
+      def unhandled(filter: Filter): Boolean = {
+        filter match {
+          case EqualTo(_, _)                                                            => false
+          case GreaterThan(_, _)                                                        => false
+          case GreaterThanOrEqual(_, _)                                                 => false
+          case LessThan(_, _)                                                           => false
+          case LessThanOrEqual(_, _)                                                    => false
+          // In is problematic - see translate, don't filter it
+          case In(_, _)                                                                 => true
+          case IsNull(_)                                                                => false
+          case IsNotNull(_)                                                             => false
+          case And(left, right)                                                         => unhandled(left) || unhandled(right)
+          case Or(left, right)                                                          => unhandled(left) || unhandled(right)
+          case Not(pred)                                                                => unhandled(pred)
+          // Spark 1.3.1+
+          case f:Product if isClass(f, "org.apache.spark.sql.sources.StringStartsWith") => false
+          case f:Product if isClass(f, "org.apache.spark.sql.sources.StringEndsWith")   => false
+          case f:Product if isClass(f, "org.apache.spark.sql.sources.StringContains")   => false
+          // Spark 1.5+
+          case f:Product if isClass(f, "org.apache.spark.sql.sources.EqualNullSafe")    => false
 
-    // walk the filters (things like And / Or) and see whether we recognize all of them
-    // if we do, skip the filter, otherwise let it in there even though we might push some of it
-    def unhandled(filter: Filter): Boolean = {
-      filter match {
-        case EqualTo(_, _)                                                            => false
-        case GreaterThan(_, _)                                                        => false
-        case GreaterThanOrEqual(_, _)                                                 => false
-        case LessThan(_, _)                                                           => false
-        case LessThanOrEqual(_, _)                                                    => false
-        // In is problematic - see translate, don't filter it
-        case In(_, _)                                                                 => true
-        case IsNull(_)                                                                => false
-        case IsNotNull(_)                                                             => false
-        case And(left, right)                                                         => unhandled(left) || unhandled(right)
-        case Or(left, right)                                                          => unhandled(left) || unhandled(right)
-        case Not(pred)                                                                => unhandled(pred)
-        // Spark 1.3.1+
-        case f:Product if isClass(f, "org.apache.spark.sql.sources.StringStartsWith") => false
-        case f:Product if isClass(f, "org.apache.spark.sql.sources.StringEndsWith")   => false
-        case f:Product if isClass(f, "org.apache.spark.sql.sources.StringContains")   => false
-        // Spark 1.5+
-        case f:Product if isClass(f, "org.apache.spark.sql.sources.EqualNullSafe")    => false
-
-        // unknown
-        case _                                                                        => true
+          // unknown
+          case _                                                                        => true
+        }
       }
-    }
 
-    val filtered = filters.filter(unhandled)
-    if (Utils.LOGGER.isTraceEnabled()) {
-      Utils.LOGGER.trace(s"Unhandled filters from ${filters.mkString("[", ",", "]")} to ${filtered.mkString("[", ",", "]")}")
+      val filtered = filters.filter(unhandled)
+      if (Utils.LOGGER.isTraceEnabled()) {
+        Utils.LOGGER.trace(s"Unhandled filters from ${filters.mkString("[", ",", "]")} to ${filtered.mkString("[", ",", "]")}")
+      }
+      filtered
     }
-    filtered
   }
 
   private def createDSLFromFilters(filters: Array[Filter], strictPushDown: Boolean, isES50: Boolean) = {
@@ -336,8 +337,10 @@ private[sql] case class ElasticsearchRelation(parameters: Map[String, String], @
       // instead wildcard query is used, with the value lowercased (to match analyzed fields)
 
       case f:Product if isClass(f, "org.apache.spark.sql.sources.StringStartsWith") => {
-        var arg = f.productElement(1).toString()
-        if (!strictPushDown) { arg = arg.toLowerCase(Locale.ROOT) }
+        val arg = {
+          val x = f.productElement(1).toString()
+          if (!strictPushDown) x.toLowerCase(Locale.ROOT) else x
+        }
         if (isES50) {
           s"""{"wildcard":{"${f.productElement(0)}":"$arg*"}}"""
         }
@@ -347,8 +350,10 @@ private[sql] case class ElasticsearchRelation(parameters: Map[String, String], @
       }
 
       case f:Product if isClass(f, "org.apache.spark.sql.sources.StringEndsWith")   => {
-        var arg = f.productElement(1).toString()
-        if (!strictPushDown) { arg = arg.toLowerCase(Locale.ROOT) }
+        val arg = {
+          val x = f.productElement(1).toString()
+          if (!strictPushDown) x.toLowerCase(Locale.ROOT) else x
+        }
         if (isES50) {
           s"""{"wildcard":{"${f.productElement(0)}":"*$arg"}}"""
         }
@@ -358,8 +363,10 @@ private[sql] case class ElasticsearchRelation(parameters: Map[String, String], @
       }
 
       case f:Product if isClass(f, "org.apache.spark.sql.sources.StringContains")   => {
-        var arg = f.productElement(1).toString()
-        if (!strictPushDown) { arg = arg.toLowerCase(Locale.ROOT) }
+        val arg = {
+          val x = f.productElement(1).toString()
+          if (!strictPushDown) x.toLowerCase(Locale.ROOT) else x
+        }
         if (isES50) {
           s"""{"wildcard":{"${f.productElement(0)}":"*$arg*"}}"""
         }
@@ -371,7 +378,7 @@ private[sql] case class ElasticsearchRelation(parameters: Map[String, String], @
       // the filters below are available only from Spark 1.5.0
 
       case f:Product if isClass(f, "org.apache.spark.sql.sources.EqualNullSafe")    => {
-        var arg = extract(f.productElement(1))
+        val arg = extract(f.productElement(1))
         if (strictPushDown) s"""{"term":{"${f.productElement(0)}":$arg}}"""
         else {
           if (isES50) {
@@ -414,9 +421,8 @@ private[sql] case class ElasticsearchRelation(parameters: Map[String, String], @
 
     if (numbers.isEmpty) {
      if (strings.isEmpty) {
-       return StringUtils.EMPTY
-     }
-     return {
+        StringUtils.EMPTY
+     } else {
        if (SettingsUtils.isEs50(cfg)) {
          s"""{"match":{"$attribute":${strings.mkString("\"", " ", "\"")}}}"""
        }
@@ -429,10 +435,10 @@ private[sql] case class ElasticsearchRelation(parameters: Map[String, String], @
     else {
       // translate the numbers into a terms query
       val str = s"""{"terms":{"$attribute":${numbers.mkString("[", ",", "]")}}}"""
-      if (strings.isEmpty) return str
+      if (strings.isEmpty){
+        str
       // if needed, add the strings as a match query
-      else return str + 
-      {
+      } else str + {
         if (SettingsUtils.isEs50(cfg)) {
           s""",{"match":{"$attribute":${strings.mkString("\"", " ", "\"")}}}"""
         }
@@ -485,7 +491,7 @@ private[sql] case class ElasticsearchRelation(parameters: Map[String, String], @
     }
   }
 
-  def insert(data: DataFrame, overwrite: Boolean) {
+  def insert(data: DataFrame, overwrite: Boolean): Unit = {
     if (overwrite) {
       Utils.LOGGER.info(s"Overwriting data for ${cfg.getResourceWrite}")
 

--- a/spark/sql-20/src/main/scala/org/elasticsearch/spark/sql/EsSparkSQL.scala
+++ b/spark/sql-20/src/main/scala/org/elasticsearch/spark/sql/EsSparkSQL.scala
@@ -72,25 +72,23 @@ object EsSparkSQL {
   // Write
   //
   
-  def saveToEs(srdd: Dataset[_], resource: String) {
+  def saveToEs(srdd: Dataset[_], resource: String): Unit = {
     saveToEs(srdd, Map(ES_RESOURCE_WRITE -> resource))
   }
-  def saveToEs(srdd: Dataset[_], resource: String, cfg: Map[String, String]) {
+  def saveToEs(srdd: Dataset[_], resource: String, cfg: Map[String, String]): Unit = {
     saveToEs(srdd, collection.mutable.Map(cfg.toSeq: _*) += (ES_RESOURCE_WRITE -> resource))
   }
-  def saveToEs(srdd: Dataset[_], cfg: Map[String, String]) {
-     if (srdd == null) {
-      return
-    }
-     
-    val sparkCtx = srdd.sqlContext.sparkContext
-    val sparkCfg = new SparkSettingsManager().load(sparkCtx.getConf)
-    val esCfg = new PropertiesSettings().load(sparkCfg.save())
-    esCfg.merge(cfg.asJava)
+  def saveToEs(srdd: Dataset[_], cfg: Map[String, String]): Unit = {
+    if (srdd != null) {
+      val sparkCtx = srdd.sqlContext.sparkContext
+      val sparkCfg = new SparkSettingsManager().load(sparkCtx.getConf)
+      val esCfg = new PropertiesSettings().load(sparkCfg.save())
+      esCfg.merge(cfg.asJava)
 
-    InitializationUtils.checkIdForOperation(esCfg)
-    InitializationUtils.checkIndexExistence(esCfg)
-    
-    sparkCtx.runJob(srdd.toDF().rdd, new EsDataFrameWriter(srdd.schema, esCfg.save()).write _)
+      InitializationUtils.checkIdForOperation(esCfg)
+      InitializationUtils.checkIndexExistence(esCfg)
+
+      sparkCtx.runJob(srdd.toDF().rdd, new EsDataFrameWriter(srdd.schema, esCfg.save()).write _)
+    }
   }
 }

--- a/spark/sql-20/src/main/scala/org/elasticsearch/spark/sql/RowValueReader.scala
+++ b/spark/sql-20/src/main/scala/org/elasticsearch/spark/sql/RowValueReader.scala
@@ -52,7 +52,7 @@ private[sql] trait RowValueReader extends SettingsAware {
     }
   }
 
-  def addToBuffer(esRow: ScalaEsRow, key: AnyRef, value: Any) {
+  def addToBuffer(esRow: ScalaEsRow, key: AnyRef, value: Any): Unit = {
     val pos = esRow.rowOrder.indexOf(key.toString())
     if (pos < 0 || pos >= esRow.values.size) {
       // geo types allow fields which are ignored - need to skip these if they are not part of the schema

--- a/spark/sql-20/src/main/scala/org/elasticsearch/spark/sql/RowValueReader.scala
+++ b/spark/sql-20/src/main/scala/org/elasticsearch/spark/sql/RowValueReader.scala
@@ -56,11 +56,11 @@ private[sql] trait RowValueReader extends SettingsAware {
     val pos = esRow.rowOrder.indexOf(key.toString())
     if (pos < 0 || pos >= esRow.values.size) {
       // geo types allow fields which are ignored - need to skip these if they are not part of the schema
-      if (pos < 0 && currentFieldIsGeo) {
-        return
+      if (pos >= 0 || !currentFieldIsGeo) {
+        throw new EsHadoopIllegalStateException(s"Position for '$sparkRowField' not found in row; typically this is caused by a mapping inconsistency")
       }
-      throw new EsHadoopIllegalStateException(s"Position for '$sparkRowField' not found in row; typically this is caused by a mapping inconsistency")
+    } else {
+      esRow.values.update(pos, value)
     }
-    esRow.values.update(pos, value)
   }
 }

--- a/spark/sql-20/src/main/scala/org/elasticsearch/spark/sql/ScalaEsRowValueReader.scala
+++ b/spark/sql-20/src/main/scala/org/elasticsearch/spark/sql/ScalaEsRowValueReader.scala
@@ -100,8 +100,14 @@ class ScalaRowValueReader extends ScalaValueReader with RowValueReader with Valu
   override def addToArray(array: AnyRef, values: java.util.List[Object]): AnyRef = {
     // restore previous state
     array match {
-      case (pastInArray: Boolean, pastRowOrder: Seq[String]) => { inArray = pastInArray; currentArrayRowOrder = pastRowOrder }
-      case _                                                 => { inArray = false; currentArrayRowOrder = null}
+      case (pastInArray: Boolean, pastRowOrder: Seq[String @unchecked]) => {
+        inArray = pastInArray
+        currentArrayRowOrder = pastRowOrder
+      }
+      case _ => {
+        inArray = false
+        currentArrayRowOrder = null
+      }
     }
     super.addToArray(array, values)
   }
@@ -117,27 +123,27 @@ class ScalaRowValueReader extends ScalaValueReader with RowValueReader with Valu
     new Timestamp(value)
   }
 
-  def beginDoc() {}
+  def beginDoc(): Unit = {}
 
-  def beginLeadMetadata() { metadataMap = true }
+  def beginLeadMetadata(): Unit = { metadataMap = true }
 
-  def endLeadMetadata() {}
+  def endLeadMetadata(): Unit = {}
 
-  def beginSource() { rootLevel = true; sparkRowField = Utils.ROOT_LEVEL_NAME }
+  def beginSource(): Unit = { rootLevel = true; sparkRowField = Utils.ROOT_LEVEL_NAME }
 
-  def endSource() {}
+  def endSource(): Unit = {}
 
-  def beginTrailMetadata() {}
+  def beginTrailMetadata(): Unit = {}
 
-  def endTrailMetadata() {}
+  def endTrailMetadata(): Unit = {}
 
-  def endDoc() {}
+  def endDoc(): Unit = {}
   
-  def beginGeoField() {
+  def beginGeoField(): Unit = {
     currentFieldIsGeo = true
   }
   
-  def endGeoField() {
+  def endGeoField(): Unit = {
     currentFieldIsGeo = false
   }
 }

--- a/spark/sql-20/src/main/scala/org/elasticsearch/spark/sql/SchemaUtils.scala
+++ b/spark/sql-20/src/main/scala/org/elasticsearch/spark/sql/SchemaUtils.scala
@@ -110,7 +110,7 @@ private[sql] object SchemaUtils {
           // its presence is controlled through the dedicated config setting
           cfg.setProperty(InternalConfigurationOptions.INTERNAL_ES_TARGET_FIELDS, StringUtils.concatenate(Field.toLookupMap(field).keySet(), StringUtils.DEFAULT_DELIMITER))
         }
-        return (field, geoInfo)
+        (field, geoInfo)
       }
       else {
         throw new EsHadoopIllegalArgumentException(s"Cannot find mapping for ${cfg.getResourceRead} - one is required before using Spark SQL")
@@ -215,8 +215,7 @@ private[sql] object SchemaUtils {
 
     if (createArray) {
       // can't call createNestedArray for some reason...
-      var currentDepth = 0;
-      for (currentDepth <- 0 until matched.depth) {
+      for (_ <- 0 until matched.depth) {
         dataType = DataTypes.createArrayType(dataType)
       }
     }
@@ -224,9 +223,8 @@ private[sql] object SchemaUtils {
   }
   
   private def createNestedArray(elementType: DataType, depth: Int): DataType = {
-      var currentDepth = 0;
       var array = elementType
-      for (currentDepth <- 0 until depth) {
+      for (_ <- 0 until depth) {
         array = DataTypes.createArrayType(array)
       }
       array
@@ -284,7 +282,7 @@ private[sql] object SchemaUtils {
     rowInfo
   }
 
-  private def doDetectInfo(info: (Properties, Properties), level: String, dataType: DataType) {
+  private def doDetectInfo(info: (Properties, Properties), level: String, dataType: DataType): Unit = {
     dataType match {
       case s: StructType => {
         val fields = new java.util.ArrayList[String]
@@ -296,11 +294,7 @@ private[sql] object SchemaUtils {
       }
       case a: ArrayType => {
         val prop = info._2.getProperty(level)
-        var depth = 0
-        if (StringUtils.hasText(prop)) {
-          depth = Integer.parseInt(prop)
-        }
-        depth += 1
+        val depth = (if(StringUtils.hasText(prop)) Integer.parseInt(prop) else 0) + 1
         info._2.setProperty(level, String.valueOf(depth))
         doDetectInfo(info, level, a.elementType)
       }

--- a/spark/sql-20/src/main/scala/org/elasticsearch/spark/sql/api/java/JavaEsSparkSQL.scala
+++ b/spark/sql-20/src/main/scala/org/elasticsearch/spark/sql/api/java/JavaEsSparkSQL.scala
@@ -48,7 +48,7 @@ object JavaEsSparkSQL {
   def esDF(ss: SparkSession, resource: String, cfg: JMap[String, String]): DataFrame = EsSparkSQL.esDF(ss, resource, cfg.asScala)
   def esDF(ss: SparkSession, resource: String, query: String, cfg: JMap[String, String]): DataFrame = EsSparkSQL.esDF(ss, resource, query, cfg.asScala)
 
-  def saveToEs[T](ds: Dataset[T], resource: String) = EsSparkSQL.saveToEs(ds , resource)
-  def saveToEs[T](ds: Dataset[T], resource: String, cfg: JMap[String, String]) = EsSparkSQL.saveToEs(ds, resource, cfg.asScala)
-  def saveToEs[T](ds: Dataset[T], cfg: JMap[String, String]) = EsSparkSQL.saveToEs(ds, cfg.asScala)
+  def saveToEs[T](ds: Dataset[T], resource: String): Unit = EsSparkSQL.saveToEs(ds , resource)
+  def saveToEs[T](ds: Dataset[T], resource: String, cfg: JMap[String, String]): Unit = EsSparkSQL.saveToEs(ds, resource, cfg.asScala)
+  def saveToEs[T](ds: Dataset[T], cfg: JMap[String, String]): Unit = EsSparkSQL.saveToEs(ds, cfg.asScala)
 }

--- a/spark/sql-20/src/main/scala/org/elasticsearch/spark/sql/package.scala
+++ b/spark/sql-20/src/main/scala/org/elasticsearch/spark/sql/package.scala
@@ -45,9 +45,9 @@ package object sql {
   implicit def sparkDataFrameFunctions(df: DataFrame) = new SparkDataFrameFunctions(df)
 
   class SparkDataFrameFunctions(df: DataFrame) extends Serializable {
-    def saveToEs(resource: String) { EsSparkSQL.saveToEs(df, resource) }
-    def saveToEs(resource: String, cfg: scala.collection.Map[String, String]) { EsSparkSQL.saveToEs(df, resource, cfg) }
-    def saveToEs(cfg: scala.collection.Map[String, String]) { EsSparkSQL.saveToEs(df, cfg)    }
+    def saveToEs(resource: String): Unit = { EsSparkSQL.saveToEs(df, resource) }
+    def saveToEs(resource: String, cfg: scala.collection.Map[String, String]): Unit = { EsSparkSQL.saveToEs(df, resource, cfg) }
+    def saveToEs(cfg: scala.collection.Map[String, String]): Unit = { EsSparkSQL.saveToEs(df, cfg)    }
   }
   
   implicit def sparkSessionFunctions(ss: SparkSession)= new SparkSessionFunctions(ss)
@@ -64,8 +64,8 @@ package object sql {
   implicit def sparkDatasetFunctions[T : ClassTag](ds: Dataset[T]) = new SparkDatasetFunctions(ds)
   
   class SparkDatasetFunctions[T : ClassTag](ds: Dataset[T]) extends Serializable {
-    def saveToEs(resource: String) { EsSparkSQL.saveToEs(ds, resource) }
-    def saveToEs(resource: String, cfg: scala.collection.Map[String, String]) { EsSparkSQL.saveToEs(ds, resource, cfg) }
-    def saveToEs(cfg: scala.collection.Map[String, String]) { EsSparkSQL.saveToEs(ds, cfg)    }
+    def saveToEs(resource: String): Unit =  { EsSparkSQL.saveToEs(ds, resource) }
+    def saveToEs(resource: String, cfg: scala.collection.Map[String, String]): Unit =  { EsSparkSQL.saveToEs(ds, resource, cfg) }
+    def saveToEs(cfg: scala.collection.Map[String, String]): Unit =  { EsSparkSQL.saveToEs(ds, cfg)    }
   }
 }

--- a/spark/sql-20/src/main/scala/org/elasticsearch/spark/streaming/EsSparkStreaming.scala
+++ b/spark/sql-20/src/main/scala/org/elasticsearch/spark/streaming/EsSparkStreaming.scala
@@ -31,35 +31,35 @@ import scala.collection.Map
 object EsSparkStreaming {
 
   // Save methods
-  def saveToEs(ds: DStream[_], resource: String) {
+  def saveToEs(ds: DStream[_], resource: String): Unit = {
     saveToEs(ds, Map(ES_RESOURCE_WRITE -> resource))
   }
-  def saveToEs(ds: DStream[_], resource: String, cfg: Map[String, String]) {
+  def saveToEs(ds: DStream[_], resource: String, cfg: Map[String, String]): Unit = {
     saveToEs(ds, collection.mutable.Map(cfg.toSeq: _*) += (ES_RESOURCE_WRITE -> resource))
   }
-  def saveToEs(ds: DStream[_], cfg: Map[String, String]) {
+  def saveToEs(ds: DStream[_], cfg: Map[String, String]): Unit = {
     doSaveToEs(ds, cfg, hasMeta = false)
   }
 
   // Save with metadata
-  def saveToEsWithMeta[K,V](ds: DStream[(K,V)], resource: String) {
+  def saveToEsWithMeta[K,V](ds: DStream[(K,V)], resource: String): Unit = {
     saveToEsWithMeta(ds, Map(ES_RESOURCE_WRITE -> resource))
   }
-  def saveToEsWithMeta[K,V](ds: DStream[(K,V)], resource: String, cfg: Map[String, String]) {
+  def saveToEsWithMeta[K,V](ds: DStream[(K,V)], resource: String, cfg: Map[String, String]): Unit = {
     saveToEsWithMeta(ds, collection.mutable.Map(cfg.toSeq: _*) += (ES_RESOURCE_WRITE -> resource))
   }
-  def saveToEsWithMeta[K,V](ds: DStream[(K,V)], cfg: Map[String, String]) {
+  def saveToEsWithMeta[K,V](ds: DStream[(K,V)], cfg: Map[String, String]): Unit = {
     doSaveToEs(ds, cfg, hasMeta = true)
   }
 
   // Save as JSON
-  def saveJsonToEs(ds: DStream[_], resource: String) {
+  def saveJsonToEs(ds: DStream[_], resource: String): Unit = {
     saveToEs(ds, resource, Map(ES_INPUT_JSON -> true.toString))
   }
-  def saveJsonToEs(ds: DStream[_], resource: String, cfg: Map[String, String]) {
+  def saveJsonToEs(ds: DStream[_], resource: String, cfg: Map[String, String]): Unit = {
     saveToEs(ds, resource, collection.mutable.Map(cfg.toSeq: _*) += (ES_INPUT_JSON -> true.toString))
   }
-  def saveJsonToEs(ds: DStream[_], cfg: Map[String, String]) {
+  def saveJsonToEs(ds: DStream[_], cfg: Map[String, String]): Unit = {
     saveToEs(ds, collection.mutable.Map(cfg.toSeq: _*) += (ES_INPUT_JSON -> true.toString))
   }
 

--- a/spark/sql-20/src/main/scala/org/elasticsearch/spark/streaming/api/java/JavaEsSparkStreaming.scala
+++ b/spark/sql-20/src/main/scala/org/elasticsearch/spark/streaming/api/java/JavaEsSparkStreaming.scala
@@ -29,19 +29,19 @@ import org.elasticsearch.spark.streaming.EsSparkStreaming
 object JavaEsSparkStreaming {
 
   // specify the return types to make sure the bytecode is generated properly (w/o any scala.collections in it)
-  def saveToEs(ds: JavaDStream[_], resource: String) = EsSparkStreaming.saveToEs(ds.dstream, resource)
-  def saveToEs(ds: JavaDStream[_], resource: String, cfg: JMap[String, String]) = EsSparkStreaming.saveToEs(ds.dstream, resource, cfg.asScala)
-  def saveToEs(ds: JavaDStream[_], cfg: JMap[String, String]) = EsSparkStreaming.saveToEs(ds.dstream, cfg.asScala)
+  def saveToEs(ds: JavaDStream[_], resource: String): Unit = EsSparkStreaming.saveToEs(ds.dstream, resource)
+  def saveToEs(ds: JavaDStream[_], resource: String, cfg: JMap[String, String]): Unit = EsSparkStreaming.saveToEs(ds.dstream, resource, cfg.asScala)
+  def saveToEs(ds: JavaDStream[_], cfg: JMap[String, String]): Unit = EsSparkStreaming.saveToEs(ds.dstream, cfg.asScala)
 
-  def saveToEsWithMeta[K, V](ds: JavaPairDStream[K, V], resource: String) = EsSparkStreaming.saveToEsWithMeta(ds.dstream, resource)
-  def saveToEsWithMeta[K, V](ds: JavaPairDStream[K, V], resource: String, cfg: JMap[String, String]) = EsSparkStreaming.saveToEsWithMeta(ds.dstream, resource, cfg.asScala)
-  def saveToEsWithMeta[K, V](ds: JavaPairDStream[K, V], cfg: JMap[String, String]) = EsSparkStreaming.saveToEsWithMeta(ds.dstream, cfg.asScala)
+  def saveToEsWithMeta[K, V](ds: JavaPairDStream[K, V], resource: String): Unit = EsSparkStreaming.saveToEsWithMeta(ds.dstream, resource)
+  def saveToEsWithMeta[K, V](ds: JavaPairDStream[K, V], resource: String, cfg: JMap[String, String]): Unit = EsSparkStreaming.saveToEsWithMeta(ds.dstream, resource, cfg.asScala)
+  def saveToEsWithMeta[K, V](ds: JavaPairDStream[K, V], cfg: JMap[String, String]): Unit = EsSparkStreaming.saveToEsWithMeta(ds.dstream, cfg.asScala)
 
-  def saveJsonToEs(ds: JavaDStream[String], resource: String) = EsSparkStreaming.saveJsonToEs(ds.dstream, resource)
-  def saveJsonToEs(ds: JavaDStream[String], resource: String, cfg: JMap[String, String]) = EsSparkStreaming.saveJsonToEs(ds.dstream, resource, cfg.asScala)
-  def saveJsonToEs(ds: JavaDStream[String], cfg: JMap[String, String]) = EsSparkStreaming.saveJsonToEs(ds.dstream, cfg.asScala)
+  def saveJsonToEs(ds: JavaDStream[String], resource: String): Unit = EsSparkStreaming.saveJsonToEs(ds.dstream, resource)
+  def saveJsonToEs(ds: JavaDStream[String], resource: String, cfg: JMap[String, String]): Unit = EsSparkStreaming.saveJsonToEs(ds.dstream, resource, cfg.asScala)
+  def saveJsonToEs(ds: JavaDStream[String], cfg: JMap[String, String]): Unit = EsSparkStreaming.saveJsonToEs(ds.dstream, cfg.asScala)
 
-  def saveJsonByteArrayToEs(ds: JavaDStream[Array[Byte]], resource: String) = EsSparkStreaming.saveJsonToEs(ds.dstream, resource)
-  def saveJsonByteArrayToEs(ds: JavaDStream[Array[Byte]], resource: String, cfg: JMap[String, String]) = EsSparkStreaming.saveJsonToEs(ds.dstream, resource, cfg.asScala)
-  def saveJsonByteArrayToEs(ds: JavaDStream[Array[Byte]], cfg: JMap[String, String]) = EsSparkStreaming.saveJsonToEs(ds.dstream, cfg.asScala)
+  def saveJsonByteArrayToEs(ds: JavaDStream[Array[Byte]], resource: String): Unit = EsSparkStreaming.saveJsonToEs(ds.dstream, resource)
+  def saveJsonByteArrayToEs(ds: JavaDStream[Array[Byte]], resource: String, cfg: JMap[String, String]): Unit = EsSparkStreaming.saveJsonToEs(ds.dstream, resource, cfg.asScala)
+  def saveJsonByteArrayToEs(ds: JavaDStream[Array[Byte]], cfg: JMap[String, String]): Unit = EsSparkStreaming.saveJsonToEs(ds.dstream, cfg.asScala)
 }

--- a/spark/sql-20/src/main/scala/org/elasticsearch/spark/streaming/package.scala
+++ b/spark/sql-20/src/main/scala/org/elasticsearch/spark/streaming/package.scala
@@ -31,26 +31,26 @@ package object streaming {
   implicit def sparkDStreamFunctions(ds: DStream[_]): SparkDStreamFunctions = new SparkDStreamFunctions(ds)
 
   class SparkDStreamFunctions(ds: DStream[_]) extends Serializable {
-    def saveToEs(resource: String) { EsSparkStreaming.saveToEs(ds, resource) }
-    def saveToEs(resource: String, cfg: Map[String, String]) { EsSparkStreaming.saveToEs(ds, resource, cfg) }
-    def saveToEs(cfg: Map[String, String]) { EsSparkStreaming.saveToEs(ds, cfg) }
+    def saveToEs(resource: String): Unit = { EsSparkStreaming.saveToEs(ds, resource) }
+    def saveToEs(resource: String, cfg: Map[String, String]): Unit = { EsSparkStreaming.saveToEs(ds, resource, cfg) }
+    def saveToEs(cfg: Map[String, String]): Unit = { EsSparkStreaming.saveToEs(ds, cfg) }
   }
 
   implicit def sparkStringJsonDStreamFunctions(ds: DStream[String]): SparkJsonDStreamFunctions[String] = new SparkJsonDStreamFunctions[String](ds)
   implicit def sparkByteArrayJsonDStreamFunctions(ds: DStream[Array[Byte]]): SparkJsonDStreamFunctions[Array[Byte]] = new SparkJsonDStreamFunctions[Array[Byte]](ds)
 
   class SparkJsonDStreamFunctions[T : ClassTag](ds: DStream[T]) extends Serializable {
-    def saveJsonToEs(resource: String) { EsSparkStreaming.saveJsonToEs(ds, resource) }
-    def saveJsonToEs(resource: String, cfg: Map[String, String]) { EsSparkStreaming.saveJsonToEs(ds, resource, cfg) }
-    def saveJsonToEs(cfg: Map[String, String]) { EsSparkStreaming.saveJsonToEs(ds, cfg) }
+    def saveJsonToEs(resource: String): Unit = { EsSparkStreaming.saveJsonToEs(ds, resource) }
+    def saveJsonToEs(resource: String, cfg: Map[String, String]): Unit = { EsSparkStreaming.saveJsonToEs(ds, resource, cfg) }
+    def saveJsonToEs(cfg: Map[String, String]): Unit = { EsSparkStreaming.saveJsonToEs(ds, cfg) }
   }
 
   implicit def sparkPairDStreamFunctions[K : ClassTag, V : ClassTag](ds: DStream[(K,V)]): SparkPairDStreamFunctions[K,V] = new SparkPairDStreamFunctions[K,V](ds)
 
   class SparkPairDStreamFunctions[K : ClassTag, V : ClassTag](ds: DStream[(K, V)]) extends Serializable {
-    def saveToEsWithMeta(resource: String) { EsSparkStreaming.saveToEsWithMeta(ds, resource) }
-    def saveToEsWithMeta(resource: String, cfg: Map[String, String]) { EsSparkStreaming.saveToEsWithMeta(ds, resource, cfg) }
-    def saveToEsWithMeta(cfg: Map[String, String]) { EsSparkStreaming.saveToEsWithMeta(ds, cfg) }
+    def saveToEsWithMeta(resource: String): Unit = { EsSparkStreaming.saveToEsWithMeta(ds, resource) }
+    def saveToEsWithMeta(resource: String, cfg: Map[String, String]): Unit = { EsSparkStreaming.saveToEsWithMeta(ds, resource, cfg) }
+    def saveToEsWithMeta(cfg: Map[String, String]): Unit = { EsSparkStreaming.saveToEsWithMeta(ds, cfg) }
   }
 
 }


### PR DESCRIPTION
This pull request includes following fix:

- Avoid procedure syntax method declaration
  - Because it brings potential of bug in the future code change. Procedure syntax is deprecated currently in the Scala standard and it will be removed in the future version of Scala.
- Avoid unnecessary `return` statement
  - `return` is translated into throwing an exception (and catching it) by Scala compiler, so we shouldn't use it in the performance reason. Also compiler can't inference a return type of the method if return is being used in the method.
- Avoid unnecessary `while` loop and mutable variable
  - Typically, we can write code safer by using immutable variables. `while` loop depends mutable flags in many cases, but it can be replaced with other way in Scala. It makes possible to eliminate mutable flags.

And I have questions about code in `ScalaValueReader.scala`, so I added inline comment to that code.

----

Thank you for submitting a pull request! 

Please make sure you have signed our [Contributor License Agreement (CLA)][].  
We are not asking you to assign copyright to us, but to give us the right to distribute your code without restriction. We ask this of all contributors in order to assure our users of the origin and continuing existence of the code.  
You only need to sign the CLA once.

- [x] I have signed the [Contributor License Agreement (CLA)][]

[Contributor License Agreement (CLA)]: https://www.elastic.co/contributor-agreement/
