### PR TITLE
An HTTP line is larger than 4096 bytes

### DIFF
--- a/mr/src/main/java/org/elasticsearch/hadoop/rest/SearchRequestBuilder.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/rest/SearchRequestBuilder.java
@@ -201,13 +201,6 @@ public class SearchRequestBuilder {
             uriParams.put("version", "");
         }
 
-        // override fields
-        if (StringUtils.hasText(fields)) {
-            uriParams.put("_source", HttpEncodingTools.concatenateAndUriEncode(StringUtils.tokenize(fields), StringUtils.DEFAULT_DELIMITER));
-        } else if (excludeSource) {
-            uriParams.put("_source", "false");
-        }
-
         // set shard preference
         StringBuilder pref = new StringBuilder();
         if (StringUtils.hasText(shard)) {
@@ -281,6 +274,18 @@ public class SearchRequestBuilder {
             generator.writeBeginObject();
             root.toJson(generator);
             generator.writeEndObject();
+            generator.writeFieldName("_source");
+            // override fields
+            if (StringUtils.hasText(fields)) {
+                generator.writeBeginArray();
+                final String[] fieldsArray = org.apache.commons.lang.StringUtils.split(fields, StringUtils.DEFAULT_DELIMITER);
+                for (String field : fieldsArray) {
+                    generator.writeString(field);
+                }
+                generator.writeEndArray();
+            } else if (excludeSource) {
+                generator.writeBoolean(false);
+            }
             generator.writeEndObject();
         } finally {
             generator.close();

--- a/mr/src/test/java/org/elasticsearch/hadoop/rest/QueryTest.java
+++ b/mr/src/test/java/org/elasticsearch/hadoop/rest/QueryTest.java
@@ -45,7 +45,7 @@ public class QueryTest {
 
     @Test
     public void testExcludeSourceTrue() {
-        assertTrue(builder.excludeSource(true).toString().contains("_source=false"));
+        assertFalse(builder.excludeSource(true).toString().contains("_source=false"));
     }
 
     @Test


### PR DESCRIPTION
        val conf = new SparkConf().setAppName("EsTest").setMaster("local[*]")
        conf.set("spark.sql.shuffle.partitions", "6")
        conf.set("spark.default.parallelism", "6")
        conf.set("es.cluster.name", "common")
        conf.set("es.nodes", "localhost")
        conf.set("es.port", "9200")
        val sc = new SparkContext(conf)
        val sqlContext = new SQLContext(sc)
        val index = "le_plan_d/dpa"
        val query = "{\"query\":{\"match_all\":{}}}"
        val dataFrame = sqlContext.esDF(index, query)
        dataFrame.show(2)

My index has more than 600 fields. I execute a simple match_all query. 

The wrong information is as follows: 
Caused by: org.elasticsearch.hadoop.rest.EsHadoopInvalidRequest: An HTTP line is larger than 4096 bytes.
{"query":{"match_all":{}}}


So，Transfer to post mode.