### PR TITLE
Add support for dropping bulk errors for particular HTTP status codes

### DIFF
--- a/mr/src/main/java/org/elasticsearch/hadoop/cfg/ConfigurationOptions.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/cfg/ConfigurationOptions.java
@@ -245,6 +245,8 @@ public interface ConfigurationOptions {
     String ES_UPDATE_SCRIPT_PARAMS = "es.update.script.params";
     String ES_UPDATE_SCRIPT_PARAMS_JSON = "es.update.script.params.json";
 
+    String ES_BATCH_WRITE_DROP_ERROR_STATUSES = "es.write.drop.error.statuses";
+
     /** Output options **/
     String ES_OUTPUT_JSON = "es.output.json";
     String ES_OUTPUT_JSON_DEFAULT = "no";

--- a/mr/src/main/java/org/elasticsearch/hadoop/cfg/Settings.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/cfg/Settings.java
@@ -19,11 +19,8 @@
 package org.elasticsearch.hadoop.cfg;
 
 import java.io.InputStream;
-import java.util.Enumeration;
-import java.util.Locale;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.Properties;
 
 import org.apache.commons.logging.LogFactory;
 import org.elasticsearch.hadoop.util.EsMajorVersion;
@@ -573,6 +570,22 @@ public abstract class Settings {
 
     public boolean getDataFrameWriteNullValues() {
         return Booleans.parseBoolean(getProperty(ES_SPARK_DATAFRAME_WRITE_NULL_VALUES, ES_SPARK_DATAFRAME_WRITE_NULL_VALUES_DEFAULT));
+    }
+
+    public Set<Integer> getDropErrorStatuses() {
+        String dropErrorStatuses = getProperty(ES_BATCH_WRITE_DROP_ERROR_STATUSES, StringUtils.EMPTY);
+
+        if (!StringUtils.hasText(dropErrorStatuses)) {
+            return Collections.emptySet();
+        }
+        else {
+            Set<Integer> statuses = new HashSet<Integer>();
+            for (String statusString : dropErrorStatuses.split(",")) {
+                statuses.add(Integer.parseInt(statusString.trim()));
+            }
+
+            return statuses;
+        }
     }
 
     public abstract InputStream loadResource(String location);


### PR DESCRIPTION
Hi,
I run a 24/7 Spark Streaming to Elasticsearch application that processes around 4TB a day. Occasionally, a single bad document will get in and bring the whole thing down. Unfortunately, I have very little control over upstream parsing of the documents. So I'd like ES to just drop the individual document, log the error and continue.

I've seen several PRs in the past that dealt with ignoring various types of errors, but they never seem to get merged. Please let me know if there's anything I can do to clean up this PR and push this forward!

Thanks for a great product.