### PR TITLE
add EsInputSplit.toString method which can be used for debugging

### DIFF
--- a/mr/src/main/java/org/elasticsearch/hadoop/mr/EsInputFormat.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/mr/EsInputFormat.java
@@ -97,6 +97,13 @@ public class EsInputFormat<K, V> extends InputFormat<K, V> implements org.apache
         public PartitionDefinition getPartition() {
             return partition;
         }
+
+        @Override
+        public String toString() {
+            return "EsInputSplit{" +
+                    (partition == null ? "NULL" : partition.toString()) +
+                    "}";
+        }
     }
 
     protected static abstract class EsInputRecordReader<K,V> extends RecordReader<K, V> implements org.apache.hadoop.mapred.RecordReader<K, V> {


### PR DESCRIPTION
When we debug the mapreduce program, EsInputSplit's detail message will tell us what the map is doing.
