### PR TITLE
Update configuration.adoc

### DIFF
--- a/docs/src/reference/asciidoc/core/configuration.adoc
+++ b/docs/src/reference/asciidoc/core/configuration.adoc
@@ -85,14 +85,14 @@ For example assuming the data contains a +@timestamp+ field, one can group the d
 [source,ini]
 ----
 # index the documents based on their date
-es.resource.write = my-collection/{@timestamp:YYYY.MM.dd} <1>
+es.resource.write = my-collection/{@timestamp:yyyy.MM.dd} <1>
 ----
 
-<1> +@timestamp+ field formatting - in this case +YYYY.MM.dd+
+<1> +@timestamp+ field formatting - in this case +yyyy.MM.dd+
 
 The same configuration property is used (+es.resource.write+) however, through the special +:+ characters a formatting pattern is specified.
 Please refer to the http://docs.oracle.com/javase/7/docs/api/java/text/SimpleDateFormat.html[SimpleDateFormat] javadocs for more information on the syntax supported.
-In this case +YYYY.MM.dd+ translates the date into the year (specified by four digits), month by 2 digits followed by the day by two digits (such as +2015.01.28+).
+In this case +yyyy.MM.dd+ translates the date into the year (specified by four digits), month by 2 digits followed by the day by two digits (such as +2015.01.28+).
 
 http://logstash.net/[Logstash] users will find this _pattern_ quite http://logstash.net/docs/latest/filters/date[familiar].
 


### PR DESCRIPTION
YYYY is the calendar year for the WEEK that the day falls in, which is determined by the calendar year for the SATURDAY of that week.
yyyy is the calendar year as of that DAY.

To avoid confusion, better use yyyy instead.

Thank you for submitting a pull request! 

Please make sure you have signed our [Contributor License Agreement (CLA)][].  
We are not asking you to assign copyright to us, but to give us the right to distribute your code without restriction. We ask this of all contributors in order to assure our users of the origin and continuing existence of the code.  
You only need to sign the CLA once.

- [x] I have signed the [Contributor License Agreement (CLA)][]

[Contributor License Agreement (CLA)]: https://www.elastic.co/contributor-agreement/
