### PR TITLE
Deprecate Hadoop 1.x in 5.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ or [build](#building-the-source) the project yourself.
 
 We do build and test the code on _each_ commit.
 
-### Hadoop 2.0/YARN
+### Supported Hadoop Version
 
-Already supported - it does not matter if you are using Hadoop 1.x or 2.x, the same jar works across both Hadoop environments.
+Hadoop 1.x as well as the "old" api (mapred) are deprecated in 5.5 and will be removed in 6.0.
 More information in this [section](http://www.elastic.co/guide/en/elasticsearch/hadoop/current/install.html).
 
 ## Feedback / Q&A
@@ -93,9 +93,12 @@ For basic, low-level or performance-sensitive environments, ES-Hadoop provides d
 (either by bundling the library along - it's ~300kB and there are no-dependencies), using the [DistributedCache][] or by provisioning the cluster manually.
 See the [documentation](http://www.elastic.co/guide/en/elasticsearch/hadoop/current/index.html) for more information.
 
-Note that es-hadoop supports both the so-called 'old' and the 'new' API through its `EsInputFormat` and `EsOutputFormat` classes.
+Note that support of the (old) 'mapred' API is deprecated as of 5.5 and will be removed in 6.0. 
 
 ### 'Old' (`org.apache.hadoop.mapred`) API
+
+#### !!! DEPRECATED IN 5.5 !!!
+Support of the (old) 'mapred' API is deprecated as of 5.5 and will be removed in 6.0.
 
 ### Reading
 To read data from ES, configure the `EsInputFormat` on your job configuration along with the relevant [properties](#configuration-properties):

--- a/docs/src/reference/asciidoc/core/intro/download.adoc
+++ b/docs/src/reference/asciidoc/core/intro/download.adoc
@@ -15,7 +15,8 @@
 The jar above contains all the features of {eh} and does not require any other dependencies at runtime; in other words it can be used as is.
 
 [[yarn]]
-{eh} binary is suitable for both Hadoop 1.x and Hadoop 2.x (also known as YARN) environments without any changes.
+{eh} binary is suitable for Hadoop 2.x (also known as YARN) environments.
+Support for Hadoop 1.x environments as well as the old mapred packages are deprecated in 5.5 and will be removed in 6.0.
 
 === Minimalistic binaries
 

--- a/docs/src/reference/asciidoc/core/intro/features.adoc
+++ b/docs/src/reference/asciidoc/core/intro/features.adoc
@@ -9,7 +9,7 @@ REST based:: {eh} uses {es} REST interface for communication, allowing for flexi
 
 Self contained:: the library has been designed to be small and efficient. At around 300KB and _no_ extra dependencies outside Hadoop itself, distributing {eh} within your cluster is simple and fast.
 
-Universal jar:: whether you are using Hadoop 1.x or Hadoop 2.x, vanilla Apache Hadoop or a certain distro, the _same_ {eh} jar works transparently across all of them.
+Universal jar:: whether you are using vanilla Apache Hadoop or a certain distro, the _same_ {eh} jar works transparently across all of them.
 
 Memory and I/O efficient:: {eh} is focused on performance. From pull-based parsing, to bulk updates and direct conversion to/of native types, {eh} keeps its memory and network I/O usage finely-tuned.
 
@@ -18,8 +18,6 @@ Adaptive I/O:: {eh} detects transport errors and retries automatically. If the {
 Facilitates data co-location:: {eh} fully integrates with Hadoop exposing its network access information, allowing co-located {es} and Hadoop clusters to be aware of each other and reduce network IO.
 
 {mr} API support:: At its core, {eh} uses the low-level {mr} API to read and write data to {es} allowing for maximum integration flexibility and performance.
-
-'old'(`mapred`) & 'new'(`mapreduce`) {mr} APIs supported:: {eh} automatically adjusts to your environment; one does not have to change between using the `mapred` or `mapreduce` APIs - both are supported, by the same classes, at the same time.
 
 Apache Hive support:: Run Hive queries against {es} for advanced analystics and _real_time_ responses. {eh} exposes {es} as a Hive table so your scripts can crunch through data faster then ever.
 

--- a/docs/src/reference/asciidoc/core/intro/requirements.adoc
+++ b/docs/src/reference/asciidoc/core/intro/requirements.adoc
@@ -52,14 +52,14 @@ $ curl -XGET http://localhost:9200
 [[requirements-hadoop]]
 === Hadoop
 
-Hadoop 1.x (ideally the latest stable version in the 1.x line, currently 1.2.1) or 2.x (ideally the latest stable version, currently 2.4.1). {eh} is tested daily against Apache Hadoop; any distro compatible with Apache Hadoop should work just fine.
+Hadoop 2.x (ideally the latest stable version, currently 2.4.1). {eh} is tested daily against Apache Hadoop; any distro compatible with Apache Hadoop should work just fine.
 
 To check the version of Hadoop, one can refer either to its folder or jars (which contain the version in their names) or from the command line:
 
 [source, bash]
 ----
 $ bin/hadoop version
-Hadoop 1.2.1
+Hadoop 2.4.1
 ----
 
 As a guide, the table below lists the Hadoop-based distributions against with this version has been tested against at various points in time:
@@ -71,8 +71,6 @@ As a guide, the table below lists the Hadoop-based distributions against with th
 | Apache Hadoop     | 2.6.x
 | Apache Hadoop     | 2.4.x
 | Apache Hadoop     | 2.2.x
-| Apache Hadoop     | 1.2.x
-| Apache Hadoop     | 1.1.x
 
 | Amazon EMR        | 4.5.x
 | Amazon EMR        | 4.4.x
@@ -109,7 +107,7 @@ IMPORTANT: Use the table above for guidance only; if your distro (or its version
 [[requirements-yarn]]
 === Apache YARN / Hadoop 2.x
 
-{eh} binary can run transparently on both Hadoop 1.x and Yarn / Hadoop 2.x without any changes or modifications.
+{eh} binary can run on Yarn / Hadoop 2.x without any changes or modifications.
 
 [[requirements-cascading]]
 === Cascading

--- a/docs/src/reference/asciidoc/core/intro/requirements.adoc
+++ b/docs/src/reference/asciidoc/core/intro/requirements.adoc
@@ -52,7 +52,7 @@ $ curl -XGET http://localhost:9200
 [[requirements-hadoop]]
 === Hadoop
 
-Hadoop 2.x (ideally the latest stable version, currently 2.4.1). {eh} is tested daily against Apache Hadoop; any distro compatible with Apache Hadoop should work just fine.
+Hadoop 2.x (ideally the latest stable version, currently 2.7.3). {eh} is tested daily against Apache Hadoop; any distro compatible with Apache Hadoop should work just fine.
 
 To check the version of Hadoop, one can refer either to its folder or jars (which contain the version in their names) or from the command line:
 
@@ -61,48 +61,6 @@ To check the version of Hadoop, one can refer either to its folder or jars (whic
 $ bin/hadoop version
 Hadoop 2.4.1
 ----
-
-As a guide, the table below lists the Hadoop-based distributions against with this version has been tested against at various points in time:
-
-|===
-| Distribution      | Release
-
-| Apache Hadoop     | 2.7.x
-| Apache Hadoop     | 2.6.x
-| Apache Hadoop     | 2.4.x
-| Apache Hadoop     | 2.2.x
-
-| Amazon EMR        | 4.5.x
-| Amazon EMR        | 4.4.x
-| Amazon EMR        | 4.3.x
-| Amazon EMR        | 4.2.x
-| Amazon EMR        | 4.1.x
-| Amazon EMR        | 4.0.x
-| Amazon EMR        | 3.11.x
-| Amazon EMR        | 3.10.x
-| Amazon EMR        | 3.9.x
-| Amazon EMR        | 3.8.x
-| Amazon EMR        | 3.7.x
-| Amazon EMR        | 3.6.x
-| Amazon EMR        | 3.5.x
-| Amazon EMR        | 3.4.x
-| Amazon EMR        | 3.3.x
-| Amazon EMR        | 3.2.x
-
-| Cloudera CDH      | 5.7.x
-| Cloudera CDH      | 5.6.x
-| Cloudera CDH      | 5.5.x
-| Cloudera CDH      | 5.4.x
-
-| Hortonworks HDP   | 2.4.x
-| Hortonworks HDP   | 2.3.x
-
-| MapR              | 5.x
-| MapR              | 4.1.x
-| MapR              | 4.0.x
-|===
-
-IMPORTANT: Use the table above for guidance only; if your distro (or its version) is not there, it does not mean {eh} is not compatible with it; rather go ahead and try it out and let us know how it went.
 
 [[requirements-yarn]]
 === Apache YARN / Hadoop 2.x

--- a/docs/src/reference/asciidoc/core/mr.adoc
+++ b/docs/src/reference/asciidoc/core/mr.adoc
@@ -43,9 +43,7 @@ Simply use the configuration object when constructing the Hadoop job and you are
 [float]
 === Writing data to {es}
 
-With {eh}, {mr} jobs can write data to {es} making it searchable through {ref}/glossary.html#glossary-index[indexes]. {eh} supports both (so-called)  http://hadoop.apache.org/docs/r1.2.1/api/org/apache/hadoop/mapred/package-use.html['old'] and http://hadoop.apache.org/docs/r1.2.1/api/org/apache/hadoop/mapreduce/package-use.html['new'] Hadoop APIs.
-
-TIP: Both Hadoop 1.x and 2.x are supported by the same binary
+With {eh}, {mr} jobs can write data to {es} making it searchable through {ref}/glossary.html#glossary-index[indexes]. {eh} supports only the http://hadoop.apache.org/docs/r1.2.1/api/org/apache/hadoop/mapreduce/package-use.html['new'] Hadoop APIs.
 
 `EsOutputFormat` expects a `Map<Writable, Writable>` representing a _document_ value that is converted internally into a JSON document and indexed in {es}.
 Hadoop `OutputFormat` requires implementations to expect a key and a value however, since for {es} only the document (that is the value) is necessary, `EsOutputFormat`
@@ -53,6 +51,7 @@ ignores the key.
 
 [float]
 ==== 'Old' (`org.apache.hadoop.mapred`) API
+deprecated[5.5.0,"Hadoop old api library support is deprecated and will be removed in 6.0"]
 
 To write data to ES, use `org.elasticsearch.hadoop.mr.EsOutputFormat` on your job along with the relevant configuration <<configuration,properties>>:
 
@@ -105,6 +104,8 @@ At runtime, {eh} will extract the value from each document and use it accordingl
 [[writing-json-old-api]]
 ==== Writing existing JSON to {es}
 
+deprecated[5.5.0,"Hadoop old api library support is deprecated and will be removed in 6.0"]
+
 For cases where the job input data is already in JSON, {eh} allows direct indexing _without_ applying any transformation; the data is taken as is and sent directly to {es}. In such cases, one needs to indicate the json input by setting
 the `es.input.json` parameter. As such, in this case {eh} expects either a `Text` or `BytesWritable` (preferred as it requires no `String` conversion) object as output; if these types are not used, the library will simply fall back to the `toString` representation of the target object.
 
@@ -152,6 +153,8 @@ public class MyMapper extends MapReduceBase implements Mapper {
 [float]
 [[writing-dyn-index-old-api]]
 ==== Writing to dynamic/multi-resources
+
+deprecated[5.5.0,"Hadoop old api library support is deprecated and will be removed in 6.0"]
 
 For cases when the data being written to {es} needs to be indexed under different buckets (based on the data content) one can use the `es.resource.write` field which accepts pattern that are resolved from the document content, at runtime.
 Following the aforementioned <<cfg-multi-writes,media example>>, one could configure it as follows:
@@ -272,6 +275,8 @@ TIP: If one needs the document structure returned from {es} to be preserved, con
 
 [float]
 ==== 'Old' (`org.apache.hadoop.mapred`) API
+
+deprecated[5.5.0,"Hadoop old api library support is deprecated and will be removed in 6.0"]
 
 Following our example above on radio artists, to get a hold of all the artists that start with 'me', one could use the following snippet:
 
@@ -406,13 +411,6 @@ IMPORTANT: If automatic index creation is used, please review <<auto-mapping-typ
 | `MD5Writable`     | `string`
 | `ArrayWritable`   | `array`
 | `AbstractMapWritable` | `map`
-
-2+h| Available only in Apache Hadoop 1.x
-
-| `UTF8`            | `string`
-
-2+h| Available only in Apache Hadoop 2.x
-
 | `ShortWritable`   | `short`
 
 |===


### PR DESCRIPTION
Deprecations for Hadoop 1.x and the old `mapred` api