### PR TITLE
add sparkSession conf

### DIFF
--- a/spark/sql-20/src/main/scala/org/elasticsearch/spark/sql/DefaultSource.scala
+++ b/spark/sql-20/src/main/scala/org/elasticsearch/spark/sql/DefaultSource.scala
@@ -215,7 +215,7 @@ private[sql] case class ElasticsearchRelation(parameters: Map[String, String], @
   extends BaseRelation with PrunedFilteredScan with InsertableRelation
   {
 
-  @transient lazy val cfg = { new SparkSettingsManager().load(sqlContext.sparkContext.getConf).merge(parameters.asJava) }
+  @transient lazy val cfg = { new SparkSettingsManager().load(sqlContext.sparkContext.getConf).merge(parameters.asJava).merge(sqlContext.sparkSession.conf.getAll.asJava) }
 
   @transient lazy val lazySchema = { SchemaUtils.discoverMapping(cfg) }
 
@@ -231,7 +231,7 @@ private[sql] case class ElasticsearchRelation(parameters: Map[String, String], @
 
   // PrunedFilteredScan
   def buildScan(requiredColumns: Array[String], filters: Array[Filter]) = {
-    val paramWithScan = LinkedHashMap[String, String]() ++ parameters
+    val paramWithScan = LinkedHashMap[String, String]() ++ parameters ++ sqlContext.sparkSession.conf.getAll
 
     var filteredColumns = requiredColumns
     

--- a/spark/sql-20/src/main/scala/org/elasticsearch/spark/sql/EsSparkSQL.scala
+++ b/spark/sql-20/src/main/scala/org/elasticsearch/spark/sql/EsSparkSQL.scala
@@ -51,7 +51,7 @@ object EsSparkSQL {
   def esDF(sc: SQLContext, resource: String, query: String): DataFrame = esDF(sc, Map(ES_RESOURCE_READ -> resource, ES_QUERY -> query))
   def esDF(sc: SQLContext, cfg: Map[String, String]): DataFrame = {
     val esConf = new SparkSettingsManager().load(sc.sparkContext.getConf).copy()
-    esConf.merge(cfg.asJava)
+    esConf.merge(cfg.asJava).merge(sc.sparkSession.conf.getAll.asJava)
 
     sc.read.format("org.elasticsearch.spark.sql").options(esConf.asProperties.asScala.toMap).load
   }

--- a/spark/sql-20/src/test/scala/org/elasticsearch/spark/sql/EsSparkSQLTest.scala
+++ b/spark/sql-20/src/test/scala/org/elasticsearch/spark/sql/EsSparkSQLTest.scala
@@ -1,0 +1,28 @@
+package org.elasticsearch.spark.sql
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.SparkSession
+import org.junit.Assert._
+import org.junit.Test
+
+class EsSparkSQLTest {
+
+  @Test
+  def parameters(): Unit = {
+    val sparkConf = new SparkConf().setAppName("session conf").setMaster("local[*]")
+    val session1 = SparkSession.builder().config(sparkConf).getOrCreate()
+    session1.conf.set("es.nodes", "127.0.0.1")
+    session1.conf.set("es.port", "9200")
+
+    val session2 = SparkSession.builder().config(sparkConf).getOrCreate()
+    session2.conf.set("es.nodes", "localhost")
+    session2.conf.set("es.port", "9201")
+
+    assertTrue(session1.conf.get("es.nodes").equals("127.0.0.1"))
+    assertTrue(session1.conf.get("es.port").equals("9200"))
+
+    assertTrue(session2.conf.get("es.nodes").equals("localhost"))
+    assertTrue(session2.conf.get("es.port").equals("9201"))
+
+  }
+}

--- a/spark/sql-20/src/test/scala/org/elasticsearch/spark/sql/SparkSessionTest.scala
+++ b/spark/sql-20/src/test/scala/org/elasticsearch/spark/sql/SparkSessionTest.scala
@@ -5,7 +5,7 @@ import org.apache.spark.sql.SparkSession
 import org.junit.Assert._
 import org.junit.Test
 
-class EsSparkSQLTest {
+class SparkSessionTest {
 
   @Test
   def parameters(): Unit = {
@@ -13,14 +13,12 @@ class EsSparkSQLTest {
     val session1 = SparkSession.builder().config(sparkConf).getOrCreate()
     session1.conf.set("es.nodes", "127.0.0.1")
     session1.conf.set("es.port", "9200")
+    assertTrue(session1.conf.get("es.nodes").equals("127.0.0.1"))
+    assertTrue(session1.conf.get("es.port").equals("9200"))
 
     val session2 = SparkSession.builder().config(sparkConf).getOrCreate()
     session2.conf.set("es.nodes", "localhost")
     session2.conf.set("es.port", "9201")
-
-    assertTrue(session1.conf.get("es.nodes").equals("127.0.0.1"))
-    assertTrue(session1.conf.get("es.port").equals("9200"))
-
     assertTrue(session2.conf.get("es.nodes").equals("localhost"))
     assertTrue(session2.conf.get("es.port").equals("9201"))
 


### PR DESCRIPTION
        val sparkConf = new SparkConf().setAppName("HiveToES").setMaster("local[*]")
        sparkConf.set("spark.sql.hive.metastorePartitionPruning", "false")
        sparkConf.set("es.index.auto.create", "true")
        val session1 = SparkSession.builder().config(sparkConf).getOrCreate()
        session1.sql("create table if not exists es_test using es OPTIONS (es.nodes 'localhost', es.port '9200',path 'hanbj')")
        val dataFrame = session1.sql("select * from es_test")
        dataFrame.show()

        val session2 = SparkSession.builder().config(sparkConf).getOrCreate()
        session2.conf.set("es.nodes", "localhost")
        session2.conf.set("es.port", "9201")
        val df = EsSparkSQL.esDF(session2, "ddposorderinfo")
        df.show()


In Spark2.x，SparkConf is a global configuration. Users can have multiple SparkSession and the configuration of each SparkSession can be different. This will be more flexible.