### PR TITLE
[#1097] normalize jars by inode

### DIFF
--- a/mr/src/itest/java/org/elasticsearch/hadoop/VersionTest.java
+++ b/mr/src/itest/java/org/elasticsearch/hadoop/VersionTest.java
@@ -23,6 +23,9 @@ import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import org.elasticsearch.hadoop.util.StringUtils;
 import org.junit.Test;
@@ -37,16 +40,18 @@ public class VersionTest {
         List<URL> urls = new ArrayList<URL>();
         urls.add(new URL("jar:file:/tmp/mesos/slaves/3014350f-cd05-44af-9c9c-3974bdeed86e-S1/frameworks/3014350f-cd05-44af-9c9c-3974bdeed86e-0016/executors/3014350f-cd05-44af-9c9c-3974bdeed86e-S1/runs/3697bc14-f0bd-48b9-8599-9683867eec63/elasticsearch-spark_2.10-2.2.0-m1.jar!/"));
         urls.add(new URL("jar:file:/tmp/mesos/slaves/3014350f-cd05-44af-9c9c-3974bdeed86e-S1/frameworks/3014350f-cd05-44af-9c9c-3974bdeed86e-0016/executors/3014350f-cd05-44af-9c9c-3974bdeed86e-S1/runs/3697bc14-f0bd-48b9-8599-9683867eec63/./elasticsearch-spark_2.10-2.2.0-m1.jar!/"));
-
-        Set<String> normalized = new LinkedHashSet<String>();
-
-        for (URL url : urls) {
-            // try normalization first
-            String norm = StringUtils.normalize(url.toString());
-            System.out.println(norm);
-            normalized.add(norm);
+        String originPath = url.get(0).toString();
+        File file = new File(originPath);
+        if (file.createNewFile()){
+          System.out.println("File is created!");
+        } else {
+          System.out.println("File already exists.");
         }
+        Path existingFilePath = Paths.get(originPath);
+        Path symLinkPath = Paths.get(System.getProperty("java.io.tmpdir") + File.separator + "elasticsearch-spark_2.10-2.2.0-m1.jar");
+        Files.createSymbolicLink(symLinkPath, existingFilePath);
 
+        Set<String> normalized = StringUtils.normalize(urls);
         System.out.println(normalized);
         assertEquals(1, normalized.size());
     }

--- a/mr/src/main/java/org/elasticsearch/hadoop/util/StringUtils.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/util/StringUtils.java
@@ -22,6 +22,8 @@ import org.codehaus.jackson.io.JsonStringEncoder;
 import org.elasticsearch.hadoop.EsHadoopIllegalStateException;
 import org.elasticsearch.hadoop.serialization.json.BackportedJsonStringEncoder;
 
+import java.io.File;
+import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -29,6 +31,8 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.LinkedHashSet;
+import java.util.Set;
 import java.util.StringTokenizer;
 
 
@@ -409,57 +413,13 @@ public abstract class StringUtils {
         return new IpAndPort(httpAddr);
     }
 
-    public static String normalize(String path) {
-        if (path == null) {
-            return null;
+    public static Set<String> normalize(List<URL> urls) throws IOException {
+        Set<String> normalized = new LinkedHashSet<String>();
+        for (URL url : urls) {
+            File file = new File(url.toString());
+            paths.add(file.getCanonicalPath());
         }
-        String pathToUse = path.replace("\\", SLASH);
-
-        int prefixIndex = pathToUse.indexOf(":");
-        String prefix = "";
-        if (prefixIndex != -1) {
-            prefix = pathToUse.substring(0, prefixIndex + 1);
-            if (prefix.contains(SLASH)) {
-                prefix = "";
-            }
-            else {
-                pathToUse = pathToUse.substring(prefixIndex + 1);
-            }
-        }
-        if (pathToUse.startsWith(SLASH)) {
-            prefix = prefix + SLASH;
-            pathToUse = pathToUse.substring(1);
-        }
-
-        List<String> pathList = tokenize(pathToUse, SLASH);
-        List<String> pathTokens = new LinkedList<String>();
-        int tops = 0;
-
-        for (int i = pathList.size() - 1; i >= 0; i--) {
-            String element = pathList.get(i);
-            if (PATH_CURRENT.equals(element)) {
-                // current folder, ignore it
-            }
-            else if (PATH_TOP.equals(element)) {
-                // top folder, skip previous element
-                tops++;
-            }
-            else {
-                if (tops > 0) {
-                    // should it be skipped?
-                    tops--;
-                }
-                else {
-                    pathTokens.add(0, element);
-                }
-            }
-        }
-
-        for (int i = 0; i < tops; i++) {
-            pathTokens.add(0, PATH_TOP);
-        }
-
-        return prefix + concatenate(pathTokens, SLASH);
+        return normalized;
     }
 
     public static String stripFieldNameSourcePrefix(String fieldName) {

--- a/mr/src/main/java/org/elasticsearch/hadoop/util/Version.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/util/Version.java
@@ -52,10 +52,12 @@ public abstract class Version {
 
         if (res != null) {
             List<URL> urls = Collections.list(res);
-            Set<String> normalized = new LinkedHashSet<String>();
-
-            for (URL url : urls) {
-                normalized.add(StringUtils.normalize(url.toString()));
+            try {
+                Set<String> normalized = StringUtils.normalize(urls);
+            } catch (IOException ex) {
+                StringBuilder sb = new StringBuilder("Fail to normalize urls of jars.");
+                LogFactory.getLog(Version.class).fatal(sb);
+                throw new Error(sb.toString());
             }
 
             int foundJars = 0;


### PR DESCRIPTION
Thank you for submitting a pull request! 

Please make sure you have signed our [Contributor License Agreement (CLA)][].  
We are not asking you to assign copyright to us, but to give us the right to distribute your code without restriction. We ask this of all contributors in order to assure our users of the origin and continuing existence of the code.  
You only need to sign the CLA once.

- [x] I have signed the [Contributor License Agreement (CLA)][]

[Contributor License Agreement (CLA)]: https://www.elastic.co/contributor-agreement/


Hello, I request this pull request to solve #1097 issue.
I tried to normalize duplicate jars by getting and comparing inodes of jars.
I think it is more reasonable to investigate the inodes of a jar than to just remove `.` or `..` in urls.