### PR TITLE
Support for custom MetadataExtractor within Spark flows

### DIFF
--- a/mr/src/main/java/org/elasticsearch/hadoop/cfg/ConfigurationOptions.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/cfg/ConfigurationOptions.java
@@ -154,6 +154,8 @@ public interface ConfigurationOptions {
 
     /** Mapping types */
     String ES_MAPPING_DEFAULT_EXTRACTOR_CLASS = "es.mapping.default.extractor.class";
+    
+    String ES_MAPPING_METADATA_EXTRACTOR_CLASS = "es.mapping.metadata.extractor.class";
 
     String ES_MAPPING_ID = "es.mapping.id";
     String ES_MAPPING_ID_EXTRACTOR_CLASS = "es.mapping.id.extractor.class";

--- a/mr/src/main/java/org/elasticsearch/hadoop/cfg/Settings.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/cfg/Settings.java
@@ -236,6 +236,10 @@ public abstract class Settings {
     public String getMappingDefaultClassExtractor() {
         return getProperty(ES_MAPPING_DEFAULT_EXTRACTOR_CLASS);
     }
+    
+    public String getMappingMetadataExtractorClassName() {
+        return getProperty(ES_MAPPING_METADATA_EXTRACTOR_CLASS);
+    }
 
     public String getMappingIdExtractorClassName() {
         return getProperty(ES_MAPPING_ID_EXTRACTOR_CLASS, getMappingDefaultClassExtractor());

--- a/mr/src/main/java/org/elasticsearch/hadoop/rest/InitializationUtils.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/rest/InitializationUtils.java
@@ -18,6 +18,9 @@
  */
 package org.elasticsearch.hadoop.rest;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.elasticsearch.hadoop.EsHadoopException;
@@ -32,6 +35,7 @@ import org.elasticsearch.hadoop.serialization.builder.ContentBuilder;
 import org.elasticsearch.hadoop.serialization.builder.NoOpValueWriter;
 import org.elasticsearch.hadoop.serialization.builder.ValueReader;
 import org.elasticsearch.hadoop.serialization.builder.ValueWriter;
+import org.elasticsearch.hadoop.serialization.bulk.MetadataExtractor;
 import org.elasticsearch.hadoop.serialization.dto.NodeInfo;
 import org.elasticsearch.hadoop.serialization.field.FieldExtractor;
 import org.elasticsearch.hadoop.util.Assert;
@@ -40,9 +44,6 @@ import org.elasticsearch.hadoop.util.EsMajorVersion;
 import org.elasticsearch.hadoop.util.FastByteArrayOutputStream;
 import org.elasticsearch.hadoop.util.SettingsUtils;
 import org.elasticsearch.hadoop.util.StringUtils;
-
-import java.util.ArrayList;
-import java.util.List;
 
 public abstract class InitializationUtils {
 
@@ -356,6 +357,21 @@ public abstract class InitializationUtils {
             throw new EsHadoopIllegalArgumentException(String.format("Target index [%s] does not exist and auto-creation is disabled [setting '%s' is '%s']",
                     settings.getResourceWrite(), ConfigurationOptions.ES_INDEX_AUTO_CREATE, settings.getIndexAutoCreate()));
         }
+    }
+    
+    public static boolean setMetadataExtractorIfNotSet(Settings settings, Class<? extends MetadataExtractor> clazz, Log log) {
+        if (!StringUtils.hasText(settings.getMappingMetadataExtractorClassName())) {
+            Log logger = (log != null ? log : LogFactory.getLog(clazz));
+
+            String name = clazz.getName();
+            settings.setProperty(ConfigurationOptions.ES_MAPPING_METADATA_EXTRACTOR_CLASS, name);
+            if (logger.isDebugEnabled()) {
+                logger.debug(String.format("Using pre-defined metadata extractor [%s] as default", settings.getMappingMetadataExtractorClassName()));
+            }
+            return true;
+        }
+
+        return false;
     }
 
     public static boolean setFieldExtractorIfNotSet(Settings settings, Class<? extends FieldExtractor> clazz, Log log) {

--- a/mr/src/main/java/org/elasticsearch/hadoop/serialization/bulk/MetadataExtractor.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/serialization/bulk/MetadataExtractor.java
@@ -70,4 +70,5 @@ public interface MetadataExtractor {
     }
 
     FieldExtractor get(Metadata metadata);
+    void setObject(Object entity);
 }

--- a/spark/core/main/scala/org/elasticsearch/spark/rdd/EsRDDWriter.scala
+++ b/spark/core/main/scala/org/elasticsearch/spark/rdd/EsRDDWriter.scala
@@ -29,6 +29,9 @@ import org.elasticsearch.hadoop.serialization.BytesConverter
 import org.elasticsearch.hadoop.serialization.JdkBytesConverter
 import org.elasticsearch.hadoop.serialization.builder.ValueWriter
 import org.elasticsearch.hadoop.serialization.field.FieldExtractor
+import org.elasticsearch.hadoop.serialization.bulk.MetadataExtractor
+import org.elasticsearch.hadoop.serialization.bulk.PerEntityPoolingMetadataExtractor
+import org.elasticsearch.hadoop.util.ObjectUtils
 import org.elasticsearch.spark.serialization.ScalaMapFieldExtractor
 import org.elasticsearch.spark.serialization.ScalaMetadataExtractor
 import org.elasticsearch.spark.serialization.ScalaValueWriter
@@ -48,11 +51,12 @@ private[spark] class EsRDDWriter[T: ClassTag](val serializedSettings: String,
     InitializationUtils.setValueWriterIfNotSet(settings, valueWriter, log)
     InitializationUtils.setBytesConverterIfNeeded(settings, bytesConverter, log)
     InitializationUtils.setFieldExtractorIfNotSet(settings, fieldExtractor, log)
+    InitializationUtils.setMetadataExtractorIfNotSet(settings, metadataExtractor, log)
 
     settings
   }
 
-  lazy val metaExtractor = new ScalaMetadataExtractor(settings.getInternalVersionOrThrow)
+  lazy val metaExtractor = ObjectUtils.instantiate[MetadataExtractor](settings.getMappingMetadataExtractorClassName, settings)
 
   def write(taskContext: TaskContext, data: Iterator[T]): Unit = {
     val writer = RestService.createWriter(settings, taskContext.partitionId.toLong, -1, log)
@@ -71,13 +75,14 @@ private[spark] class EsRDDWriter[T: ClassTag](val serializedSettings: String,
   protected def valueWriter: Class[_ <: ValueWriter[_]] = classOf[ScalaValueWriter]
   protected def bytesConverter: Class[_ <: BytesConverter] = classOf[JdkBytesConverter]
   protected def fieldExtractor: Class[_ <: FieldExtractor] = classOf[ScalaMapFieldExtractor]
+  protected def metadataExtractor: Class[_ <: MetadataExtractor] = classOf[ScalaMetadataExtractor]
 
   protected def processData(data: Iterator[T]): Any = {
     val next = data.next
     if (runtimeMetadata) {
       // use the key to extract metadata && return the value to be used as the document
       val (key, value) = next
-      metaExtractor.setObject(key)
+      metaExtractor.setObject(key);
       value
     } else {
       next

--- a/spark/core/main/scala/org/elasticsearch/spark/serialization/ScalaMetadataExtractor.scala
+++ b/spark/core/main/scala/org/elasticsearch/spark/serialization/ScalaMetadataExtractor.scala
@@ -24,10 +24,9 @@ import java.util.{Map => JMap}
 import scala.collection.{Map => SMap}
 import org.elasticsearch.hadoop.serialization.bulk.MetadataExtractor.{Metadata => InternalMetadata}
 import org.elasticsearch.hadoop.serialization.bulk.PerEntityPoolingMetadataExtractor
-import org.elasticsearch.hadoop.util.EsMajorVersion
 import org.elasticsearch.spark.rdd.{Metadata => SparkMetadata}
 
-private[spark] class ScalaMetadataExtractor(version: EsMajorVersion) extends PerEntityPoolingMetadataExtractor(version) {
+private[spark] class ScalaMetadataExtractor extends PerEntityPoolingMetadataExtractor {
 
   override def getValue(metadata: InternalMetadata): AnyRef = {
     val sparkEnum = ScalaMetadataExtractor.toSparkEnum(metadata)


### PR DESCRIPTION
Changes:
* Add support for a user defined MetadataExtractor within Spark. Also includes support for SettingsAware MetadataExtractor classes. 
* Expands the MetadataExtractor interface to recieve the Metadata Object during their work flow. 
* PerEntityPoolingMetadataExtractor expanded to support it's reuse within user defined MetadataExtractors.

Thank you for submitting a pull request! 

Please make sure you have signed our [Contributor License Agreement (CLA)][].  
We are not asking you to assign copyright to us, but to give us the right to distribute your code without restriction. We ask this of all contributors in order to assure our users of the origin and continuing existence of the code.  
You only need to sign the CLA once.

- [x] I have signed the [Contributor License Agreement (CLA)][]

[Contributor License Agreement (CLA)]: https://www.elastic.co/contributor-agreement/
