### PR TITLE
Updating Spark latest version

### DIFF
--- a/docs/src/reference/asciidoc/index.adoc
+++ b/docs/src/reference/asciidoc/index.adoc
@@ -13,7 +13,7 @@
 :ver:	6.0.0-alpha-2
 :ver-d: 6.0.0.BUILD-SNAPSHOT
 :es-v:	6.0.0-alpha-2
-:sp-v:	1.6.2
+:sp-v:	2.2.0
 :st-v:	1.0.1
 :pg-v:	0.15.0
 :hv-v:	1.2.1


### PR DESCRIPTION
Documentation shows 1.6.2 as the latest Spark version but Apache documentation indicates 2.2.0

Thank you for submitting a pull request! 

Please make sure you have signed our [Contributor License Agreement (CLA)][].  
We are not asking you to assign copyright to us, but to give us the right to distribute your code without restriction. We ask this of all contributors in order to assure our users of the origin and continuing existence of the code.  
You only need to sign the CLA once.

- [x] I have signed the [Contributor License Agreement (CLA)][]

[Contributor License Agreement (CLA)]: https://www.elastic.co/contributor-agreement/
