### PR TITLE
add option to ignore document missing or already exists exception

### DIFF
--- a/mr/src/main/java/org/elasticsearch/hadoop/cfg/ConfigurationOptions.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/cfg/ConfigurationOptions.java
@@ -228,6 +228,13 @@ public interface ConfigurationOptions {
     String ES_OPERATION_DELETE = "delete";
     String ES_WRITE_OPERATION_DEFAULT = ES_OPERATION_INDEX;
 
+    // ignore document already exists exception, like we don't want to overwrite document that already exists when batch insert docs from hive
+    String ES_CREATE_IGNORE_EXISTS = "es.create.ignore.exists";
+    String ES_CREATE_IGNORE_EXISTS_DEFAULT = "false";
+    // ignore document missing exception, like we don't care deleted docs when update statistical fields
+    String ES_UPDATE_IGNORE_404 = "es.update.ignore.document.missing";
+    String ES_UPDATE_IGNORE_404_DEFAULT = "false";
+
     String ES_UPDATE_RETRY_ON_CONFLICT = "es.update.retry.on.conflict";
     String ES_UPDATE_RETRY_ON_CONFLICT_DEFAULT = "0";
 

--- a/mr/src/main/java/org/elasticsearch/hadoop/cfg/Settings.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/cfg/Settings.java
@@ -279,6 +279,14 @@ public abstract class Settings {
         return Integer.parseInt(getProperty(ES_UPDATE_RETRY_ON_CONFLICT, ES_UPDATE_RETRY_ON_CONFLICT_DEFAULT));
     }
 
+    public boolean getUpdateIgnore404() {
+        return Boolean.parseBoolean(getProperty(ES_UPDATE_IGNORE_404, ES_UPDATE_IGNORE_404_DEFAULT));
+    }
+
+    public boolean getCreateIgnoreExists() {
+        return Boolean.parseBoolean(getProperty(ES_CREATE_IGNORE_EXISTS, ES_CREATE_IGNORE_EXISTS_DEFAULT));
+    }
+
     public String getUpdateScript() {
         return getProperty(ES_UPDATE_SCRIPT);
     }


### PR DESCRIPTION
add two options:
1. es.create.ignore.exists
2. es.update.ignore.document.missing

reasons:
1. we generate new docs in hive, but some realtime docs are already in elasticsearch, so we don't want to overwrite them when batch insert;
2. we generate statistical fields in hive, but realtime update action delete some invalid docs in elasticsearch, so just jump missing documents to finish update successfully.
