### PR TITLE
#1115 Added support to bulk error handling to generate exception stack

### DIFF
--- a/mr/src/main/java/org/elasticsearch/hadoop/rest/ErrorExtractor.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/rest/ErrorExtractor.java
@@ -27,9 +27,9 @@ public class ErrorExtractor {
     	EsHadoopException ex = null;
     	if(reason != null) {
     		if(type != null) {
-    			ex = new EsHadoopBulkException(type.toString(), reason.toString());
+    			ex = new EsHadoopRemoteException(type.toString(), reason.toString());
     		} else {
-    			ex = new EsHadoopBulkException(reason.toString());
+    			ex = new EsHadoopRemoteException(reason.toString());
     		}
     	}
     	if(causedBy != null) {
@@ -41,7 +41,7 @@ public class ErrorExtractor {
     	}
     	
     	if(ex == null) {
-    		ex = new EsHadoopBulkException(m.toString());
+    		ex = new EsHadoopRemoteException(m.toString());
     	}
     	
     	return ex;
@@ -68,20 +68,20 @@ public class ErrorExtractor {
                             	error = extractErrorWithCause(nestedM);
                             }
                             else {
-                                error = new EsHadoopBulkException(nested.toString());
+                                error = new EsHadoopRemoteException(nested.toString());
                             }
                         }
                         else {
-                        	error = new EsHadoopBulkException(nested.toString());
+                        	error = new EsHadoopRemoteException(nested.toString());
                         }
                     }
                     else {
-                    	error = new EsHadoopBulkException(err.toString());
+                    	error = new EsHadoopRemoteException(err.toString());
                     }
                 }
             }
             else {
-            	error = new EsHadoopBulkException(err.toString());
+            	error = new EsHadoopRemoteException(err.toString());
             }
         }
         return error;

--- a/mr/src/main/java/org/elasticsearch/hadoop/rest/ErrorExtractor.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/rest/ErrorExtractor.java
@@ -3,6 +3,7 @@ package org.elasticsearch.hadoop.rest;
 import java.util.List;
 import java.util.Map;
 
+import org.elasticsearch.hadoop.EsHadoopException;
 import org.elasticsearch.hadoop.util.ByteSequence;
 import org.elasticsearch.hadoop.util.EsMajorVersion;
 
