### PR TITLE
Add Scala compiler options

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -576,6 +576,16 @@ def baseSparkProject(target, sparkVersion) {
             jvmArgs = ['-XX:MaxPermSize=512m']
         }
         scalaCompileOptions.useAnt = false
+        scalaCompileOptions.additionalParameters = [
+            "-feature",
+            "-unchecked",
+            "-deprecation",
+            "-Xfuture",
+            "-Yno-adapted-args",
+            "-Ywarn-dead-code",
+            "-Ywarn-numeric-widen",
+            "-Ywarn-value-discard"
+        ]
 
         sourceCompatibility = 1.6
         targetCompatibility = 1.6


### PR DESCRIPTION
Add Scala compiler options to warn bad code. Compiler output example is:

```
/Users/naoki.takezoe/elasticsearch-hadoop/spark/core/main/scala/org/elasticsearch/spark/rdd/EsSpark.scala:102: discarded non-Unit value
    rdd.sparkContext.runJob(rdd, new EsRDDWriter(config.save(), hasMeta).write _)
                           ^
/Users/naoki.takezoe/elasticsearch-hadoop/spark/core/main/scala/org/elasticsearch/spark/rdd/JavaEsRDD.scala:49: discarded non-Unit value
    InitializationUtils.setValueReaderIfNotSet(settings, classOf[JdkValueReader], log)
                                              ^
/Users/naoki.takezoe/elasticsearch-hadoop/spark/core/main/scala/org/elasticsearch/spark/rdd/ScalaEsRDD.scala:51: discarded non-Unit value
    InitializationUtils.setValueReaderIfNotSet(settings, classOf[ScalaValueReader], log)
                                              ^
/Users/naoki.takezoe/elasticsearch-hadoop/spark/core/main/scala/org/elasticsearch/spark/serialization/ScalaValueReader.scala:190: discarded non-Unit value
    map.asInstanceOf[Map[AnyRef, Any]].put(key, value)
                                          ^
/Users/naoki.takezoe/elasticsearch-hadoop/spark/core/main/scala/org/elasticsearch/spark/serialization/ScalaValueReader.scala:228: non-variable type argument AnyRef in type pattern Seq[AnyRef] is unchecked since it is eliminated by erasure
        case col: Seq[AnyRef] => {
                  ^
/Users/naoki.takezoe/elasticsearch-hadoop/spark/sql-20/src/main/scala/org/elasticsearch/spark/sql/DataFrameValueWriter.scala:112: dead code following this construct
    value match {
          ^
/Users/naoki.takezoe/elasticsearch-hadoop/spark/sql-20/src/main/scala/org/elasticsearch/spark/sql/EsSparkSQL.scala:94: discarded non-Unit value
    sparkCtx.runJob(srdd.toDF().rdd, new EsDataFrameWriter(srdd.schema, esCfg.save()).write _)
                   ^
/Users/naoki.takezoe/elasticsearch-hadoop/spark/sql-20/src/main/scala/org/elasticsearch/spark/sql/ScalaEsRowValueReader.scala:103: non-variable type argument String in type pattern Seq[String] is unchecked since it is eliminated by erasure
      case (pastInArray: Boolean, pastRowOrder: Seq[String]) => { inArray = pastInArray; currentArrayRowOrder = pastRowOrder }
                                                ^
/Users/naoki.takezoe/elasticsearch-hadoop/spark/sql-20/src/main/scala/org/elasticsearch/spark/sql/SchemaUtils.scala:295: discarded non-Unit value
        info._1.setProperty(level, StringUtils.concatenate(fields, StringUtils.DEFAULT_DELIMITER))
                           ^
/Users/naoki.takezoe/elasticsearch-hadoop/spark/sql-20/src/main/scala/org/elasticsearch/spark/streaming/package.scala:31: implicit conversion method sparkDStreamFunctions should be enabled
by making the implicit value scala.language.implicitConversions visible.
This can be achieved by adding the import clause 'import scala.language.implicitConversions'
or by setting the compiler option -language:implicitConversions.
See the Scala docs for value scala.language.implicitConversions for a discussion
why the feature should be explicitly enabled.
  implicit def sparkDStreamFunctions(ds: DStream[_]): SparkDStreamFunctions = new SparkDStreamFunctions(ds)
               ^
/Users/naoki.takezoe/elasticsearch-hadoop/spark/sql-20/src/main/scala/org/elasticsearch/spark/streaming/package.scala:39: implicit conversion method sparkStringJsonDStreamFunctions should be enabled
by making the implicit value scala.language.implicitConversions visible.
  implicit def sparkStringJsonDStreamFunctions(ds: DStream[String]): SparkJsonDStreamFunctions[String] = new SparkJsonDStreamFunctions[String](ds)
               ^
/Users/naoki.takezoe/elasticsearch-hadoop/spark/sql-20/src/main/scala/org/elasticsearch/spark/streaming/package.scala:40: implicit conversion method sparkByteArrayJsonDStreamFunctions should be enabled
by making the implicit value scala.language.implicitConversions visible.
  implicit def sparkByteArrayJsonDStreamFunctions(ds: DStream[Array[Byte]]): SparkJsonDStreamFunctions[Array[Byte]] = new SparkJsonDStreamFunctions[Array[Byte]](ds)
               ^
/Users/naoki.takezoe/elasticsearch-hadoop/spark/sql-20/src/main/scala/org/elasticsearch/spark/streaming/package.scala:48: implicit conversion method sparkPairDStreamFunctions should be enabled
by making the implicit value scala.language.implicitConversions visible.
  implicit def sparkPairDStreamFunctions[K : ClassTag, V : ClassTag](ds: DStream[(K,V)]): SparkPairDStreamFunctions[K,V] = new SparkPairDStreamFunctions[K,V](ds)
               ^
/Users/naoki.takezoe/elasticsearch-hadoop/spark/sql-20/src/main/scala/org/elasticsearch/spark/sql/DataFrameValueWriter.scala:112: dead code following this construct
    value match {
    ^
14 warnings found
```