### PR TITLE
Remove unmatched format specifier from Restservice

### DIFF
--- a/mr/src/main/java/org/elasticsearch/hadoop/rest/RestService.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/rest/RestService.java
@@ -408,7 +408,7 @@ public abstract class RestService implements Serializable {
             String pinAddress = checkLocality(partition.getLocations(), log);
             if (pinAddress != null) {
                 if (log.isDebugEnabled()) {
-                    log.debug(String.format("Partition reader instance [%s] assigned to [%s]:[%s]", partition, pinAddress));
+                    log.debug(String.format("Partition reader instance [%s] assigned to [%s]", partition, pinAddress));
                 }
                 SettingsUtils.pinNode(settings, pinAddress);
             }


### PR DESCRIPTION
`MissingFormatArgumentException` was thrown if the log level is set to `DEBUG`, this PR fixes it.

- [x] I have signed the [Contributor License Agreement (CLA)][]

[Contributor License Agreement (CLA)]: https://www.elastic.co/contributor-agreement/
