### PR TITLE
Add switchable findPartitions behavior.

### DIFF
--- a/docs/src/reference/asciidoc/core/configuration.adoc
+++ b/docs/src/reference/asciidoc/core/configuration.adoc
@@ -424,6 +424,10 @@ added[5.0.0]
 `es.input.max.docs.per.partition` (default 100000)::
 When reading from an {es} cluster that supports scroll slicing ({es} v5.0.0 and above), this parameter advises the connector on what the maximum number of documents per input partition should be. The connector will sample and estimate the number of documents on each shard to be read and divides each shard into input slices using the value supplied by this property. This property is ignored if you are reading from an {es} cluster that does not support scroll slicing ({es} any version below v5.0.0).
 
+added[6.2.2]
+`es.input.use.sliced.partitions` (default true)::
+By default, when this parameter is true, sliced partitions are used (standard behavior for {es} v5.0.0 and above). This can cause a significant slowdown in the pre-reading phase of the index. In some cases, the preparation time can be significantly longer than the time it takes to retrieve the data. This option allows you to disable this behavior and use shard partitions (as for {es} before 5.0.0).
+
 [float]
 ==== Network
 

--- a/mr/src/main/java/org/elasticsearch/hadoop/cfg/ConfigurationOptions.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/cfg/ConfigurationOptions.java
@@ -139,6 +139,9 @@ public interface ConfigurationOptions {
     String ES_INPUT_JSON = "es.input.json";
     String ES_INPUT_JSON_DEFAULT = "no";
 
+    String ES_INPUT_USE_SLICED_PARTITIONS = "es.input.use.sliced.partitions";
+    String ES_INPUT_USE_SLICED_PARTITIONS_DEFAULT = "true";
+
     /** Index settings */
     String ES_INDEX_AUTO_CREATE = "es.index.auto.create";
     String ES_INDEX_AUTO_CREATE_DEFAULT = "yes";
@@ -197,9 +200,6 @@ public interface ConfigurationOptions {
     /** Technology Specific **/
     String ES_SPARK_DATAFRAME_WRITE_NULL_VALUES = "es.spark.dataframe.write.null";
     String ES_SPARK_DATAFRAME_WRITE_NULL_VALUES_DEFAULT = "false";
-
-    String ES_SPARK_FIND_SLICE_PARTITIONS = "es.find.slice.partitions";
-    String ES_SPARK_FIND_SLICE_PARTITIONS_DEFAULT = "true";
 
     /** Read settings */
 

--- a/mr/src/main/java/org/elasticsearch/hadoop/cfg/ConfigurationOptions.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/cfg/ConfigurationOptions.java
@@ -198,6 +198,9 @@ public interface ConfigurationOptions {
     String ES_SPARK_DATAFRAME_WRITE_NULL_VALUES = "es.spark.dataframe.write.null";
     String ES_SPARK_DATAFRAME_WRITE_NULL_VALUES_DEFAULT = "false";
 
+    String ES_SPARK_FIND_SLICE_PARTITIONS = "es.find.slice.partitions";
+    String ES_SPARK_FIND_SLICE_PARTITIONS_DEFAULT = "true";
+
     /** Read settings */
 
     /** Field options **/

--- a/mr/src/main/java/org/elasticsearch/hadoop/cfg/Settings.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/cfg/Settings.java
@@ -579,6 +579,10 @@ public abstract class Settings {
         return Booleans.parseBoolean(getProperty(ES_SPARK_DATAFRAME_WRITE_NULL_VALUES, ES_SPARK_DATAFRAME_WRITE_NULL_VALUES_DEFAULT));
     }
 
+    public boolean getFindSlicePartitions() {
+        return Booleans.parseBoolean(getProperty(ES_SPARK_FIND_SLICE_PARTITIONS, ES_SPARK_FIND_SLICE_PARTITIONS_DEFAULT));
+    }
+
     public abstract InputStream loadResource(String location);
 
     public abstract Settings copy();

--- a/mr/src/main/java/org/elasticsearch/hadoop/cfg/Settings.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/cfg/Settings.java
@@ -579,8 +579,8 @@ public abstract class Settings {
         return Booleans.parseBoolean(getProperty(ES_SPARK_DATAFRAME_WRITE_NULL_VALUES, ES_SPARK_DATAFRAME_WRITE_NULL_VALUES_DEFAULT));
     }
 
-    public boolean getFindSlicePartitions() {
-        return Booleans.parseBoolean(getProperty(ES_SPARK_FIND_SLICE_PARTITIONS, ES_SPARK_FIND_SLICE_PARTITIONS_DEFAULT));
+    public boolean getInputUseSlicedPartitions() {
+        return Booleans.parseBoolean(getProperty(ES_INPUT_USE_SLICED_PARTITIONS, ES_INPUT_USE_SLICED_PARTITIONS_DEFAULT));
     }
 
     public abstract InputStream loadResource(String location);

--- a/mr/src/main/java/org/elasticsearch/hadoop/rest/RestService.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/rest/RestService.java
@@ -265,7 +265,7 @@ public abstract class RestService implements Serializable {
                 }
             }
             final List<PartitionDefinition> partitions;
-            if (version.onOrAfter(EsMajorVersion.V_5_X) && settings.getFindSlicePartitions()) {
+            if (version.onOrAfter(EsMajorVersion.V_5_X) && settings.getInputUseSlicedPartitions()) {
                 partitions = findSlicePartitions(client.getRestClient(), settings, mapping, nodesMap, shards, log);
             } else {
                 partitions = findShardPartitions(settings, mapping, nodesMap, shards, log);

--- a/mr/src/main/java/org/elasticsearch/hadoop/rest/RestService.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/rest/RestService.java
@@ -265,7 +265,7 @@ public abstract class RestService implements Serializable {
                 }
             }
             final List<PartitionDefinition> partitions;
-            if (version.onOrAfter(EsMajorVersion.V_5_X)) {
+            if (version.onOrAfter(EsMajorVersion.V_5_X) && settings.getFindSlicePartitions()) {
                 partitions = findSlicePartitions(client.getRestClient(), settings, mapping, nodesMap, shards, log);
             } else {
                 partitions = findShardPartitions(settings, mapping, nodesMap, shards, log);


### PR DESCRIPTION
For queries that process many indexes with many shards findSlicePartitions is the slowest.
There is a separate indexes for each day, every contains tens millions documents, i need to query six months for example.
findShardPartitions gets a lot more partitions, but it does not delay the execution.
Let, in my case, findShardPartitions will receive 18k partitions, but they will be processed in 10 minutes than I will wait until findSlicePartitions is performed in almost 2 hours.


- [x] I have signed the [Contributor License Agreement (CLA)][]
