### PR TITLE
Update spark.adoc for Windows

### DIFF
--- a/docs/src/reference/asciidoc/core/spark.adoc
+++ b/docs/src/reference/asciidoc/core/spark.adoc
@@ -221,7 +221,7 @@ new SparkContext(conf).makeRDD(Seq(json1, json2))
                       .saveJsonToEs("spark/json-trips") <2>
 ----
 
-<1> example of an entry within the +RDD+ - the JSON is _written_ as is, without any transformation
+<1> example of an entry within the +RDD+ - the JSON is _written_ as is, without any transformation, it should not contains breakline character like \n or \r\n
 <2> index the JSON data through the dedicated +saveJsonToEs+ method
 
 [float]
@@ -238,7 +238,7 @@ JavaRDD<String><2> stringRDD = jsc.parallelize(ImmutableList.of(json1, json2));
 JavaEsSpark.saveJsonToEs(stringRDD, "spark/json-trips");             <3>
 ----
 
-<1> example of an entry within the +RDD+ - the JSON is _written_ as is, without any transformation
+<1> example of an entry within the +RDD+ - the JSON is _written_ as is, without any transformation, it should not contains breakline character like \n or \r\n
 <2> notice the +RDD<String>+ signature
 <3> index the JSON data through the dedicated +saveJsonToEs+ method
 


### PR DESCRIPTION
When I try to insert JSON that contains breaklines (I was on a Windows env), resulting Mapping does not contains my fields, I only end up with the JSON content in the source field : 
{"_index":"spark","_type":"json-xxx","_id":"myId","_score":1.0,"_source":{"field1" : 1, "field2" : "2"}}

Thank you for submitting a pull request! 

Please make sure you have signed our [Contributor License Agreement (CLA)][].  
We are not asking you to assign copyright to us, but to give us the right to distribute your code without restriction. We ask this of all contributors in order to assure our users of the origin and continuing existence of the code.  
You only need to sign the CLA once.

- [x] I have signed the [Contributor License Agreement (CLA)][]

[Contributor License Agreement (CLA)]: https://www.elastic.co/contributor-agreement/
