### PR TITLE
Upgrade Scala minor version to support Java 9/10

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -21,9 +21,9 @@ cascadingVersion = 2.6.3
 spark13Version = 1.6.2
 spark20Version = 2.3.0
 # same as Spark's
-scala210Version = 2.10.6
+scala210Version = 2.10.7
 scala210MajorVersion = 2.10
-scala211Version = 2.11.8
+scala211Version = 2.11.12
 scala211MajorVersion = 2.11
 
 stormVersion = 1.0.1

--- a/spark/sql-13/build.gradle
+++ b/spark/sql-13/build.gradle
@@ -8,8 +8,8 @@ apply plugin: 'scala'
 apply plugin: 'scala.variants'
 
 variants {
-    defaultVersion '2.11.8'
-    targetVersions '2.10.6', '2.11.8'
+    defaultVersion '2.11.12'
+    targetVersions '2.10.7', '2.11.12'
 }
 
 println "Compiled using Scala ${project.ext.scalaMajorVersion} [${project.ext.scalaVersion}]"

--- a/spark/sql-20/build.gradle
+++ b/spark/sql-20/build.gradle
@@ -8,8 +8,8 @@ apply plugin: 'es.hadoop.build.integration'
 apply plugin: 'scala.variants'
 
 variants {
-    defaultVersion '2.11.8'
-    targetVersions '2.10.6', '2.11.8'
+    defaultVersion '2.11.12'
+    targetVersions '2.10.7', '2.11.12'
 }
 
 println "Compiled using Scala ${project.ext.scalaMajorVersion} [${project.ext.scalaVersion}]"


### PR DESCRIPTION
This just upgrades the scala minor versions to the latest. This is to fix compile issues within java 9/10 environment(s).

Thank you for submitting a pull request! 

Please make sure you have signed our [Contributor License Agreement (CLA)][].  
We are not asking you to assign copyright to us, but to give us the right to distribute your code without restriction. We ask this of all contributors in order to assure our users of the origin and continuing existence of the code.  
You only need to sign the CLA once.

- [x] I have signed the [Contributor License Agreement (CLA)][]

[Contributor License Agreement (CLA)]: https://www.elastic.co/contributor-agreement/