@@ -16,25 +17,47 @@ public class ErrorExtractor {
     public ErrorExtractor(EsMajorVersion internalVersion) {
         this.internalVersion = internalVersion;
     }
+    
+    @SuppressWarnings("rawtypes")
+	public EsHadoopException extractErrorWithCause(Map m) {
+    	Object type = m.get("type");
+    	Object reason = m.get("reason");
+    	Object causedBy = m.get("caused_by");
+    	
+    	EsHadoopException ex = null;
+    	if(reason != null) {
+    		if(type != null) {
+    			ex = new EsHadoopBulkException(type.toString(), reason.toString());
+    		} else {
+    			ex = new EsHadoopBulkException(reason.toString());
+    		}
+    	}
+    	if(causedBy != null) {
+    		if(ex == null) {
+    			ex = extractErrorWithCause((Map)causedBy);
+    		} else {
+    			ex.initCause(extractErrorWithCause((Map)causedBy));
+    		}
+    	}
+    	
+    	if(ex == null) {
+    		ex = new EsHadoopBulkException(m.toString());
+    	}
+    	
+    	return ex;
+    }
 
-    public String extractError(Map jsonMap) {
+    @SuppressWarnings("rawtypes")
+	public EsHadoopException extractError(Map jsonMap) {
         Object err = jsonMap.get("error");
-        String error = "";
+        EsHadoopException error = null;
         if (err != null) {
             // part of ES 2.0
             if (err instanceof Map) {
                 Map m = ((Map) err);
                 err = m.get("root_cause");
                 if (err == null) {
-                    if (m.containsKey("reason")) {
-                        error = m.get("reason").toString();
-                    }
-                    else if (m.containsKey("caused_by")) {
-                        error += ";" + ((Map) m.get("caused_by")).get("reason");
-                    }
-                    else {
-                        error = m.toString();
-                    }
+                    error = extractErrorWithCause(m);
                 }
                 else {
                     if (err instanceof List) {
@@ -42,23 +65,23 @@ public class ErrorExtractor {
                         if (nested instanceof Map) {
                             Map nestedM = (Map) nested;
                             if (nestedM.containsKey("reason")) {
-                                error = nestedM.get("reason").toString();
+                            	error = extractErrorWithCause(nestedM);
                             }
                             else {
-                                error = nested.toString();
+                                error = new EsHadoopBulkException(nested.toString());
                             }
                         }
                         else {
-                            error = nested.toString();
+                        	error = new EsHadoopBulkException(nested.toString());
                         }
                     }
                     else {
-                        error = err.toString();
+                    	error = new EsHadoopBulkException(err.toString());
                     }
                 }
             }
             else {
-                error = err.toString();
+            	error = new EsHadoopBulkException(err.toString());
             }
         }
         return error;

--- a/mr/src/main/java/org/elasticsearch/hadoop/rest/EsHadoopBulkException.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/rest/EsHadoopBulkException.java
@@ -1,0 +1,44 @@
+package org.elasticsearch.hadoop.rest;
+
+import org.elasticsearch.hadoop.EsHadoopException;
+
+public class EsHadoopBulkException extends EsHadoopException {
+	private static final long serialVersionUID = 5402297229024034583L;
+	
+	private String type=null;
+	
+	public EsHadoopBulkException(String message) {
+		super(message);
+	}
+	public EsHadoopBulkException(String message, Throwable throwable) {
+		super(message, throwable);
+	}
+	public EsHadoopBulkException(String type, String message) {
+		super(message);
+		this.type = type;
+	}
+	public EsHadoopBulkException(String type, String message, Throwable throwable) {
+		super(message, throwable);
+		this.type = type;
+	}
+	
+	public String getType() {
+		return type;
+	}
+	
+	public String toString() {
+        String s = getClass().getName();
+        String message = getLocalizedMessage();
+        String type = this.getType();
+        
+        final StringBuilder b = new StringBuilder();
+        b.append(s);
+        if(type != null) {
+        	b.append(": ").append(type);
+        }
+        if(message != null) {
+        	b.append(": ").append(message);
+        }
+        return b.toString();
+    }
+}

--- a/mr/src/main/java/org/elasticsearch/hadoop/rest/EsHadoopRemoteException.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/rest/EsHadoopRemoteException.java
@@ -2,22 +2,22 @@ package org.elasticsearch.hadoop.rest;
 
 import org.elasticsearch.hadoop.EsHadoopException;
 
-public class EsHadoopBulkException extends EsHadoopException {
+public class EsHadoopRemoteException extends EsHadoopException {
 	private static final long serialVersionUID = 5402297229024034583L;
 	
 	private String type=null;
 	
-	public EsHadoopBulkException(String message) {
+	public EsHadoopRemoteException(String message) {
 		super(message);
 	}
-	public EsHadoopBulkException(String message, Throwable throwable) {
+	public EsHadoopRemoteException(String message, Throwable throwable) {
 		super(message, throwable);
 	}
-	public EsHadoopBulkException(String type, String message) {
+	public EsHadoopRemoteException(String type, String message) {
 		super(message);
 		this.type = type;
 	}
-	public EsHadoopBulkException(String type, String message, Throwable throwable) {
+	public EsHadoopRemoteException(String type, String message, Throwable throwable) {
 		super(message, throwable);
 		this.type = type;
 	}

--- a/mr/src/main/java/org/elasticsearch/hadoop/rest/RestClient.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/rest/RestClient.java
@@ -22,6 +22,7 @@ import org.codehaus.jackson.JsonParser;
 import org.codehaus.jackson.map.DeserializationConfig;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.codehaus.jackson.map.SerializationConfig;
+import org.elasticsearch.hadoop.EsHadoopException;
 import org.elasticsearch.hadoop.EsHadoopIllegalStateException;
 import org.elasticsearch.hadoop.cfg.ConfigurationOptions;
 import org.elasticsearch.hadoop.cfg.Settings;
@@ -401,10 +402,11 @@ public class RestClient implements Closeable, StatsAware {
     private void checkResponse(Request request, Response response) {
         if (response.hasFailed()) {
             // check error first
-            String msg = null;
+        	String msg = null;
             // try to parse the answer
             try {
-                msg = errorExtractor.extractError(this.<Map> parseContent(response.body(), null));
+            	EsHadoopException ex = errorExtractor.extractError(this.<Map> parseContent(response.body(), null));
+                msg = (ex != null) ? ex.toString() : null;
                 if (response.isClientError()) {
                     msg = msg + "\n" + request.body();
                 }

--- a/mr/src/main/java/org/elasticsearch/hadoop/rest/bulk/BulkProcessor.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/rest/bulk/BulkProcessor.java
@@ -16,7 +16,7 @@ import org.elasticsearch.hadoop.cfg.Settings;
 import org.elasticsearch.hadoop.handler.EsHadoopAbortHandlerException;
 import org.elasticsearch.hadoop.handler.HandlerResult;
 import org.elasticsearch.hadoop.rest.ErrorExtractor;
-import org.elasticsearch.hadoop.rest.EsHadoopBulkException;
+import org.elasticsearch.hadoop.rest.EsHadoopRemoteException;
 import org.elasticsearch.hadoop.rest.Resource;
 import org.elasticsearch.hadoop.rest.RestClient;
 import org.elasticsearch.hadoop.rest.bulk.handler.BulkWriteErrorCollector;
@@ -472,6 +472,9 @@ public class BulkProcessor implements Closeable, StatsAware {
                 message.append("\t");
                 appendError(message, errors.getError());
                 message.append("\n");
+                message.append("\t")
+                	.append(errors.getDocument().toString())
+                	.append("\n");
                 i++;
             }
             message.append("Bailing out...");

--- a/mr/src/main/java/org/elasticsearch/hadoop/rest/bulk/BulkProcessor.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/rest/bulk/BulkProcessor.java
@@ -16,6 +16,7 @@ import org.elasticsearch.hadoop.cfg.Settings;
 import org.elasticsearch.hadoop.handler.EsHadoopAbortHandlerException;
 import org.elasticsearch.hadoop.handler.HandlerResult;
 import org.elasticsearch.hadoop.rest.ErrorExtractor;
+import org.elasticsearch.hadoop.rest.EsHadoopBulkException;
 import org.elasticsearch.hadoop.rest.Resource;
 import org.elasticsearch.hadoop.rest.RestClient;
 import org.elasticsearch.hadoop.rest.bulk.handler.BulkWriteErrorCollector;
@@ -229,9 +230,9 @@ public class BulkProcessor implements Closeable, StatsAware {
                             // Get the underlying document information as a map and extract the error information.
                             Map values = (Map) map.values().iterator().next();
                             Integer docStatus = (Integer) values.get("status");
-                            String error = errorExtractor.extractError(values);
+                            EsHadoopException error = errorExtractor.extractError(values);
 
-                            if (error == null || error.isEmpty()){
+                            if (error == null){
                                 // Write operation for this entry succeeded
                                 stats.bytesAccepted += data.length(trackingBytesPosition);
                                 stats.docsAccepted += 1;
@@ -260,7 +261,7 @@ public class BulkProcessor implements Closeable, StatsAware {
                                 List<String> bulkErrorPassReasons = new ArrayList<String>();
                                 BulkWriteFailure failure = new BulkWriteFailure(
                                         status,
-                                        new Exception(error),
+                                        error,
                                         document,
                                         previousAttempt.attemptNumber,
                                         bulkErrorPassReasons
@@ -279,7 +280,7 @@ public class BulkProcessor implements Closeable, StatsAware {
                                             LOG.error("Bulk write error handler abort exception caught with underlying cause:", cause);
                                         }
                                         result = HandlerResult.ABORT;
-                                        error = ahe.getMessage();
+                                        error = ahe;
                                     } catch (Exception e) {
                                         throw new EsHadoopException("Encountered exception during error handler.", e);
                                     }
@@ -468,12 +469,24 @@ public class BulkProcessor implements Closeable, StatsAware {
                 if (i >=maxErrors ) {
                     break;
                 }
-                message.append("\t").append(errors.getErrorMessage()).append("\n");
+                message.append("\t");
+                appendError(message, errors.getError());
+                message.append("\n");
                 i++;
             }
             message.append("Bailing out...");
             throw new EsHadoopException(message.toString());
         }
+    }
+    
+    private void appendError(StringBuilder message, Throwable exception) {
+    	if(exception != null) {
+    		message.append(exception);
+    		if(exception.getCause() != null) {
+    			message.append(';');
+    			appendError(message, exception.getCause());
+    		}
+    	}
     }
 
 

--- a/mr/src/main/java/org/elasticsearch/hadoop/rest/bulk/BulkResponse.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/rest/bulk/BulkResponse.java
@@ -22,6 +22,7 @@ package org.elasticsearch.hadoop.rest.bulk;
 import java.util.Collections;
 import java.util.List;
 
+import org.elasticsearch.hadoop.EsHadoopException;
 import org.elasticsearch.hadoop.rest.HttpStatus;
 import org.elasticsearch.hadoop.util.BytesArray;
 
@@ -60,13 +61,13 @@ public class BulkResponse {
         private final int originalPosition;
         private final BytesArray document;
         private final int documentStatus;
-        private final String errorMessage;
+        private final EsHadoopException error;
 
-        public BulkError(int originalPosition, BytesArray document, int documentStatus, String errorMessage) {
+        public BulkError(int originalPosition, BytesArray document, int documentStatus, EsHadoopException error) {
             this.originalPosition = originalPosition;
             this.document = document;
             this.documentStatus = documentStatus;
-            this.errorMessage = errorMessage;
+            this.error = error;
         }
 
         /**
@@ -87,8 +88,8 @@ public class BulkResponse {
             return documentStatus;
         }
 
-        public String getErrorMessage() {
-            return errorMessage;
+        public EsHadoopException getError() {
+            return error;
         }
     }
 

--- a/mr/src/test/java/org/elasticsearch/hadoop/rest/ErrorExtractorTest.java
+++ b/mr/src/test/java/org/elasticsearch/hadoop/rest/ErrorExtractorTest.java
@@ -1,0 +1,104 @@
+package org.elasticsearch.hadoop.rest;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Map;
+
+import org.elasticsearch.hadoop.EsHadoopException;
+import org.elasticsearch.hadoop.util.EsMajorVersion;
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableMap;
+
+public class ErrorExtractorTest {
+	@Test
+	public void extractErrorWithCause() {
+		final Map<String, String> nestedCause = ImmutableMap.<String, String>builder()
+				.put("type", "illegal_argument_exception")
+				.put("reason", "Failed to parse value [not_analyzed] as only [true] or [false] are allowed.")
+				.build();
+		final Map<String, Object> cause = ImmutableMap.<String, Object>builder()
+				.put("type", "illegal_argument_exception")
+				.put("reason", "Could not convert [version.index] to boolean")
+				.put("caused_by", nestedCause)
+				.build();
+		
+		final ErrorExtractor extractor = new ErrorExtractor(EsMajorVersion.V_5_X);
+		
+		final EsHadoopException ex = extractor.extractErrorWithCause(cause);
+		checkException(ex, cause);
+		
+	}
+	@Test
+	public void extractErrorV5() {
+		final Map<String, String> nestedCause = ImmutableMap.<String, String>builder()
+				.put("type", "illegal_argument_exception")
+				.put("reason", "Failed to parse value [not_analyzed] as only [true] or [false] are allowed.")
+				.build();
+		final Map<String, Object> cause = ImmutableMap.<String, Object>builder()
+				.put("type", "illegal_argument_exception")
+				.put("reason", "Could not convert [version.index] to boolean")
+				.put("caused_by", nestedCause)
+				.build();
+		
+		final Map<String, Object> error = ImmutableMap.<String, Object>builder()
+				.put("error", cause)
+				.build();
+		
+		final ErrorExtractor extractor = new ErrorExtractor(EsMajorVersion.V_5_X);
+		
+		final EsHadoopException ex = extractor.extractError(error);
+		checkException(ex, cause);
+		
+	}
+	@Test
+	public void extractErrorV2() {
+		final Map<String, Object> cause = ImmutableMap.<String, Object>builder()
+				.put("type", "illegal_argument_exception")
+				.put("reason", "Could not convert [version.index] to boolean")
+				.build();
+		
+		final Map<String, Object> error = ImmutableMap.<String, Object>builder()
+				.put("error", cause)
+				.build();
+		
+		final ErrorExtractor extractor = new ErrorExtractor(EsMajorVersion.V_2_X);
+		
+		final EsHadoopException ex = extractor.extractError(error);
+		checkException(ex, cause);
+		
+	}
+	@Test
+	public void extractErrorV1() {
+		final Map<String, Object> error = ImmutableMap.<String, Object>builder()
+				.put("error", "UnKnown Issue")
+				.build();
+		
+		final ErrorExtractor extractor = new ErrorExtractor(EsMajorVersion.V_1_X);
+		
+		final EsHadoopException ex = extractor.extractError(error);
+		
+		assertNotNull(ex);
+		assertTrue(EsHadoopRemoteException.class.isAssignableFrom(ex.getClass()));
+		assertEquals(error.get("error"), ex.getMessage());
+		
+	}
+	
+	@SuppressWarnings("unchecked")
+	protected void checkException(Throwable ex, Map<String, ?> json) {
+		assertNotNull(ex);
+		assertTrue(EsHadoopRemoteException.class.isAssignableFrom(ex.getClass()));
+		
+		final EsHadoopRemoteException exRemote = (EsHadoopRemoteException)ex;
+		
+		assertEquals(json.get("type"), exRemote.getType());
+		assertEquals(json.get("reason"), exRemote.getMessage());
+		
+		if(json.containsKey("caused_by")) {
+			assertNotNull(exRemote.getCause());
+			checkException(exRemote.getCause(), (Map<String, ?>) json.get("caused_by"));
+		}
+	}
+}

--- a/mr/src/test/java/org/elasticsearch/hadoop/rest/bulk/BulkProcessorTest.java
+++ b/mr/src/test/java/org/elasticsearch/hadoop/rest/bulk/BulkProcessorTest.java
@@ -284,7 +284,7 @@ public class BulkProcessorTest {
         assertEquals(4, bulkResponse.getDocsSent());
         assertEquals(0, bulkResponse.getDocsSkipped());
         assertEquals(1, bulkResponse.getDocsAborted());
-        assertEquals("This data is bogus", bulkResponse.getDocumentErrors().get(0).getErrorMessage());
+        assertEquals("This data is bogus", bulkResponse.getDocumentErrors().get(0).getError().getMessage());
 
         processor.close();
         Stats stats = processor.stats();
@@ -316,7 +316,7 @@ public class BulkProcessorTest {
         assertEquals(4, bulkResponse.getDocsSent());
         assertEquals(0, bulkResponse.getDocsSkipped());
         assertEquals(1, bulkResponse.getDocsAborted());
-        assertEquals("This data is bogus", bulkResponse.getDocumentErrors().get(0).getErrorMessage());
+        assertEquals("This data is bogus", bulkResponse.getDocumentErrors().get(0).getError().getMessage());
 
         processor.close();
         Stats stats = processor.stats();
@@ -717,7 +717,7 @@ public class BulkProcessorTest {
         assertEquals(4, bulkResponse.getDocsSent());
         assertEquals(0, bulkResponse.getDocsSkipped());
         assertEquals(1, bulkResponse.getDocsAborted());
-        assertEquals("Abort the handler!!", bulkResponse.getDocumentErrors().get(0).getErrorMessage());
+        assertEquals("Abort the handler!!", bulkResponse.getDocumentErrors().get(0).getError().getMessage());
 
         processor.close();
         Stats stats = processor.stats();


### PR DESCRIPTION
#1115 Added support to bulk error handling to generate exception stack for caused_by trees. Improved reporting of errors in BulkProcessor to include type and stack of messages.

Thank you for submitting a pull request! 

Please make sure you have signed our [Contributor License Agreement (CLA)][].  
We are not asking you to assign copyright to us, but to give us the right to distribute your code without restriction. We ask this of all contributors in order to assure our users of the origin and continuing existence of the code.  
You only need to sign the CLA once.

- [x] I have signed the [Contributor License Agreement (CLA)][]

[Contributor License Agreement (CLA)]: https://www.elastic.co/contributor-agreement/
