### PR TITLE
Add serialization error handler API

### DIFF
--- a/docs/src/reference/asciidoc/core/errorhandlers.adoc
+++ b/docs/src/reference/asciidoc/core/errorhandlers.adoc
@@ -55,6 +55,7 @@ index mapping, or conflict with the current version of the document.
 - HTTP status code for the document
 - Number of times that the current document has been sent to {es}
 
+There are a few default error handlers provided by the connector:
 
 [[errorhandlers-bulk-http]]
 [float]
@@ -346,6 +347,275 @@ You now have a chain of handlers that retries bulk rejections by default (HTTP R
 any errors that are conflicts (our own ignore conflicts handler), then ignores any other errors by writing them out to
 a file (our own output to file handler).
 
+[[errorhandlers-serialization]]
+=== Serialization Error Handlers
+
+Before sending data to Elasticsearch, {eh} must serialize each document into a JSON bulk entry. It is during this
+process that the bulk operation is determined, document metadata is extracted, and integration specific data structures
+are converted into JSON documents. During this process, inconsistencies with record structure can cause exceptions to be
+thrown during the serialization process. These errors often lead to failed tasks and halted processing.
+
+{ehtm} provides an API to handle serialization errors at the record level. Error handlers for serialization are given:
+
+- The integration specific data structure that was unable to be serialized
+- Exception encountered during serialization
+
+NOTE: Serialization Error Handlers are not yet available for Hive. {ehtm} uses Hive's SerDe constructs to convert data into
+bulk entries before being sent to the output format. SerDe objects do not have a cleanup method that is called when the
+object ends its lifecycle. Because of this, we do not support serialization error handlers in Hive as they cannot be
+closed at the end of the job execution.
+
+There are a few default error handlers provided by the connector:
+
+[[errorhandlers-serialization-log]]
+[float]
+==== Drop and Log Error Handler
+Default Handler Name: `log`
+
+When this handler is invoked it logs a message containing the data structure's toString() contents that failed, the
+error message, and any previous handler messages. After logging this message, the handler signals that the error has
+been acknowledged, thus consuming/ignoring it.
+
+Available configurations for this handler:
+
+`es.write.data.error.handler.log.logger.name` (required)::
+The string name to use when creating the logger instance to log the errors. This setting is required if this handler is used.
+
+`es.write.data.error.handler.log.logger.class` (alternative to logger.name)::
+The class name to use when creating the logger instance to log the errors. This setting can be used instead of the
+required setting `es.write.data.error.handler.log.logger.name`.
+
+`es.write.data.error.handler.log.logger.level` (default: WARN)::
+The logger level to use when logging the error message. Available options are `FATAL`, `ERROR`, `WARN`, `INFO`, `DEBUG`, and `TRACE`.
+
+
+[[errorhandlers-serialization-fail]]
+[float]
+==== Abort on Failure Error Handler
+Default Handler Name: `fail`
+
+When this handler is called it rethrows the error given to it and aborts. This handler is always loaded and automatically
+placed at the end of the list of error handlers.
+
+There are no configurations for this handler.
+
+
+[[errorhandlers-serialization-use]]
+[float]
+=== Using Serialization Error Handlers
+
+To configure serialization error handlers, you must specify the handlers in order with the following properties.
+
+Setting `es.write.data.error.handlers`::
+Lists the names of the error handlers to use for serialization error handling, and the order that they should be called on.
+Each default handler can be referenced by their handler name as the connector knows how to load them. Any handlers
+provided from users or third party code will need to have their handler names defined with the `es.write.data.error.handler.`
+prefix.
+
+For serialization failures, the Abort on Failure built-in handler is always placed as the last error handler to catch
+any unhandled errors. This error handler forms the default serialization error handling behavior for {eh}, which
+matches the behavior from previous versions.
+
+1. Any configured user handlers will go here.
+2. Abort on Failure Built-In Handler: Rethrows the any errors it encounters
+
+This behavior is modified by inserting handlers into the chain by using the handlers property. Let's say that we want
+to log ALL errors and ignore them.
+
+[source,ini]
+----
+es.write.data.error.handlers = log <1>
+----
+<1> Specifying the default Drop and Log handler
+
+With the above configuration, the handler list now looks like the following:
+
+1. Drop and Log Handler
+2. Abort on Failure Handler
+
+As described above, the built-in `log` error handler has a required setting: What to use for the logger name. The logger
+used will respect whatever logging configuration you have in place, and thus needs a name for the logger to use:
+
+[source,ini]
+----
+es.write.data.error.handlers = log <1>
+es.write.data.error.handler.log.logger.name = SerializationErrors <2>
+----
+<1> Specifying the default Drop and Log built-in handler
+<2> The Drop and Log built-in handler will log all errors to the `SerializationErrors` logger
+
+At this point, the Abort on Failure built-in handler is effectively ignored since the Drop and Log built-in handler will
+always mark an error as consumed. This practice can prove to be hazardous, as potentially important errors may simply be
+ignored. In many cases, it is preferable for users to write their own error handler to handle expected exceptions.
+
+[[errorhandlers-serialization-user-handlers]]
+[float]
+==== Writing Your Own Serialization Handlers
+
+Let's say that you are streaming some unstructured data to {es}. In this scenario, your data is not fully sanitized and
+may contain field values that cannot be translated to JSON by the connector. You may not want to have your streaming job
+fail on this data, as you are potentially expecting it to contain errors. In this situation, you may want to log the
+data in a more comprehensive manner than to rely on the logging solution's toString() method for your data.
+
+Let's write an error handler for this situation:
+
+[source, java]
+----
+package org.myproject.myhandlers;
+
+import org.elasticsearch.hadoop.handler.HandlerResult;
+import org.elasticsearch.hadoop.handler.ErrorCollector;
+import org.elasticsearch.hadoop.serialization.handler.write.SerializationErrorHandler;
+import org.elasticsearch.hadoop.serialization.handler.write.SerializationFailure;
+
+public class CustomLogOnError extends SerializationErrorHandler {      <1>
+
+    private Log logger = ???; <2>
+
+    @Override
+    public HandlerResult onError(SerializationFailure entry, ErrorCollector<Object> collector) throws Exception {  <3>
+        MyRecord record = (MyRecord) entry.getRecord();                             <4>
+        logger.error("Could not serialize record. " +
+                "Record data : " + record.getSpecificField() + ", " + record.getOtherField(), entry.getException()); <5>
+        return HandlerResult.HANDLED;                                               <6>
+    }
+}
+----
+<1> We create a class and extend the SerializationErrorHandler base class
+<2> Create a logger using preferred logging solution
+<3> Override the `onError` method which will be invoked with the error details
+<4> Retrieve the record that failed to be serialized. Cast it to the record type you are expecting from your job
+<5> Log the specific information from the data you are interested in
+<6> Finally after logging the error, return `HandlerResult.HANDLED` to signal that the error is acknowledged
+
+Before we can place this handler in the list of serialization error handlers, we must register the handler class with a
+name in the settings using `es.write.data.error.handler.[HANDLER-NAME]`:
+
+Setting `es.write.data.error.handler.[HANDLER-NAME]`::
+Create a new handler named HANDLER-NAME. The value of this property must be the binary name of the class to
+instantiate for this handler.
+
+In this case, lets register a handler name for our ignore conflicts handler:
+
+[source,ini]
+----
+es.write.data.error.handler.customLog = org.myproject.myhandlers.CustomLogOnError
+----
+
+Now that we have a name for the handler, we can use it in the handler list:
+
+[source,ini]
+----
+es.write.data.error.handlers = customLog
+es.write.data.error.handler.customLog = org.myproject.myhandlers.CustomLogOnError
+----
+
+Now, your custom logging error handler will be invoked whenever a serialization failure occurs, and will instruct the
+connector that it is ok with ignoring those failures to continue processing.
+
+[[errorhandlers-serialization-advanced]]
+[float]
+==== Advanced Concepts
+
+Instead of logging data and dropping it, what if you wanted to persist it somewhere for safe keeping? What if
+we wanted to pass properties into our handlers to parameterize their behavior? Lets create a handler that stores error
+information in a local file for later analysis.
+
+[source, java]
+----
+package org.myproject.myhandlers;
+
+import ...
+
+import org.elasticsearch.hadoop.handler.HandlerResult;
+import org.elasticsearch.hadoop.handler.ErrorCollector;
+import org.elasticsearch.hadoop.serialization.handler.write.SerializationErrorHandler;
+import org.elasticsearch.hadoop.serialization.handler.write.SerializationFailure;
+
+public class OutputToFileHandler extends SerializationErrorHandler { <1>
+
+    private OutputStream outputStream;   <2>
+    private BufferedWriter writer;
+
+    @Override
+    public void init(Properties properties) {   <3>
+        try {
+            outputStream = new FileOutputStream(properties.getProperty("filename"));   <4>
+            writer = new BufferedWriter(new OutputStreamWriter(outputStream));
+        } catch (FileNotFoundException e) {
+            throw new RuntimeException("Could not open file", e);
+        }
+    }
+
+    @Override
+    public HandlerResult onError(SerializationFailure entry, ErrorCollector<Object> collector)   <5>
+    throws Exception
+    {
+        writer.write("Record: " + entry.getRecord().toString());
+        writer.newLine();
+        writer.write("Error: " + entry.getException().getMessage());
+        writer.newLine();
+        for (String message : entry.previousHandlerMessages()) {
+            writer.write("Previous Handler: " + message);           <6>
+            writer.newLine();
+        }
+
+        return HandlerResult.PASS; <7>
+    }
+
+    @Override
+    public void close() {   <8>
+        try {
+            writer.close();
+            outputStream.close();
+        } catch (IOException e) {
+            throw new RuntimeException("Closing file failed", e);
+        }
+    }
+}
+----
+<1> Extend the SerializationErrorHandler base class
+<2> Some local state for writing data out to a file
+<3> We override the `init` method. Any properties for this handler are passed in here.
+<4> We are extracting the file to write to from the properties. We'll see how to set this property below.
+<5> Overriding the `onError` method to define our behavior.
+<6> Write out the error information. This highlights all the available data provided by the `SerializationFailure` object.
+<7> Return the `PASS` result to signal that the error should be handed off to the next error handler in the chain.
+<8> Finally, close out any internally allocated resources.
+
+Added to this handler are the `init` and `close` methods. The `init` method is called when the handler is first created
+at the start of the task and the `close` method is called when the task concludes. The `init` method accepts a properties
+parameter, which contains any handler specific properties set by using `es.write.data.error.handler.[HANDLER-NAME].[PROPERTY-NAME]`.
+
+Setting `es.write.data.error.handler.[HANDLER-NAME].[PROPERTY-NAME]`::
+Used to pass properties into handlers. HANDLER-NAME is the handler to be configured, and PROPERTY-NAME is the property
+to set for the handler.
+
+In our use case, we will configure the our file logging error handler like so:
+
+[source,ini]
+----
+es.write.data.error.handler.writeFile = org.myproject.myhandlers.OutputToFileHandler   <1>
+es.write.data.error.handler.writeFile.filename = /path/to/some/output/file <2>
+----
+<1> We register our new handler with the name `writeFile`
+<2> Now we set a property named `filename` for the `writeFile` handler. In the `init` method of the handler, this can be picked up by using `filename` as the property key.
+
+Now to bring it all together:
+
+[source,ini]
+----
+es.write.data.error.handlers = writeFile,customLog
+
+es.write.data.error.handler.customLog = org.myproject.myhandlers.CustomLogOnError
+
+es.write.data.error.handler.writeFile = org.myproject.myhandlers.OutputToFileHandler
+es.write.data.error.handler.writeFile.filename = /path/to/some/output/file
+----
+
+You now have a chain of handlers that writes all relevant data about the failure to a file (our writeFile handler), then
+logs the errors using a custom log line and ignores the error to continue processing (our customLog handler).
+
 [[errorhandlers-read-json]]
 === Deserialization Error Handlers
 
@@ -368,6 +638,8 @@ responses. It may be possible that a search result can be successfully read, but
 exception when it is used in a completely different part of the framework. This Error Handler is called from the top of
 the most reasonable place to handle exceptions in the scroll reading process, but this does not encapsulate all logic
 for each integration.
+
+There are a few default error handlers provided by the connector:
 
 [[errorhandlers-read-json-log]]
 [float]

--- a/hive/src/main/java/org/elasticsearch/hadoop/hive/EsSerDe.java
+++ b/hive/src/main/java/org/elasticsearch/hadoop/hive/EsSerDe.java
@@ -160,6 +160,8 @@ public class EsSerDe extends AbstractSerDe {
         hiveType.setObjectInspector(objInspector);
         hiveType.setObject(data);
 
+        // We use the command directly instead of the bulk entry writer since there is no close() method on SerDes.
+        // See FileSinkOperator#process() for more info of how this is used with the output format.
         command.write(hiveType).copyTo(scratchPad);
         result.setContent(scratchPad);
         return result;

--- a/mr/src/main/java/org/elasticsearch/hadoop/serialization/bulk/BulkEntryWriter.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/serialization/bulk/BulkEntryWriter.java
@@ -1,0 +1,155 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.hadoop.serialization.bulk;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.elasticsearch.hadoop.EsHadoopException;
+import org.elasticsearch.hadoop.cfg.Settings;
+import org.elasticsearch.hadoop.handler.EsHadoopAbortHandlerException;
+import org.elasticsearch.hadoop.handler.HandlerResult;
+import org.elasticsearch.hadoop.serialization.EsHadoopSerializationException;
+import org.elasticsearch.hadoop.serialization.handler.SerdeErrorCollector;
+import org.elasticsearch.hadoop.serialization.handler.write.SerializationErrorHandler;
+import org.elasticsearch.hadoop.serialization.handler.write.SerializationFailure;
+import org.elasticsearch.hadoop.serialization.handler.write.SerializationHandlerLoader;
+import org.elasticsearch.hadoop.util.Assert;
+import org.elasticsearch.hadoop.util.BytesRef;
+
+/**
+ * Manages the creation of bulk entries for use in a bulk request. Encapsulates all serialization error handling
+ * logic. Must be closed at conclusion of the process.
+ */
+public class BulkEntryWriter {
+
+    private static final Log LOG = LogFactory.getLog(BulkEntryWriter.class);
+
+    private final BulkCommand bulkCommand;
+    private final List<SerializationErrorHandler> serializationErrorHandlers;
+
+    public BulkEntryWriter(Settings settings, BulkCommand bulkCommand) {
+        this.bulkCommand = bulkCommand;
+
+        SerializationHandlerLoader loader = new SerializationHandlerLoader();
+        loader.setSettings(settings);
+
+        this.serializationErrorHandlers = loader.loadHandlers();
+    }
+
+    public BytesRef writeBulkEntry(Object object) {
+        Object toRead = object;
+        BytesRef writeResult = null;
+        boolean retryWrite = false;
+        boolean skip = false;
+        int attempts = 0;
+        do {
+            try {
+                retryWrite = false;
+                writeResult = bulkCommand.write(toRead);
+            } catch (Exception serializationException) {
+                // Create error event
+                List<String> passReasons = new ArrayList<String>();
+                SerializationFailure entry = new SerializationFailure(serializationException, object, passReasons);
+
+                // Set up error collector
+                SerdeErrorCollector<Object> errorCollector = new SerdeErrorCollector<Object>();
+
+                // Attempmt failure handling
+                Exception abortException = serializationException;
+                handlerloop:
+                for (SerializationErrorHandler serializationErrorHandler : serializationErrorHandlers) {
+                    HandlerResult result;
+                    try {
+                        result = serializationErrorHandler.onError(entry, errorCollector);
+                    } catch (EsHadoopAbortHandlerException ahe) {
+                        // Count this as an abort operation. Wrap cause in a serialization exception.
+                        result = HandlerResult.ABORT;
+                        abortException = new EsHadoopSerializationException(ahe.getMessage(), ahe.getCause());
+                    } catch (Exception e) {
+                        LOG.error("Could not handle serialization error event due to an exception in error handler. " +
+                                "Serialization exception:", serializationException);
+                        throw new EsHadoopException("Encountered unexpected exception during error handler execution.", e);
+                    }
+
+                    switch (result) {
+                        case HANDLED:
+                            Assert.isTrue(errorCollector.getAndClearMessage() == null,
+                                    "Found pass message with Handled response. Be sure to return the value returned from " +
+                                            "the pass(String) call.");
+                            // Check for retries
+                            if (errorCollector.receivedRetries()) {
+                                Object retryObject = errorCollector.getAndClearRetryValue();
+                                if (retryObject != null) {
+                                    // Use new retry object to read
+                                    toRead = retryObject;
+                                }
+                                // If null, retry same object.
+
+                                // Limit the number of retries though to like 50
+                                if (attempts >= 50) {
+                                    throw new EsHadoopException("Maximum retry attempts (50) reached for serialization errors.");
+                                } else {
+                                    retryWrite = true;
+                                    attempts++;
+                                }
+                            } else {
+                                if (LOG.isDebugEnabled()) {
+                                    LOG.debug("Skipping a record that resulted in error while reading: [" +
+                                            object.toString() + "]");
+                                } else {
+                                    LOG.info("Skipping a record that resulted in error while reading. (DEBUG for more info).");
+                                }
+                                skip = true;
+                            }
+                            break handlerloop;
+                        case PASS:
+                            String reason = errorCollector.getAndClearMessage();
+                            if (reason != null) {
+                                passReasons.add(reason);
+                            }
+                            continue handlerloop;
+                        case ABORT:
+                            errorCollector.getAndClearMessage(); // Sanity clearing
+                            if (abortException instanceof EsHadoopSerializationException) {
+                                throw (EsHadoopSerializationException) abortException;
+                            } else {
+                                throw new EsHadoopSerializationException(abortException);
+                            }
+                    }
+                }
+            }
+        } while (retryWrite);
+
+        if (writeResult == null && skip == false) {
+            throw new EsHadoopSerializationException("Could not write record to bulk request.");
+        }
+
+        return writeResult;
+    }
+
+    public void close() {
+        for (SerializationErrorHandler errorHandler : serializationErrorHandlers) {
+            errorHandler.close();
+        }
+    }
+}

--- a/mr/src/main/java/org/elasticsearch/hadoop/serialization/handler/write/SerializationAbortOnFailure.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/serialization/handler/write/SerializationAbortOnFailure.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.hadoop.serialization.handler.write;
+
+import org.elasticsearch.hadoop.handler.ErrorCollector;
+import org.elasticsearch.hadoop.handler.HandlerResult;
+
+public class SerializationAbortOnFailure extends SerializationErrorHandler {
+    @Override
+    public HandlerResult onError(SerializationFailure entry, ErrorCollector<Object> collector) throws Exception {
+        return HandlerResult.ABORT;
+    }
+}

--- a/mr/src/main/java/org/elasticsearch/hadoop/serialization/handler/write/SerializationDropAndLog.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/serialization/handler/write/SerializationDropAndLog.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.hadoop.serialization.handler.write;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.elasticsearch.hadoop.EsHadoopIllegalArgumentException;
+import org.elasticsearch.hadoop.handler.ErrorCollector;
+import org.elasticsearch.hadoop.handler.HandlerResult;
+
+public class SerializationDropAndLog extends SerializationErrorHandler {
+    public static final String CONF_LOGGER_NAME = "logger.name";
+    public static final String CONF_LOGGER_CLASS = "logger.class";
+    public static final String CONF_LOGGER_LEVEL = "logger.level";
+
+    private enum LogLevel {
+        FATAL,
+        ERROR,
+        WARN,
+        INFO,
+        DEBUG,
+        TRACE;
+
+        private static Set<String> names = new LinkedHashSet<String>();
+        static {
+            for (LogLevel logLevel : values()) {
+                names.add(logLevel.name());
+            }
+        }
+    }
+
+    private Log logger;
+    private LogLevel loggerLevel;
+
+    @Override
+    public void init(Properties properties) {
+        String loggerName = properties.getProperty(CONF_LOGGER_NAME);
+        String loggerClassName = properties.getProperty(CONF_LOGGER_CLASS);
+        Class loggerClass;
+        if (loggerClassName != null) {
+            try {
+                loggerClass = Class.forName(loggerClassName);
+            } catch (ClassNotFoundException cnfe) {
+                // Could not find class name
+                throw new EsHadoopIllegalArgumentException("Could not locate logger class [" + loggerClassName + "].", cnfe);
+            }
+        } else {
+            loggerClass = null;
+        }
+
+        if (loggerName != null && loggerClass != null) {
+            throw new EsHadoopIllegalArgumentException("Both logger name and logger class provided for drop and log handler. Provide only one. Bailing out...");
+        }
+
+        if (loggerName != null) {
+            logger = LogFactory.getLog(loggerName);
+        } else if (loggerClass != null) {
+            logger = LogFactory.getLog(loggerClass);
+        } else {
+            throw new EsHadoopIllegalArgumentException("No logger name or logger class provided for drop and log handler. Provide one. Bailing out...");
+        }
+
+        String rawLoggerLevel = properties.getProperty(CONF_LOGGER_LEVEL, LogLevel.WARN.name());
+        if (!LogLevel.names.contains(rawLoggerLevel)) {
+            throw new EsHadoopIllegalArgumentException("Invalid logger level [" + rawLoggerLevel + "] given. Available logging levels: " + LogLevel.names.toString());
+        }
+        loggerLevel = LogLevel.valueOf(rawLoggerLevel);
+    }
+
+    @Override
+    public HandlerResult onError(SerializationFailure entry, ErrorCollector<Object> collector) throws Exception {
+        switch (loggerLevel) {
+            case FATAL:
+                if (logger.isFatalEnabled()) {
+                    logger.fatal(renderLogMessage(entry));
+                }
+                break;
+            case ERROR:
+                if (logger.isErrorEnabled()) {
+                    logger.error(renderLogMessage(entry));
+                }
+                break;
+            case WARN:
+                if (logger.isWarnEnabled()) {
+                    logger.warn(renderLogMessage(entry));
+                }
+                break;
+            case INFO:
+                if (logger.isInfoEnabled()) {
+                    logger.info(renderLogMessage(entry));
+                }
+                break;
+            case DEBUG:
+                if (logger.isDebugEnabled()) {
+                    logger.debug(renderLogMessage(entry));
+                }
+                break;
+            case TRACE:
+                if (logger.isTraceEnabled()) {
+                    logger.trace(renderLogMessage(entry));
+                }
+                break;
+        }
+        return HandlerResult.HANDLED;
+    }
+
+    private String renderLogMessage(SerializationFailure entry) {
+        // Render the previous handler messages
+        List<String> handlerMessages = entry.previousHandlerMessages();
+        String tailMessage;
+        if (!handlerMessages.isEmpty()) {
+            StringBuilder tail = new StringBuilder("Previous handler messages:");
+            for (String handlerMessage : handlerMessages) {
+                tail.append("\n\t").append(handlerMessage);
+            }
+            tailMessage = tail.toString();
+        } else {
+            tailMessage = "";
+        }
+
+        // Log the failure
+        return String.format(
+                "Dropping failed bulk entry (response [%s] from server) after [%s] attempts due to error [%s]:%n" +
+                        "Entry Contents:%n" +
+                        "%s" +
+                        "%s",
+                entry.getException().getMessage(),
+                stringify(entry.getRecord()),
+                tailMessage
+        );
+    }
+
+    private String stringify(Object entry) {
+        return entry.toString();
+    }
+}

--- a/mr/src/main/java/org/elasticsearch/hadoop/serialization/handler/write/SerializationErrorHandler.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/serialization/handler/write/SerializationErrorHandler.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.hadoop.serialization.handler.write;
+
+import java.util.Properties;
+
+import org.elasticsearch.hadoop.handler.ErrorCollector;
+import org.elasticsearch.hadoop.handler.ErrorHandler;
+import org.elasticsearch.hadoop.handler.HandlerResult;
+
+public abstract class SerializationErrorHandler implements ErrorHandler<SerializationFailure, Object, ErrorCollector<Object>> {
+    @Override
+    public void init(Properties properties) {}
+
+    public abstract HandlerResult onError(SerializationFailure entry, ErrorCollector<Object> collector) throws Exception;
+
+    @Override
+    public void close() {}
+}

--- a/mr/src/main/java/org/elasticsearch/hadoop/serialization/handler/write/SerializationFailure.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/serialization/handler/write/SerializationFailure.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.hadoop.serialization.handler.write;
+
+import java.util.List;
+
+import org.elasticsearch.hadoop.handler.Exceptional;
+
+public class SerializationFailure implements Exceptional {
+    private final Object record;
+    private final Exception reason;
+    private final List<String> passReasons;
+
+    public SerializationFailure(Exception reason, Object record, List<String> passReasons) {
+        this.record = record;
+        this.reason = reason;
+        this.passReasons = passReasons;
+    }
+
+    /**
+     * @return the record that triggered the exception while being processed for bulk indexing.
+     */
+    public Object getRecord() {
+        return record;
+    }
+
+    @Override
+    public Exception getException() {
+        return reason;
+    }
+
+    @Override
+    public List<String> previousHandlerMessages() {
+        return passReasons;
+    }
+}

--- a/mr/src/main/java/org/elasticsearch/hadoop/serialization/handler/write/SerializationHandlerLoader.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/serialization/handler/write/SerializationHandlerLoader.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.hadoop.serialization.handler.write;
+
+import org.elasticsearch.hadoop.EsHadoopIllegalArgumentException;
+import org.elasticsearch.hadoop.handler.AbstractHandlerLoader;
+
+public class SerializationHandlerLoader extends AbstractHandlerLoader<SerializationErrorHandler> {
+
+    public static final String ES_WRITE_DATA_ERROR_HANDLERS = "";
+    public static final String ES_WRITE_DATA_ERROR_HANDLER = "";
+
+    public SerializationHandlerLoader() {
+        super(SerializationErrorHandler.class);
+    }
+
+    @Override
+    protected String getHandlersPropertyName() {
+        return ES_WRITE_DATA_ERROR_HANDLERS;
+    }
+
+    @Override
+    protected String getHandlerPropertyName() {
+        return ES_WRITE_DATA_ERROR_HANDLER;
+    }
+
+    @Override
+    protected SerializationErrorHandler loadBuiltInHandler(NamedHandlers handlerName) {
+        switch (handlerName) {
+            case FAIL:
+                return null; // TODO
+            case LOG:
+                return null; // TODO
+            default:
+                throw new EsHadoopIllegalArgumentException(
+                        "Could not find default implementation for built in handler type [" + handlerName + "]"
+                );
+        }
+    }
+}

--- a/mr/src/main/java/org/elasticsearch/hadoop/serialization/handler/write/SerializationHandlerLoader.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/serialization/handler/write/SerializationHandlerLoader.java
@@ -24,8 +24,8 @@ import org.elasticsearch.hadoop.handler.AbstractHandlerLoader;
 
 public class SerializationHandlerLoader extends AbstractHandlerLoader<SerializationErrorHandler> {
 
-    public static final String ES_WRITE_DATA_ERROR_HANDLERS = "";
-    public static final String ES_WRITE_DATA_ERROR_HANDLER = "";
+    public static final String ES_WRITE_DATA_ERROR_HANDLERS = "es.write.data.error.handlers";
+    public static final String ES_WRITE_DATA_ERROR_HANDLER = "es.write.data.error.handler";
 
     public SerializationHandlerLoader() {
         super(SerializationErrorHandler.class);
@@ -45,9 +45,9 @@ public class SerializationHandlerLoader extends AbstractHandlerLoader<Serializat
     protected SerializationErrorHandler loadBuiltInHandler(NamedHandlers handlerName) {
         switch (handlerName) {
             case FAIL:
-                return null; // TODO
+                return new SerializationAbortOnFailure();
             case LOG:
-                return null; // TODO
+                return new SerializationDropAndLog();
             default:
                 throw new EsHadoopIllegalArgumentException(
                         "Could not find default implementation for built in handler type [" + handlerName + "]"

--- a/mr/src/test/java/org/elasticsearch/hadoop/serialization/bulk/BulkEntryWriterTest.java
+++ b/mr/src/test/java/org/elasticsearch/hadoop/serialization/bulk/BulkEntryWriterTest.java
@@ -1,0 +1,229 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.hadoop.serialization.bulk;
+
+import org.elasticsearch.hadoop.EsHadoopException;
+import org.elasticsearch.hadoop.EsHadoopIllegalStateException;
+import org.elasticsearch.hadoop.cfg.Settings;
+import org.elasticsearch.hadoop.handler.ErrorCollector;
+import org.elasticsearch.hadoop.handler.EsHadoopAbortHandlerException;
+import org.elasticsearch.hadoop.handler.HandlerResult;
+import org.elasticsearch.hadoop.serialization.EsHadoopSerializationException;
+import org.elasticsearch.hadoop.serialization.handler.write.SerializationErrorHandler;
+import org.elasticsearch.hadoop.serialization.handler.write.SerializationFailure;
+import org.elasticsearch.hadoop.serialization.handler.write.SerializationHandlerLoader;
+import org.elasticsearch.hadoop.util.BytesRef;
+import org.elasticsearch.hadoop.util.TestSettings;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import static org.junit.Assert.*;
+
+public class BulkEntryWriterTest {
+
+    @Test(expected = EsHadoopSerializationException.class)
+    public void testWriteBulkEntryThatAbortsByDefault() {
+        BulkCommand command = Mockito.mock(BulkCommand.class);
+        Mockito.when(command.write(1)).thenThrow(new EsHadoopIllegalStateException("Things broke"));
+
+        Settings settings = new TestSettings();
+
+        BulkEntryWriter bulkEntryWriter = new BulkEntryWriter(settings, command);
+
+        bulkEntryWriter.writeBulkEntry(1);
+        fail("Should abort on error by default");
+    }
+
+    @Test(expected = EsHadoopException.class)
+    public void testWriteBulkEntryWithHandlerThrowingException() {
+        BulkCommand command = Mockito.mock(BulkCommand.class);
+        Mockito.when(command.write(1)).thenThrow(new EsHadoopIllegalStateException("Things broke"));
+
+        Settings settings = new TestSettings();
+        settings.setProperty(SerializationHandlerLoader.ES_WRITE_DATA_ERROR_HANDLERS, "thrower");
+        settings.setProperty(SerializationHandlerLoader.ES_WRITE_DATA_ERROR_HANDLER+".thrower", ExceptionThrowingHandler.class.getName());
+
+        BulkEntryWriter bulkEntryWriter = new BulkEntryWriter(settings, command);
+
+        bulkEntryWriter.writeBulkEntry(1);
+        fail("Should fail from unexpected handler exception");
+    }
+
+    @Test(expected = EsHadoopSerializationException.class)
+    public void testWriteBulkEntryWithHandlerThrowingAbortException() {
+        BulkCommand command = Mockito.mock(BulkCommand.class);
+        Mockito.when(command.write(1)).thenThrow(new EsHadoopIllegalStateException("Things broke"));
+
+        Settings settings = new TestSettings();
+        settings.setProperty(SerializationHandlerLoader.ES_WRITE_DATA_ERROR_HANDLERS, "thrower");
+        settings.setProperty(SerializationHandlerLoader.ES_WRITE_DATA_ERROR_HANDLER+".thrower", AbortingExceptionThrowingHandler.class.getName());
+
+        BulkEntryWriter bulkEntryWriter = new BulkEntryWriter(settings, command);
+
+        bulkEntryWriter.writeBulkEntry(1);
+        fail("Should fail from aborting handler exception");
+    }
+
+    @Test(expected = EsHadoopException.class)
+    public void testWriteBulkEntryWithNeverEndingHandler() {
+        BulkCommand command = Mockito.mock(BulkCommand.class);
+        Mockito.when(command.write(1)).thenThrow(new EsHadoopIllegalStateException("Things broke"));
+
+        Settings settings = new TestSettings();
+        settings.setProperty(SerializationHandlerLoader.ES_WRITE_DATA_ERROR_HANDLERS, "evil");
+        settings.setProperty(SerializationHandlerLoader.ES_WRITE_DATA_ERROR_HANDLER+".evil", NeverSurrenderHandler.class.getName());
+
+        BulkEntryWriter bulkEntryWriter = new BulkEntryWriter(settings, command);
+
+        bulkEntryWriter.writeBulkEntry(1);
+        fail("Should fail from too many unsuccessful retries");
+    }
+
+    @Test
+    public void testWriteBulkEntryWithIgnoreFailure() {
+        BulkCommand command = Mockito.mock(BulkCommand.class);
+        Mockito.when(command.write(1)).thenThrow(new EsHadoopIllegalStateException("Things broke"));
+
+        Settings settings = new TestSettings();
+        settings.setProperty(SerializationHandlerLoader.ES_WRITE_DATA_ERROR_HANDLERS, "skip");
+        settings.setProperty(SerializationHandlerLoader.ES_WRITE_DATA_ERROR_HANDLER+".skip", NothingToSeeHereHandler.class.getName());
+
+        BulkEntryWriter bulkEntryWriter = new BulkEntryWriter(settings, command);
+
+        BytesRef value = bulkEntryWriter.writeBulkEntry(1);
+        Assert.assertNull("Skipped values should be null", value);
+    }
+
+    @Test
+    public void testWriteBulkEntryWithHandlersThatPassMessages() {
+        BulkCommand command = Mockito.mock(BulkCommand.class);
+        Mockito.when(command.write(1)).thenThrow(new EsHadoopIllegalStateException("Things broke"));
+
+        Settings settings = new TestSettings();
+        settings.setProperty(SerializationHandlerLoader.ES_WRITE_DATA_ERROR_HANDLERS, "marco,polo,skip");
+        settings.setProperty(SerializationHandlerLoader.ES_WRITE_DATA_ERROR_HANDLER+".marco", MarcoHandler.class.getName());
+        settings.setProperty(SerializationHandlerLoader.ES_WRITE_DATA_ERROR_HANDLER+".polo", PoloHandler.class.getName());
+        settings.setProperty(SerializationHandlerLoader.ES_WRITE_DATA_ERROR_HANDLER+".skip", NothingToSeeHereHandler.class.getName());
+
+        BulkEntryWriter bulkEntryWriter = new BulkEntryWriter(settings, command);
+
+        BytesRef value = bulkEntryWriter.writeBulkEntry(1);
+        Assert.assertNull("Skipped values should be null", value);
+    }
+
+    @Test
+    public void testWriteBulkEntryWithHandlersThatCorrectsData() {
+        BytesRef response = new BytesRef();
+        response.add("abcdefg".getBytes());
+        BulkCommand command = Mockito.mock(BulkCommand.class);
+        Mockito.when(command.write(1)).thenThrow(new EsHadoopIllegalStateException("Things broke"));
+        Mockito.when(command.write(10)).thenReturn(response);
+
+        Settings settings = new TestSettings();
+        settings.setProperty(SerializationHandlerLoader.ES_WRITE_DATA_ERROR_HANDLERS, "fix");
+        settings.setProperty(SerializationHandlerLoader.ES_WRITE_DATA_ERROR_HANDLER+".fix", CorrectingHandler.class.getName());
+
+        BulkEntryWriter bulkEntryWriter = new BulkEntryWriter(settings, command);
+
+        BytesRef value = bulkEntryWriter.writeBulkEntry(1);
+        Assert.assertNotNull("Skipped values should be null", value);
+        Assert.assertEquals(7, response.length());
+        Assert.assertArrayEquals("abcdefg".getBytes(), response.toString().getBytes());
+    }
+
+    /**
+     * Case: Handler throws random Exceptions
+     * Outcome: Processing fails fast.
+     */
+    public static class ExceptionThrowingHandler extends SerializationErrorHandler {
+        @Override
+        public HandlerResult onError(SerializationFailure entry, ErrorCollector<Object> collector) throws Exception {
+            throw new IllegalArgumentException("Whoopsie!");
+        }
+    }
+
+    /**
+     * Case: Handler throws exception, wrapped in abort based exception
+     * Outcome: Exception is collected and used as the reason for aborting that specific document.
+     */
+    public static class AbortingExceptionThrowingHandler extends SerializationErrorHandler {
+        @Override
+        public HandlerResult onError(SerializationFailure entry, ErrorCollector<Object> collector) throws Exception {
+            throw new EsHadoopAbortHandlerException("Abort the handler!!");
+        }
+    }
+
+    /**
+     * Case: Evil or incorrect handler causes infinite loop.
+     */
+    public static class NeverSurrenderHandler extends SerializationErrorHandler {
+        @Override
+        public HandlerResult onError(SerializationFailure entry, ErrorCollector<Object> collector) throws Exception {
+            return collector.retry(); // NEVER GIVE UP
+        }
+    }
+
+    /**
+     * Case: Handler acks the failure and expects the processing to move along.
+     */
+    public static class NothingToSeeHereHandler extends SerializationErrorHandler {
+        @Override
+        public HandlerResult onError(SerializationFailure entry, ErrorCollector<Object> collector) throws Exception {
+            return HandlerResult.HANDLED; // Move along.
+        }
+    }
+
+    /**
+     * Case: Handler passes on the failure, setting a "message for why"
+     */
+    public static class MarcoHandler extends SerializationErrorHandler {
+        @Override
+        public HandlerResult onError(SerializationFailure entry, ErrorCollector<Object> collector) throws Exception {
+            return collector.pass("MARCO!");
+        }
+    }
+
+    /**
+     * Case: Handler checks the pass messages and ensures that they have been set.
+     * Outcome: If set, it acks and continues, and if not, it aborts.
+     */
+    public static class PoloHandler extends SerializationErrorHandler {
+        @Override
+        public HandlerResult onError(SerializationFailure entry, ErrorCollector<Object> collector) throws Exception {
+            if (entry.previousHandlerMessages().contains("MARCO!")) {
+                return collector.pass("POLO!");
+            }
+            throw new EsHadoopAbortHandlerException("FISH OUT OF WATER!");
+        }
+    }
+
+    /**
+     * Case: Handler somehow knows how to fix data.
+     * Outcome: Data is deserialized correctly.
+     */
+    public static class CorrectingHandler extends SerializationErrorHandler {
+        @Override
+        public HandlerResult onError(SerializationFailure entry, ErrorCollector<Object> collector) throws Exception {
+            entry.getException().printStackTrace();
+            return collector.retry(10);
+        }
+    }
+}

--- a/mr/src/test/java/org/elasticsearch/hadoop/serialization/bulk/BulkEntryWriterTest.java
+++ b/mr/src/test/java/org/elasticsearch/hadoop/serialization/bulk/BulkEntryWriterTest.java
@@ -35,7 +35,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.fail;
 
 public class BulkEntryWriterTest {
 


### PR DESCRIPTION
Add error handler API to wrap the execution of serializing records to JSON bulk entries. This should encapsulate the process of extracting document metadata from the record to place in the action header, as well as the traversal and conversion of the record fields to JSON data.