### PR TITLE
Adding comment on breaking change

### DIFF
--- a/docs/src/reference/asciidoc/appendix/breaking.adoc
+++ b/docs/src/reference/asciidoc/appendix/breaking.adoc
@@ -23,8 +23,8 @@ of types. ES-Hadoop was previously using this deprecated endpoint up until
 the 5.4.x releases. If you have upgraded to Elasticsearch 5.5.0, you will
 need to upgrade ES-Hadoop to version 5.5.0.
 
-The new endpoint is available since Elasticsearch 5.x. It makes the ES-Hadoop
-library no more backward compatible with Elasticsearch 2.x.
+The new endpoint is available since Elasticsearch 5.x. In case you are running
+Elasticsearch 2.x, the correct endpoint will be used.
 
 [[breaking-changes-5.0]]
 === Breaking Changes in 5.0

--- a/docs/src/reference/asciidoc/appendix/breaking.adoc
+++ b/docs/src/reference/asciidoc/appendix/breaking.adoc
@@ -23,6 +23,9 @@ of types. ES-Hadoop was previously using this deprecated endpoint up until
 the 5.4.x releases. If you have upgraded to Elasticsearch 5.5.0, you will
 need to upgrade ES-Hadoop to version 5.5.0.
 
+The new endpoint is available since Elasticsearch 5.x. It makes the ES-Hadoop
+library no more backward compatible with Elasticsearch 2.x.
+
 [[breaking-changes-5.0]]
 === Breaking Changes in 5.0
 


### PR DESCRIPTION
Hello,
the release ES-Hadoop 5.5 actually breaks the previous backward compatibility with Elasticsearch 2.x as mentioned also in the following [documentation page](https://www.elastic.co/guide/en/elasticsearch/hadoop/5.5/requirements.html#requirements-es)

```We highly recommend using the latest Elasticsearch (currently 5.5.3), but elasticsearch-hadoop is also backwards compatible with the 1.X and 2.X versions of Elasticsearch.```

Thank you for submitting a pull request! 

Please make sure you have signed our [Contributor License Agreement (CLA)][].  
We are not asking you to assign copyright to us, but to give us the right to distribute your code without restriction. We ask this of all contributors in order to assure our users of the origin and continuing existence of the code.  
You only need to sign the CLA once.

- [x] I have signed the [Contributor License Agreement (CLA)][]

[Contributor License Agreement (CLA)]: https://www.elastic.co/contributor-agreement/
