### PR TITLE
Missing "JAR" keyword

### DIFF
--- a/docs/src/reference/asciidoc/core/hive.adoc
+++ b/docs/src/reference/asciidoc/core/hive.adoc
@@ -14,7 +14,7 @@ Hive abstracts Hadoop by abstracting it through SQL-like language, called HiveQL
 Make {eh} jar available in the Hive classpath. Depending on your options, there are various https://cwiki.apache.org/confluence/display/Hive/HivePlugins#HivePlugins-DeployingjarsforUserDefinedFunctionsandUserDefinedSerDes[ways] to achieve that. Use https://cwiki.apache.org/Hive/languagemanual-cli.html#LanguageManualCli-HiveResources[ADD] command to add files, jars (what we want) or archives to the classpath:
 
 ----
-ADD /path/elasticsearch-hadoop.jar;
+ADD JAR /path/elasticsearch-hadoop.jar;
 ----
 
 NOTE: the command expects a proper URI that can be found either on the local file-system or remotely. Typically it's best to use a distributed file-system (like HDFS or Amazon S3) and use that since the script might be executed


### PR DESCRIPTION
According https://cwiki.apache.org/confluence/display/Hive/LanguageManual+Cli

It seems better to precise "ADD JAR"
