### PR TITLE
Bugfix - return _version field in metadata when requested

### DIFF
--- a/mr/src/main/java/org/elasticsearch/hadoop/rest/SearchRequestBuilder.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/rest/SearchRequestBuilder.java
@@ -200,7 +200,7 @@ public class SearchRequestBuilder {
         uriParams.put("scroll", String.valueOf(scroll.toString()));
         uriParams.put("size", String.valueOf(size));
         if (includeVersion) {
-            uriParams.put("version", "");
+            uriParams.put("version", "true");
         }
 
         // set shard preference

--- a/mr/src/test/java/org/elasticsearch/hadoop/rest/SearchRequestBuilderTest.java
+++ b/mr/src/test/java/org/elasticsearch/hadoop/rest/SearchRequestBuilderTest.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.hadoop.rest;
+
+import org.elasticsearch.hadoop.util.EsMajorVersion;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+public class SearchRequestBuilderTest {
+
+    @Test
+    public void testVersion() {
+        EsMajorVersion esVersion = EsMajorVersion.LATEST;
+        SearchRequestBuilder includeVersionBuilder = new SearchRequestBuilder(esVersion, true);
+        SearchRequestBuilder noVersionBuilder = new SearchRequestBuilder(esVersion, false);
+
+        String versionQueryParam = "version=true";
+
+        assertTrue(includeVersionBuilder.toString().contains(versionQueryParam));
+        assertTrue(!noVersionBuilder.toString().contains(versionQueryParam));
+    }
+}


### PR DESCRIPTION
Bugfix for: https://github.com/elastic/elasticsearch-hadoop/issues/1160

- [x] I have signed the [Contributor License Agreement (CLA)][]

[Contributor License Agreement (CLA)]: https://www.elastic.co/contributor-agreement/
