### PR TITLE
Elasticsearch Generic Error Handler

### DIFF
--- a/cascading/src/itest/java/org/elasticsearch/hadoop/integration/cascading/AbstractCascadingHadoopSaveTest.java
+++ b/cascading/src/itest/java/org/elasticsearch/hadoop/integration/cascading/AbstractCascadingHadoopSaveTest.java
@@ -112,6 +112,20 @@ public class AbstractCascadingHadoopSaveTest {
     }
 
     @Test
+    public void testIndexPatternFailing() throws Exception {
+        Properties props = HdpBootstrap.asProperties(CascadingHadoopSuite.configuration);
+
+        props.put("es.mapping.id", "nonexistent");
+        props.put("es.write.data.error.handlers", "es");
+        props.put("es.write.data.error.handler.es.client.resource", "cascading-hadoop-pattern-errors/data");
+
+        Tap in = sourceTap();
+        Tap out = new EsTap("cascading-hadoop-error-pattern-{tag}/data", new Fields("id", "name", "url", "picture", "tag"));
+        Pipe pipe = new Pipe("copy");
+        StatsUtils.proxy(new HadoopFlowConnector(props).connect(in, out, pipe)).complete();
+    }
+
+    @Test
     public void testIndexPatternWithFormat() throws Exception {
         Properties props = HdpBootstrap.asProperties(CascadingHadoopSuite.configuration);
 

--- a/cascading/src/itest/java/org/elasticsearch/hadoop/integration/cascading/CascadingHadoopSuite.java
+++ b/cascading/src/itest/java/org/elasticsearch/hadoop/integration/cascading/CascadingHadoopSuite.java
@@ -42,9 +42,7 @@ import org.junit.runners.Suite;
 import cascading.util.Update;
 
 @RunWith(Suite.class)
-//@Suite.SuiteClasses({ AbstractCascadingHadoopSaveTest.class, AbstractCascadingHadoopJsonSaveTest.class, AbstractCascadingHadoopSearchTest.class, AbstractCascadingHadoopJsonSearchTest.class, AbstractCascadingHadoopJsonReadTest.class })
-@Suite.SuiteClasses({ AbstractCascadingHadoopSaveTest.class })
-//@Suite.SuiteClasses({ AbstractCascadingHadoopJsonSaveTest.class, AbstractCascadingHadoopJsonSearchTest.class })
+@Suite.SuiteClasses({ AbstractCascadingHadoopSaveTest.class, AbstractCascadingHadoopJsonSaveTest.class, AbstractCascadingHadoopSearchTest.class, AbstractCascadingHadoopJsonSearchTest.class, AbstractCascadingHadoopJsonReadTest.class })
 public class CascadingHadoopSuite {
 
     @ClassRule

--- a/cascading/src/itest/java/org/elasticsearch/hadoop/integration/cascading/CascadingHadoopSuite.java
+++ b/cascading/src/itest/java/org/elasticsearch/hadoop/integration/cascading/CascadingHadoopSuite.java
@@ -42,7 +42,8 @@ import org.junit.runners.Suite;
 import cascading.util.Update;
 
 @RunWith(Suite.class)
-@Suite.SuiteClasses({ AbstractCascadingHadoopSaveTest.class, AbstractCascadingHadoopJsonSaveTest.class, AbstractCascadingHadoopSearchTest.class, AbstractCascadingHadoopJsonSearchTest.class, AbstractCascadingHadoopJsonReadTest.class })
+//@Suite.SuiteClasses({ AbstractCascadingHadoopSaveTest.class, AbstractCascadingHadoopJsonSaveTest.class, AbstractCascadingHadoopSearchTest.class, AbstractCascadingHadoopJsonSearchTest.class, AbstractCascadingHadoopJsonReadTest.class })
+@Suite.SuiteClasses({ AbstractCascadingHadoopSaveTest.class })
 //@Suite.SuiteClasses({ AbstractCascadingHadoopJsonSaveTest.class, AbstractCascadingHadoopJsonSearchTest.class })
 public class CascadingHadoopSuite {
 

--- a/docs/src/reference/asciidoc/core/errorhandlers.adoc
+++ b/docs/src/reference/asciidoc/core/errorhandlers.adoc
@@ -117,6 +117,66 @@ placed at the end of the list of error handlers.
 
 There are no configurations for this handler.
 
+[[errorhandlers-bulk-es]]
+[float]
+==== Elasticsearch Error Handler
+Default Handler Name: `es`
+
+When this handler is invoked it converts the error given into a JSON document and inserts it into an Elasticsearch index.
+When this indexing operation is complete, the handler can be configured to signal that the error is handled (default),
+or pass the error along to the next handler in the chain. The ES handler serializes error information using its own
+mapping of the Elastic Common Schema. This data can accept additional user provided metadata that can assist users in
+searching and reporting on failures (see labels and tags settings below).
+
+NOTE: Error handlers are built to execute on a per record/error basis. The Elasticsearch Error Handler does not bulk
+insert error information currently. Each error is inserted one at a time in order to ensure each record/error is handled.
+This handler may not provide a very high throughput in cases where there are a large number of error events to handle. You
+should try to design your jobs so that error handling is a relatively uncommon occurrence.
+
+Available configurations for this handler:
+
+`es.write.rest.error.handler.es.client.nodes` (default: "localhost" or currently configured nodes)::
+The comma separated string of node addresses to write errors to. It is recommended that this be a different cluster than
+the one being written to (in order to avoid write contention).
+
+`es.write.rest.error.handler.es.client.port` (default: 9200 or currently configured port)::
+The http port to use when connecting to the Elasticsearch nodes.
+
+`es.write.rest.error.handler.es.client.resource` (required)::
+The index to write error information into. It is highly recommended that this index be just for error information.
+Does not support index patterns.
+
+`es.write.rest.error.handler.es.client.inherit` (default: true)::
+Determines if the settings to create the client used for sending error information should inherit the same client settings
+from the currently running job. By default, all client settings in the job configuration are inherited by this client.
+
+`es.write.rest.error.handler.es.client.conf.<CONFIGURATION>` ::
+This configuration prefix is used to set client configuration values in the handler's underlying ES client. This accepts
+most of the settings documented in <<configuration>>.
+
+`es.write.rest.error.handler.es.label.<LABEL>` (optional)::
+A user defined label field that is added to each error event created by this handler. This field will be indexed into
+the Elasticsearch index provided for this handler. Text data only.
+
+`es.write.rest.error.handler.es.tags` (optional)::
+The comma separated string of tags to add to each error event created by this handler. This field will be indexed into
+the Elasticsearch index provided for this handler. Text data only.
+
+`es.write.rest.error.handler.es.return.default` (default: HANDLED)::
+The handler result to be returned to the error handling framework when an error is successfully written to Elasticsearch.
+Available values are `HANDLED`, `PASS`, and `ABORT`. Default result is `HANDLED`.
+
+`es.write.rest.error.handler.es.return.default.reason` (optional)::
+In the case that the default return value is `PASS`, this optional text setting allows a user to specify the reason for
+the handler to pass the data along to the next handler in the chain.
+
+`es.write.rest.error.handler.es.return.error` (default: ABORT)::
+The handler result to be returned to the error handling framework when an error cannot be written to Elasticsearch.
+Available values are `HANDLED`, `PASS`, and `ABORT`. Default result is `ABORT`.
+
+`es.write.rest.error.handler.es.return.error.reason` (optional)::
+In the case that the error return value is `PASS`, this optional text setting allows a user to specify the reason for the
+handler to pass the data along to the next handler in the chain.
 
 [[errorhandlers-bulk-use]]
 [float]
@@ -399,6 +459,67 @@ placed at the end of the list of error handlers.
 
 There are no configurations for this handler.
 
+[[errorhandlers-serialization-es]]
+[float]
+==== Elasticsearch Error Handler
+Default Handler Name: `es`
+
+When this handler is invoked it converts the error given into a JSON document and inserts it into an Elasticsearch index.
+When this indexing operation is complete, the handler can be configured to signal that the error is handled (default),
+or pass the error along to the next handler in the chain. The ES handler serializes error information using its own
+mapping of the Elastic Common Schema. This data can accept additional user provided metadata that can assist users in
+searching and reporting on failures (see labels and tags settings below).
+
+NOTE: Error handlers are built to execute on a per record/error basis. The Elasticsearch Error Handler does not bulk
+insert error information currently. Each error is inserted one at a time in order to ensure each record/error is handled.
+This handler may not provide a very high throughput in cases where there are a large number of error events to handle. You
+should try to design your jobs so that error handling is a relatively uncommon occurrence.
+
+Available configurations for this handler:
+
+`es.write.rest.error.handler.es.client.nodes` (default: "localhost" or currently configured nodes)::
+The comma separated string of node addresses to write errors to. It is recommended that this be a different cluster than
+the one being written to (in order to avoid write contention).
+
+`es.write.rest.error.handler.es.client.port` (default: 9200 or currently configured port)::
+The http port to use when connecting to the Elasticsearch nodes.
+
+`es.write.rest.error.handler.es.client.resource` (required)::
+The index to write error information into. It is highly recommended that this index be just for error information.
+Does not support index patterns.
+
+`es.write.rest.error.handler.es.client.inherit` (default: true)::
+Determines if the settings to create the client used for sending error information should inherit the same client settings
+from the currently running job. By default, all client settings in the job configuration are inherited by this client.
+
+`es.write.rest.error.handler.es.client.conf.<CONFIGURATION>` ::
+This configuration prefix is used to set client configuration values in the handler's underlying ES client. This accepts
+most of the settings documented in <<configuration>>.
+
+`es.write.rest.error.handler.es.label.<LABEL>` (optional)::
+A user defined label field that is added to each error event created by this handler. This field will be indexed into
+the Elasticsearch index provided for this handler. Text data only.
+
+`es.write.rest.error.handler.es.tags` (optional)::
+The comma separated string of tags to add to each error event created by this handler. This field will be indexed into
+the Elasticsearch index provided for this handler. Text data only.
+
+`es.write.rest.error.handler.es.return.default` (default: HANDLED)::
+The handler result to be returned to the error handling framework when an error is successfully written to Elasticsearch.
+Available values are `HANDLED`, `PASS`, and `ABORT`. Default result is `HANDLED`.
+
+`es.write.rest.error.handler.es.return.default.reason` (optional)::
+In the case that the default return value is `PASS`, this optional text setting allows a user to specify the reason for
+the handler to pass the data along to the next handler in the chain.
+
+`es.write.rest.error.handler.es.return.error` (default: ABORT)::
+The handler result to be returned to the error handling framework when an error cannot be written to Elasticsearch.
+Available values are `HANDLED`, `PASS`, and `ABORT`. Default result is `ABORT`.
+
+`es.write.rest.error.handler.es.return.error.reason` (optional)::
+In the case that the error return value is `PASS`, this optional text setting allows a user to specify the reason for the
+handler to pass the data along to the next handler in the chain.
+
 
 [[errorhandlers-serialization-use]]
 [float]
@@ -673,6 +794,67 @@ placed at the end of the list of error handlers.
 
 There are no configurations for this handler.
 
+
+[[errorhandlers-read-json-es]]
+[float]
+==== Elasticsearch Error Handler
+Default Handler Name: `es`
+
+When this handler is invoked it converts the error given into a JSON document and inserts it into an Elasticsearch index.
+When this indexing operation is complete, the handler can be configured to signal that the error is handled (default),
+or pass the error along to the next handler in the chain. The ES handler serializes error information using its own
+mapping of the Elastic Common Schema. This data can accept additional user provided metadata that can assist users in
+searching and reporting on failures (see labels and tags settings below).
+
+NOTE: Error handlers are built to execute on a per record/error basis. The Elasticsearch Error Handler does not bulk
+insert error information currently. Each error is inserted one at a time in order to ensure each record/error is handled.
+This handler may not provide a very high throughput in cases where there are a large number of error events to handle. You
+should try to design your jobs so that error handling is a relatively uncommon occurrence.
+
+Available configurations for this handler:
+
+`es.write.rest.error.handler.es.client.nodes` (default: "localhost" or currently configured nodes)::
+The comma separated string of node addresses to write errors to. It is recommended that this be a different cluster than
+the one being written to (in order to avoid write contention).
+
+`es.write.rest.error.handler.es.client.port` (default: 9200 or currently configured port)::
+The http port to use when connecting to the Elasticsearch nodes.
+
+`es.write.rest.error.handler.es.client.resource` (required)::
+The index to write error information into. It is highly recommended that this index be just for error information.
+Does not support index patterns.
+
+`es.write.rest.error.handler.es.client.inherit` (default: true)::
+Determines if the settings to create the client used for sending error information should inherit the same client settings
+from the currently running job. By default, all client settings in the job configuration are inherited by this client.
+
+`es.write.rest.error.handler.es.client.conf.<CONFIGURATION>` ::
+This configuration prefix is used to set client configuration values in the handler's underlying ES client. This accepts
+most of the settings documented in <<configuration>>.
+
+`es.write.rest.error.handler.es.label.<LABEL>` (optional)::
+A user defined label field that is added to each error event created by this handler. This field will be indexed into
+the Elasticsearch index provided for this handler. Text data only.
+
+`es.write.rest.error.handler.es.tags` (optional)::
+The comma separated string of tags to add to each error event created by this handler. This field will be indexed into
+the Elasticsearch index provided for this handler. Text data only.
+
+`es.write.rest.error.handler.es.return.default` (default: HANDLED)::
+The handler result to be returned to the error handling framework when an error is successfully written to Elasticsearch.
+Available values are `HANDLED`, `PASS`, and `ABORT`. Default result is `HANDLED`.
+
+`es.write.rest.error.handler.es.return.default.reason` (optional)::
+In the case that the default return value is `PASS`, this optional text setting allows a user to specify the reason for
+the handler to pass the data along to the next handler in the chain.
+
+`es.write.rest.error.handler.es.return.error` (default: ABORT)::
+The handler result to be returned to the error handling framework when an error cannot be written to Elasticsearch.
+Available values are `HANDLED`, `PASS`, and `ABORT`. Default result is `ABORT`.
+
+`es.write.rest.error.handler.es.return.error.reason` (optional)::
+In the case that the error return value is `PASS`, this optional text setting allows a user to specify the reason for the
+handler to pass the data along to the next handler in the chain.
 
 [[errorhandlers-read-json-use]]
 [float]

--- a/hive/src/main/java/org/elasticsearch/hadoop/hive/HiveType.java
+++ b/hive/src/main/java/org/elasticsearch/hadoop/hive/HiveType.java
@@ -48,4 +48,12 @@ public class HiveType {
     public void setObjectInspector(ObjectInspector oi) {
         this.oi = oi;
     }
+
+    @Override
+    public String toString() {
+        return "HiveType{" +
+                "object=" + object +
+                ", inspector=" + oi +
+                '}';
+    }
 }

--- a/mr/src/main/java/org/elasticsearch/hadoop/cfg/CompositeSettings.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/cfg/CompositeSettings.java
@@ -26,6 +26,12 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.Properties;
 
+/**
+ * Provides a composite view of configurations, using a hierarchical model for property lookup as well as immutable
+ * treatment of the underlying configurations. Each Composite has its own write-settings to accumulate mutations that
+ * is checked for values first. After checking the write-settings, each settings object is checked in order that they
+ * were specified.
+ */
 public class CompositeSettings extends Settings {
 
     private Settings writeSettings;

--- a/mr/src/main/java/org/elasticsearch/hadoop/cfg/CompositeSettings.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/cfg/CompositeSettings.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.hadoop.cfg;
+
+import java.io.InputStream;
+import java.util.Collection;
+import java.util.Deque;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.Properties;
+
+public class CompositeSettings extends Settings {
+
+    private Settings writeSettings;
+    private Deque<Settings> settingsList;
+
+    /**
+     * @param settings ordered input of settings, which will be checked for properties in the order that they are given.
+     */
+    public CompositeSettings(Collection<Settings> settings) {
+        this.writeSettings = new PropertiesSettings();
+        this.settingsList = new LinkedList<Settings>(settings);
+    }
+
+    private CompositeSettings(Settings writeSettings, LinkedList<Settings> settingsList) {
+        this.writeSettings = writeSettings;
+        this.settingsList = settingsList;
+    }
+
+    @Override
+    public InputStream loadResource(String location) {
+        return writeSettings.loadResource(location);
+    }
+
+    @Override
+    public Settings copy() {
+        Settings copiedWriteSettings = writeSettings.copy();
+        LinkedList<Settings> copiedSettingsList = new LinkedList<Settings>();
+        for (Settings settings : settingsList) {
+            copiedSettingsList.add(settings.copy());
+        }
+        return new CompositeSettings(copiedWriteSettings, copiedSettingsList);
+    }
+
+    @Override
+    public String getProperty(String name) {
+        String value = writeSettings.getProperty(name);
+        if (value == null) {
+            Iterator<Settings> toCheck = settingsList.iterator();
+            while (value == null && toCheck.hasNext()) {
+                Settings next = toCheck.next();
+                value = next.getProperty(name);
+            }
+        }
+        return value;
+    }
+
+    @Override
+    public void setProperty(String name, String value) {
+        writeSettings.setProperty(name, value);
+    }
+
+    @Override
+    public Properties asProperties() {
+        Properties merged = new Properties();
+        Iterator<Settings> settingsIterator = settingsList.descendingIterator();
+        while (settingsIterator.hasNext()) {
+            Settings next = settingsIterator.next();
+            Properties props = next.asProperties();
+            for (Object keyObject : props.keySet()) {
+                String key = keyObject.toString();
+                merged.setProperty(key, props.getProperty(key));
+            }
+        }
+        Properties writeProperties = writeSettings.asProperties();
+        for (Object keyObject : writeProperties.keySet()) {
+            String key = keyObject.toString();
+            merged.setProperty(key, writeProperties.getProperty(key));
+        }
+        return merged;
+    }
+}

--- a/mr/src/main/java/org/elasticsearch/hadoop/cfg/FilteredSettings.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/cfg/FilteredSettings.java
@@ -22,6 +22,10 @@ package org.elasticsearch.hadoop.cfg;
 import java.io.InputStream;
 import java.util.Properties;
 
+/**
+ * Filtered settings are used for masking and hiding configuration values by key prefix. This is useful when you want
+ * to ignore a namespace of a configuration, but still reference values from its state.
+ */
 public class FilteredSettings extends Settings {
 
     private final Settings parent;

--- a/mr/src/main/java/org/elasticsearch/hadoop/cfg/FilteredSettings.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/cfg/FilteredSettings.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.hadoop.cfg;
+
+import java.io.InputStream;
+import java.util.Properties;
+
+public class FilteredSettings extends Settings {
+
+    private final Settings parent;
+    private final String excludePrefix;
+
+    FilteredSettings(Settings parent, String excludePrefix) {
+        this.parent = parent;
+        if (excludePrefix.endsWith(".")) {
+           this.excludePrefix = excludePrefix;
+        } else {
+            this.excludePrefix = excludePrefix + ".";
+        }
+    }
+
+    private boolean validKey(String key) {
+        return !key.startsWith(excludePrefix);
+    }
+
+    @Override
+    public InputStream loadResource(String location) {
+        return parent.loadResource(location);
+    }
+
+    @Override
+    public Settings copy() {
+        return new FilteredSettings(parent.copy(), excludePrefix);
+    }
+
+    @Override
+    public String getProperty(String name) {
+        if (validKey(name)) {
+            return parent.getProperty(name);
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public void setProperty(String name, String value) {
+        // Ignore the update if it is an excluded key as it will not be readable after setting anyway
+        if (validKey(name)) {
+            parent.setProperty(name, value);
+        }
+    }
+
+    @Override
+    public Properties asProperties() {
+        Properties parentSettings = parent.asProperties();
+        Properties filteredProperties = new Properties();
+        for (Object keyObject : parentSettings.keySet()) {
+            String key = keyObject.toString();
+            if (validKey(key)) {
+                filteredProperties.put(key, parentSettings.getProperty(key));
+            }
+        }
+        return filteredProperties;
+    }
+}

--- a/mr/src/main/java/org/elasticsearch/hadoop/cfg/Settings.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/cfg/Settings.java
@@ -603,6 +603,10 @@ public abstract class Settings {
         return new SettingsView(this, name);
     }
 
+    public Settings excludeFilter(String prefix) {
+        return new FilteredSettings(this, prefix);
+    }
+
     public Settings merge(Properties properties) {
         if (properties == null || properties.isEmpty()) {
             return this;

--- a/mr/src/main/java/org/elasticsearch/hadoop/cfg/Settings.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/cfg/Settings.java
@@ -587,7 +587,7 @@ public abstract class Settings {
 
     public abstract Settings copy();
 
-    protected String getProperty(String name, String defaultValue) {
+    public String getProperty(String name, String defaultValue) {
         String value = getProperty(name);
         if (!StringUtils.hasText(value)) {
             return defaultValue;

--- a/mr/src/main/java/org/elasticsearch/hadoop/handler/impl/AbstractHandlerLoader.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/handler/impl/AbstractHandlerLoader.java
@@ -65,6 +65,10 @@ public abstract class AbstractHandlerLoader<E extends ErrorHandler> implements S
         this.settings = settings;
     }
 
+    protected Settings getSettings() {
+        return this.settings;
+    }
+
     @Override
     public List<E> loadHandlers() {
         Assert.notNull(settings, "No settings are present in the handler loader!");

--- a/mr/src/main/java/org/elasticsearch/hadoop/handler/impl/AbstractHandlerLoader.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/handler/impl/AbstractHandlerLoader.java
@@ -42,7 +42,8 @@ public abstract class AbstractHandlerLoader<E extends ErrorHandler> implements S
 
     public enum NamedHandlers {
         FAIL("fail"),
-        LOG("log");
+        LOG("log"),
+        ES("es");
 
         private final String name;
 
@@ -89,6 +90,8 @@ public abstract class AbstractHandlerLoader<E extends ErrorHandler> implements S
                 failureHandlerAdded = true;
             } else if (handlerName.equals(NamedHandlers.LOG.name)) {
                 handler = loadBuiltInHandler(NamedHandlers.LOG);
+            } else if (handlerName.equals(NamedHandlers.ES.name)) {
+                handler = loadBuiltInHandler(NamedHandlers.ES);
             } else {
                 String handlerClassName = settings.getProperty(handlerPropertyPrefix + "." + handlerName);
                 handler = ObjectUtils.instantiate(handlerClassName, AbstractHandlerLoader.class.getClassLoader());

--- a/mr/src/main/java/org/elasticsearch/hadoop/handler/impl/elasticsearch/BaseEventConverter.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/handler/impl/elasticsearch/BaseEventConverter.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.hadoop.handler.impl.elasticsearch;
+
+import java.io.IOException;
+import java.util.Calendar;
+import javax.xml.bind.DatatypeConverter;
+
+import org.elasticsearch.hadoop.handler.Exceptional;
+import org.elasticsearch.hadoop.rest.EsHadoopRemoteException;
+import org.elasticsearch.hadoop.util.BytesArray;
+import org.elasticsearch.hadoop.util.ecs.ElasticCommonSchema;
+import org.elasticsearch.hadoop.util.ecs.MessageTemplate;
+
+/**
+ * Base implementation for converting failure events into ECS documents
+ */
+public abstract class BaseEventConverter<E extends Exceptional> implements EventConverter<E> {
+
+    private final String eventType;
+    private final String eventMessage;
+
+    public BaseEventConverter(String eventType, String eventMessage) {
+        this.eventType = eventType;
+        this.eventMessage = eventMessage;
+    }
+
+    @Override
+    public ElasticCommonSchema.TemplateBuilder configureTemplate(ElasticCommonSchema.TemplateBuilder templateBuilder) {
+        return templateBuilder.setEventType(eventType);
+    }
+
+    @Override
+    public BytesArray generateEvent(E event, MessageTemplate template) throws IOException {
+        // Generate timestamp
+        String timestamp = getTimestamp(event);
+        // Generate message
+        String eventMessage = renderEventMessage(event);
+        // Exception type extraction
+        String exceptionType = renderExceptionType(event);
+        // Exception message
+        String exceptionMessage = renderExceptionMessage(event);
+        // String raw event
+        String rawEvent = getRawEvent(event);
+        return template.generateMessage(timestamp, eventMessage, exceptionType, exceptionMessage, rawEvent);
+    }
+
+    /**
+     * Visible for testing
+     */
+    public String getTimestamp(E event) {
+        long millis = System.currentTimeMillis();
+        Calendar cal = Calendar.getInstance();
+        cal.setTimeInMillis(millis);
+        return DatatypeConverter.printDateTime(cal);
+    }
+
+    /**
+     * Visible for testing
+     */
+    public String renderEventMessage(E event) {
+        return eventMessage;
+    }
+
+    /**
+     * Visible for testing
+     */
+    public String renderExceptionType(E event) {
+        Exception exception = event.getException();
+
+        if (exception instanceof EsHadoopRemoteException) {
+            EsHadoopRemoteException remoteException = ((EsHadoopRemoteException) exception);
+            return remoteException.getType();
+        } else {
+            String classText = exception.getClass().getSimpleName();
+            StringBuilder builder = new StringBuilder();
+            boolean first = true;
+            for (char c : classText.toCharArray()) {
+                if (Character.isUpperCase(c)) {
+                    if (first) {
+                        first = false;
+                    } else {
+                        builder.append("_");
+                    }
+                    builder.append(Character.toLowerCase(c));
+                } else {
+                    builder.append(c);
+                }
+            }
+            return builder.toString();
+        }
+    }
+
+    /**
+     * Visible for testing
+     */
+    public String renderExceptionMessage(E event) {
+        return event.getException().getMessage();
+    }
+
+    /**
+     * Visible for testing
+     */
+    public abstract String getRawEvent(E event) throws IOException;
+}

--- a/mr/src/main/java/org/elasticsearch/hadoop/handler/impl/elasticsearch/ElasticsearchHandler.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/handler/impl/elasticsearch/ElasticsearchHandler.java
@@ -41,6 +41,7 @@ import org.elasticsearch.hadoop.rest.RestClient;
 import org.elasticsearch.hadoop.rest.RestRepository;
 import org.elasticsearch.hadoop.rest.RestService;
 import org.elasticsearch.hadoop.serialization.field.IndexExtractor;
+import org.elasticsearch.hadoop.util.Assert;
 import org.elasticsearch.hadoop.util.BytesArray;
 import org.elasticsearch.hadoop.util.ObjectUtils;
 import org.elasticsearch.hadoop.util.SettingsUtils;
@@ -139,6 +140,10 @@ public class ElasticsearchHandler<I extends Exceptional, O, C extends ErrorColle
 
         // Inherit the original configuration or not
         this.clientSettings = handlerSettings.getSettingsView(CONF_CLIENT_CONF);
+
+        // Ensure we have a write resource to use
+        Assert.hasText(clientSettings.getResourceWrite(), "Could not locate write resource for ES error handler.");
+
         if (inheritRoot) {
             LOG.info("Elasticsearch Error Handler inheriting root configuration");
             this.clientSettings = new CompositeSettings(Arrays.asList(clientSettings, rootSettings.excludeFilter("es.internal")));

--- a/mr/src/main/java/org/elasticsearch/hadoop/handler/impl/elasticsearch/ElasticsearchHandler.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/handler/impl/elasticsearch/ElasticsearchHandler.java
@@ -1,0 +1,262 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.hadoop.handler.impl.elasticsearch;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Properties;
+import java.util.UUID;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.elasticsearch.hadoop.cfg.CompositeSettings;
+import org.elasticsearch.hadoop.cfg.ConfigurationOptions;
+import org.elasticsearch.hadoop.cfg.InternalConfigurationOptions;
+import org.elasticsearch.hadoop.cfg.PropertiesSettings;
+import org.elasticsearch.hadoop.cfg.Settings;
+import org.elasticsearch.hadoop.handler.ErrorCollector;
+import org.elasticsearch.hadoop.handler.ErrorHandler;
+import org.elasticsearch.hadoop.handler.Exceptional;
+import org.elasticsearch.hadoop.handler.HandlerResult;
+import org.elasticsearch.hadoop.rest.Resource;
+import org.elasticsearch.hadoop.rest.RestClient;
+import org.elasticsearch.hadoop.rest.RestRepository;
+import org.elasticsearch.hadoop.rest.RestService;
+import org.elasticsearch.hadoop.serialization.field.IndexExtractor;
+import org.elasticsearch.hadoop.util.BytesArray;
+import org.elasticsearch.hadoop.util.ObjectUtils;
+import org.elasticsearch.hadoop.util.SettingsUtils;
+import org.elasticsearch.hadoop.util.StringUtils;
+import org.elasticsearch.hadoop.util.ecs.ElasticCommonSchema;
+import org.elasticsearch.hadoop.util.ecs.ElasticCommonSchema.TemplateBuilder;
+import org.elasticsearch.hadoop.util.ecs.MessageTemplate;
+import org.elasticsearch.hadoop.util.unit.Booleans;
+
+/**
+ * Generic Error Handler that converts error events into JSON documents, and stores them in an Elasticsearch index.
+ * <p>
+ * Handler results returned from this handler are configurable; In the case that the event is successfully written to
+ * Elasticsearch it returns HANDLED by default and if the event cannot be written for any reason it returns ABORT by
+ * default.
+ * <p>
+ *
+ *
+ * @param <I>
+ * @param <O>
+ * @param <C>
+ */
+public class ElasticsearchHandler<I extends Exceptional, O, C extends ErrorCollector<O>> implements ErrorHandler<I, O, C> {
+
+    private static final Log LOG = LogFactory.getLog(ElasticsearchHandler.class);
+
+    private static final String CONST_EVENT_CATEGORY = "error";
+
+    // Config Names
+    /// Return logic: Use "return".<case>[.reason]
+    public static final String CONF_RETURN_VALUE = "return.default";
+    public static final String CONF_RETURN_VALUE_DEFAULT = HandlerResult.HANDLED.toString();
+    public static final String CONF_RETURN_ERROR = "return.error";
+    public static final String CONF_RETURN_ERROR_DEFAULT = HandlerResult.ABORT.toString();
+    private static final String CONF_PASS_REASON_SUFFIX = "reason";
+
+    /// Document metadata
+    public static final String CONF_LABEL = "label";
+    public static final String CONF_TAGS = "tags";
+
+    /// Client configuration
+    public static final String CONF_CLIENT_NODES = "client.nodes";
+    public static final String CONF_CLIENT_PORT = "client.port";
+    public static final String CONF_CLIENT_RESOURCE = "client.resource";
+    public static final String CONF_CLIENT_INHERIT= "client.inherit";
+    public static final String CONF_CLIENT_CONF = "client.conf";
+
+    // Settings
+    private HandlerResult returnDefault;
+    private String successReason;
+    private HandlerResult returnError;
+    private String errorReason;
+
+    // State
+    private Settings rootSettings;
+    private Settings clientSettings;
+    private EventConverter<I> eventConverter;
+    private MessageTemplate messageTemplate;
+    private boolean initialized;
+    private Resource endpoint;
+    private RestRepository writeClient;
+
+    public static <I extends Exceptional, O, C extends ErrorCollector<O>> ElasticsearchHandler<I, O, C> create(Settings rootSettings, EventConverter<I> converter) {
+        return new ElasticsearchHandler<I, O, C>(rootSettings, converter);
+    }
+
+    public ElasticsearchHandler(Settings rootSettings, EventConverter<I> eventConverter) {
+        this.rootSettings = rootSettings;
+        this.eventConverter = eventConverter;
+    }
+
+    @Override
+    public void init(Properties properties) {
+        // Collect Handler settings
+        Settings handlerSettings = new PropertiesSettings(properties);
+        boolean inheritRoot = true;
+        if (handlerSettings.getProperty(CONF_CLIENT_INHERIT) != null) {
+            inheritRoot = Booleans.parseBoolean(handlerSettings.getProperty(CONF_CLIENT_INHERIT));
+        }
+
+        // Exception: Should persist transport pooling key if it is preset in the root config, regardless of the inherit settings.
+        if (SettingsUtils.hasJobTransportPoolingKey(rootSettings)) {
+            String jobKey = SettingsUtils.getJobTransportPoolingKey(rootSettings);
+            // We want to use a different job key based on the current one since error handlers might write
+            // to other clusters or have seriously different settings from the current rest client.
+            String newJobKey = jobKey + "_" + UUID.randomUUID().toString();
+            // Place under the client configuration for the handler
+            handlerSettings.setProperty(CONF_CLIENT_CONF + "." + InternalConfigurationOptions.INTERNAL_TRANSPORT_POOLING_KEY, newJobKey);
+        }
+
+        // Gather high level configs and push to client conf level
+        resolveProperty(CONF_CLIENT_NODES, CONF_CLIENT_CONF + "." + ConfigurationOptions.ES_NODES, handlerSettings);
+        resolveProperty(CONF_CLIENT_PORT, CONF_CLIENT_CONF + "." + ConfigurationOptions.ES_PORT, handlerSettings);
+        resolveProperty(CONF_CLIENT_RESOURCE, CONF_CLIENT_CONF + "." + ConfigurationOptions.ES_RESOURCE_WRITE, handlerSettings);
+        resolveProperty(CONF_CLIENT_RESOURCE, CONF_CLIENT_CONF + "." + ConfigurationOptions.ES_RESOURCE, handlerSettings);
+
+        // Inherit the original configuration or not
+        this.clientSettings = handlerSettings.getSettingsView(CONF_CLIENT_CONF);
+        if (inheritRoot) {
+            LOG.info("Elasticsearch Error Handler inheriting root configuration");
+            this.clientSettings = new CompositeSettings(Arrays.asList(clientSettings, rootSettings.excludeFilter("es.internal")));
+        } else {
+            LOG.info("Elasticsearch Error Handler proceeding without inheriting root configuration options as configured");
+        }
+
+        // Ensure no pattern in Index format, and extract the index to send errors to
+        Resource resource = new Resource(clientSettings, false);
+        IndexExtractor iformat = ObjectUtils.instantiate(clientSettings.getMappingIndexExtractorClassName(), handlerSettings);
+        iformat.compile(resource.toString());
+        if (iformat.hasPattern()) {
+            throw new IllegalArgumentException(String.format("Cannot use index format within Elasticsearch Error Handler. Format was [%s]", resource.toString()));
+        }
+        this.endpoint = resource;
+
+        // Configure ECS
+        ElasticCommonSchema schema = new ElasticCommonSchema();
+        TemplateBuilder templateBuilder = schema.buildTemplate()
+                .setEventCategory(CONST_EVENT_CATEGORY);
+
+        // Add any Labels and Tags to schema
+        for (Map.Entry entry: handlerSettings.getSettingsView(CONF_LABEL).asProperties().entrySet()) {
+            templateBuilder.addLabel(entry.getKey().toString(), entry.getValue().toString());
+        }
+        templateBuilder.addTags(StringUtils.tokenize(handlerSettings.getProperty(CONF_TAGS)));
+
+        // Configure template using event handler
+        templateBuilder = eventConverter.configureTemplate(templateBuilder);
+        this.messageTemplate = templateBuilder.build();
+
+        // Determine the behavior for successful write and error on write:
+        this.returnDefault = HandlerResult.valueOf(handlerSettings.getProperty(CONF_RETURN_VALUE, CONF_RETURN_VALUE_DEFAULT));
+        if (HandlerResult.PASS == returnDefault) {
+            this.successReason = handlerSettings.getProperty(CONF_RETURN_VALUE + "." + CONF_PASS_REASON_SUFFIX);
+        } else {
+            this.successReason = null;
+        }
+        this.returnError = HandlerResult.valueOf(handlerSettings.getProperty(CONF_RETURN_ERROR, CONF_RETURN_ERROR_DEFAULT));
+        if (HandlerResult.PASS == returnError) {
+            this.errorReason = handlerSettings.getProperty(CONF_RETURN_ERROR + "." + CONF_PASS_REASON_SUFFIX);
+        } else {
+            this.errorReason = null;
+        }
+    }
+
+    private void resolveProperty(String highLevelProperty, String explicitProperty, Settings subject) {
+        String confValue = subject.getProperty(highLevelProperty);
+        String explicitValue = subject.getProperty(explicitProperty);
+        if (StringUtils.hasText(confValue) && StringUtils.hasText(explicitValue)) {
+            LOG.warn(
+                    String.format("Found both [%s] and [%s] settings during elasticsearch handler init. Continuing " +
+                            "with value from [%s] (%s)",
+                            highLevelProperty,
+                            explicitProperty,
+                            highLevelProperty,
+                            confValue
+                    )
+            );
+        }
+        if (StringUtils.hasText(confValue)) {
+            subject.setProperty(explicitProperty, confValue);
+        }
+    }
+
+    private void lazyInitWrite() {
+        if (!initialized) {
+            this.initialized = true;
+            this.writeClient = RestService.createWriter(clientSettings, -1, 0, LOG).repository;
+        }
+    }
+
+    @Override
+    public HandlerResult onError(I entry, C collector) throws Exception {
+        HandlerResult result;
+        try {
+            lazyInitWrite();
+            if (isOpen()) {
+                putDocument(writeClient.getRestClient(), createErrorDocument(entry));
+                result = generateResult(returnDefault, successReason, collector);
+            } else {
+                result = generateResult(returnError, errorReason, collector);
+            }
+        } catch (Exception e) {
+            LOG.error("Could not send error handling data to ES", e);
+            result = generateResult(returnError, errorReason, collector);
+        }
+        return result;
+    }
+
+    private boolean isOpen() {
+        return writeClient != null;
+    }
+
+    private BytesArray createErrorDocument(I entry) throws IOException {
+        return eventConverter.generateEvent(entry, messageTemplate);
+    }
+
+    private void putDocument(RestClient client, BytesArray document) throws IOException {
+        client.postDocument(endpoint, document);
+    }
+
+    private HandlerResult generateResult(HandlerResult expectedResult, String possiblePassReason, C collector) {
+        if (HandlerResult.PASS == expectedResult) {
+            return collector.pass(possiblePassReason);
+        } else {
+            return expectedResult;
+        }
+    }
+
+    @Override
+    public void close() {
+        if (isOpen()) {
+            // TODO: look at collecting these stats some other way later.
+            if (clientSettings.getBatchRefreshAfterWrite()) {
+                writeClient.getRestClient().refresh(endpoint);
+            }
+            writeClient.close();
+        }
+    }
+}

--- a/mr/src/main/java/org/elasticsearch/hadoop/handler/impl/elasticsearch/ElasticsearchHandler.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/handler/impl/elasticsearch/ElasticsearchHandler.java
@@ -59,10 +59,9 @@ import org.elasticsearch.hadoop.util.unit.Booleans;
  * default.
  * <p>
  *
- *
- * @param <I>
- * @param <O>
- * @param <C>
+ * @param <I> type of error event
+ * @param <O> in case of retries, this is the type of the retry value
+ * @param <C> the type of error collector used
  */
 public class ElasticsearchHandler<I extends Exceptional, O, C extends ErrorCollector<O>> implements ErrorHandler<I, O, C> {
 
@@ -76,7 +75,7 @@ public class ElasticsearchHandler<I extends Exceptional, O, C extends ErrorColle
     public static final String CONF_RETURN_VALUE_DEFAULT = HandlerResult.HANDLED.toString();
     public static final String CONF_RETURN_ERROR = "return.error";
     public static final String CONF_RETURN_ERROR_DEFAULT = HandlerResult.ABORT.toString();
-    private static final String CONF_PASS_REASON_SUFFIX = "reason";
+    public static final String CONF_PASS_REASON_SUFFIX = "reason";
 
     /// Document metadata
     public static final String CONF_LABEL = "label";

--- a/mr/src/main/java/org/elasticsearch/hadoop/handler/impl/elasticsearch/EventConverter.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/handler/impl/elasticsearch/EventConverter.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.hadoop.handler.impl.elasticsearch;
+
+import java.io.IOException;
+
+import org.elasticsearch.hadoop.handler.Exceptional;
+import org.elasticsearch.hadoop.util.BytesArray;
+import org.elasticsearch.hadoop.util.ecs.ElasticCommonSchema;
+import org.elasticsearch.hadoop.util.ecs.MessageTemplate;
+
+/**
+ * Given a failure event that extends Exceptional, provide a mechanism for transforming its fields into an ECS document.
+ */
+public interface EventConverter<E extends Exceptional> {
+
+    /**
+     * Perform some logic against the template builder in order to inject values before the template is built.
+     */
+    ElasticCommonSchema.TemplateBuilder configureTemplate(ElasticCommonSchema.TemplateBuilder templateBuilder);
+
+    /**
+     * Converts an event into an ECS compliant document using the given message template.
+     * @param event Exceptional event to convert
+     * @param template template to use for conversion
+     * @return BytesArray containing the document data
+     */
+    BytesArray generateEvent(E event, MessageTemplate template) throws IOException;
+}

--- a/mr/src/main/java/org/elasticsearch/hadoop/rest/RestClient.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/rest/RestClient.java
@@ -248,9 +248,8 @@ public class RestClient implements Closeable, StatsAware {
         }
     }
 
-    public String postDocument(String indexAndType, BytesArray document) throws IOException {
-        // target+"/1", "{\"id\":\"1\",\"note\":\"First\",\"address\":[]}".getBytes()
-        Request request = new SimpleRequest(Method.POST, null, indexAndType, null, document);
+    public String postDocument(Resource resource, BytesArray document) throws IOException {
+        Request request = new SimpleRequest(Method.POST, null, resource.index() + "/" + resource.type(), null, document);
         Response response = execute(request, true);
         Object id = parseContent(response.body(), "_id");
         if (id == null || !StringUtils.hasText(id.toString())) {

--- a/mr/src/main/java/org/elasticsearch/hadoop/rest/RestClient.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/rest/RestClient.java
@@ -54,7 +54,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -92,10 +91,13 @@ public class RestClient implements Closeable, StatsAware {
     }
 
     public RestClient(Settings settings) {
-        network = new NetworkClient(settings);
+        this(settings, new NetworkClient(settings));
+    }
 
-        scrollKeepAlive = TimeValue.timeValueMillis(settings.getScrollKeepAlive());
-        indexReadMissingAsEmpty = settings.getIndexReadMissingAsEmpty();
+    RestClient(Settings settings, NetworkClient networkClient) {
+        this.network = networkClient;
+        this.scrollKeepAlive = TimeValue.timeValueMillis(settings.getScrollKeepAlive());
+        this.indexReadMissingAsEmpty = settings.getIndexReadMissingAsEmpty();
 
         String retryPolicyName = settings.getBatchWriteRetryPolicy();
 
@@ -106,10 +108,10 @@ public class RestClient implements Closeable, StatsAware {
             retryPolicyName = NoHttpRetryPolicy.class.getName();
         }
 
-        retryPolicy = ObjectUtils.instantiate(retryPolicyName, settings);
+        this.retryPolicy = ObjectUtils.instantiate(retryPolicyName, settings);
         // Assume that the elasticsearch major version is the latest if the version is not already present in the settings
-        internalVersion = settings.getInternalVersionOrLatest();
-        errorExtractor = new ErrorExtractor(internalVersion);
+        this.internalVersion = settings.getInternalVersionOrLatest();
+        this.errorExtractor = new ErrorExtractor(internalVersion);
     }
 
     public List<NodeInfo> getHttpNodes(boolean clientNodeOnly) {
@@ -244,6 +246,22 @@ public class RestClient implements Closeable, StatsAware {
         } catch (IOException ex) {
             throw new EsHadoopParsingException(ex);
         }
+    }
+
+    public String postDocument(String indexAndType, BytesArray document) throws IOException {
+        // target+"/1", "{\"id\":\"1\",\"note\":\"First\",\"address\":[]}".getBytes()
+        Request request = new SimpleRequest(Method.POST, null, indexAndType, null, document);
+        Response response = execute(request, true);
+        Object id = parseContent(response.body(), "_id");
+        if (id == null || !StringUtils.hasText(id.toString())) {
+            throw new EsHadoopInvalidRequest(
+                    String.format("Could not determine successful write operation. Request[%s > %s] Response[%s]",
+                            request.method(), request.path(),
+                            IOUtils.asString(response.body())
+                    )
+            );
+        }
+        return id.toString();
     }
 
     public void refresh(Resource resource) {

--- a/mr/src/main/java/org/elasticsearch/hadoop/rest/SimpleRequest.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/rest/SimpleRequest.java
@@ -85,6 +85,30 @@ public class SimpleRequest implements Request {
     }
 
     @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        SimpleRequest request = (SimpleRequest) o;
+
+        if (method != request.method) return false;
+        if (uri != null ? !uri.equals(request.uri) : request.uri != null) return false;
+        if (path != null ? !path.equals(request.path) : request.path != null) return false;
+        if (params != null ? !params.equals(request.params) : request.params != null) return false;
+        return body != null ? body.equals(request.body) : request.body == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = method != null ? method.hashCode() : 0;
+        result = 31 * result + (uri != null ? uri.hashCode() : 0);
+        result = 31 * result + (path != null ? path.hashCode() : 0);
+        result = 31 * result + (params != null ? params.hashCode() : 0);
+        result = 31 * result + (body != null ? body.hashCode() : 0);
+        return result;
+    }
+
+    @Override
     public String toString() {
         StringBuilder sb = new StringBuilder(method.name());
         sb.append("@");

--- a/mr/src/main/java/org/elasticsearch/hadoop/rest/bulk/handler/impl/BulkErrorEventConverter.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/rest/bulk/handler/impl/BulkErrorEventConverter.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.hadoop.rest.bulk.handler.impl;
+
+import java.io.IOException;
+
+import org.elasticsearch.hadoop.handler.impl.elasticsearch.BaseEventConverter;
+import org.elasticsearch.hadoop.rest.bulk.handler.BulkWriteFailure;
+import org.elasticsearch.hadoop.util.IOUtils;
+
+/**
+ * Event handler used by Elasticsearch Handler to convert bulk failures into ECS fields
+ */
+public class BulkErrorEventConverter extends BaseEventConverter<BulkWriteFailure> {
+
+    public BulkErrorEventConverter() {
+        super("bulk_failure", "Encountered Bulk Failure");
+    }
+
+    /**
+     * Visible for testing
+     */
+    @Override
+    public String getRawEvent(BulkWriteFailure event) throws IOException {
+        return IOUtils.asString(event.getEntryContents());
+    }
+}

--- a/mr/src/main/java/org/elasticsearch/hadoop/rest/bulk/handler/impl/BulkWriteHandlerLoader.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/rest/bulk/handler/impl/BulkWriteHandlerLoader.java
@@ -5,6 +5,7 @@ import org.elasticsearch.hadoop.handler.ErrorHandler;
 import org.elasticsearch.hadoop.handler.impl.AbortOnFailure;
 import org.elasticsearch.hadoop.handler.impl.AbstractHandlerLoader;
 import org.elasticsearch.hadoop.handler.impl.DropAndLog;
+import org.elasticsearch.hadoop.handler.impl.elasticsearch.ElasticsearchHandler;
 import org.elasticsearch.hadoop.rest.bulk.handler.BulkWriteFailure;
 import org.elasticsearch.hadoop.rest.bulk.handler.DelayableErrorCollector;
 import org.elasticsearch.hadoop.rest.bulk.handler.IBulkWriteErrorHandler;
@@ -37,14 +38,18 @@ public class BulkWriteHandlerLoader extends AbstractHandlerLoader<IBulkWriteErro
         switch (handlerName) {
             case FAIL:
                 genericHandler = AbortOnFailure.create();
-                return new DelegatingErrorHandler(genericHandler);
+                break;
             case LOG:
                 genericHandler = DropAndLog.create(new BulkLogRenderer());
-                return new DelegatingErrorHandler(genericHandler);
+                break;
+            case ES:
+                genericHandler = ElasticsearchHandler.create(getSettings(), new BulkErrorEventConverter());
+                break;
             default:
                 throw new EsHadoopIllegalArgumentException(
                         "Could not find default implementation for built in handler type [" + handlerName + "]"
                 );
         }
+        return new DelegatingErrorHandler(genericHandler);
     }
 }

--- a/mr/src/main/java/org/elasticsearch/hadoop/serialization/bulk/BulkEntryWriter.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/serialization/bulk/BulkEntryWriter.java
@@ -31,7 +31,6 @@ import org.elasticsearch.hadoop.handler.HandlerResult;
 import org.elasticsearch.hadoop.serialization.EsHadoopSerializationException;
 import org.elasticsearch.hadoop.serialization.handler.SerdeErrorCollector;
 import org.elasticsearch.hadoop.serialization.handler.write.ISerializationErrorHandler;
-import org.elasticsearch.hadoop.serialization.handler.write.SerializationErrorHandler;
 import org.elasticsearch.hadoop.serialization.handler.write.SerializationFailure;
 import org.elasticsearch.hadoop.serialization.handler.write.impl.SerializationHandlerLoader;
 import org.elasticsearch.hadoop.util.Assert;
@@ -75,7 +74,7 @@ public class BulkEntryWriter {
                 // Set up error collector
                 SerdeErrorCollector<Object> errorCollector = new SerdeErrorCollector<Object>();
 
-                // Attempmt failure handling
+                // Attempt failure handling
                 Exception abortException = serializationException;
                 handlerloop:
                 for (ISerializationErrorHandler serializationErrorHandler : serializationErrorHandlers) {

--- a/mr/src/main/java/org/elasticsearch/hadoop/serialization/handler/read/impl/DeserializationEventConverter.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/serialization/handler/read/impl/DeserializationEventConverter.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.hadoop.serialization.handler.read.impl;
+
+import java.io.IOException;
+
+import org.elasticsearch.hadoop.handler.impl.elasticsearch.BaseEventConverter;
+import org.elasticsearch.hadoop.serialization.handler.read.DeserializationFailure;
+import org.elasticsearch.hadoop.util.IOUtils;
+
+public class DeserializationEventConverter extends BaseEventConverter<DeserializationFailure> {
+
+    public DeserializationEventConverter() {
+        super("deserialization_failure", "Could not read record");
+    }
+
+    @Override
+    public String getRawEvent(DeserializationFailure event) throws IOException {
+        return IOUtils.asString(event.getHitContents());
+    }
+}

--- a/mr/src/main/java/org/elasticsearch/hadoop/serialization/handler/read/impl/DeserializationHandlerLoader.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/serialization/handler/read/impl/DeserializationHandlerLoader.java
@@ -25,6 +25,7 @@ import org.elasticsearch.hadoop.handler.ErrorHandler;
 import org.elasticsearch.hadoop.handler.impl.AbortOnFailure;
 import org.elasticsearch.hadoop.handler.impl.AbstractHandlerLoader;
 import org.elasticsearch.hadoop.handler.impl.DropAndLog;
+import org.elasticsearch.hadoop.handler.impl.elasticsearch.ElasticsearchHandler;
 import org.elasticsearch.hadoop.serialization.handler.read.DeserializationFailure;
 import org.elasticsearch.hadoop.serialization.handler.read.IDeserializationErrorHandler;
 
@@ -53,14 +54,18 @@ public class DeserializationHandlerLoader extends AbstractHandlerLoader<IDeseria
         switch (handlerName) {
             case FAIL:
                 genericHandler = AbortOnFailure.create();
-                return new DelegatingErrorHandler(genericHandler);
+                break;
             case LOG:
                 genericHandler = DropAndLog.create(new DeserializationLogRenderer());
-                return new DelegatingErrorHandler(genericHandler);
+                break;
+            case ES:
+                genericHandler = ElasticsearchHandler.create(getSettings(), new DeserializationEventConverter());
+                break;
             default:
                 throw new EsHadoopIllegalArgumentException(
                         "Could not find default implementation for built in handler type [" + handlerName + "]"
                 );
         }
+        return new DelegatingErrorHandler(genericHandler);
     }
 }

--- a/mr/src/main/java/org/elasticsearch/hadoop/serialization/handler/write/impl/SerializationEventConverter.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/serialization/handler/write/impl/SerializationEventConverter.java
@@ -32,8 +32,8 @@ public class SerializationEventConverter extends BaseEventConverter<Serializatio
 
     @Override
     public String getRawEvent(SerializationFailure event) throws IOException {
-        // TODO - We should get this data from the currently available writer object
-        // ObjectUtils.instantiate(settings.getSerializerValueWriterClassName(), settings);
+        // TODO: toString doesn't reliably render the record's contents.
+        // This should show the contents of the record more cleanly...
         return event.getRecord().toString();
     }
 }

--- a/mr/src/main/java/org/elasticsearch/hadoop/serialization/handler/write/impl/SerializationEventConverter.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/serialization/handler/write/impl/SerializationEventConverter.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.hadoop.serialization.handler.write.impl;
+
+import java.io.IOException;
+
+import org.elasticsearch.hadoop.handler.impl.elasticsearch.BaseEventConverter;
+import org.elasticsearch.hadoop.serialization.handler.write.SerializationFailure;
+
+public class SerializationEventConverter extends BaseEventConverter<SerializationFailure> {
+
+    public SerializationEventConverter() {
+        super("serialization_failure", "Could not construct bulk entry from record");
+    }
+
+    @Override
+    public String getRawEvent(SerializationFailure event) throws IOException {
+        // TODO - We should get this data from the currently available writer object
+        // ObjectUtils.instantiate(settings.getSerializerValueWriterClassName(), settings);
+        return event.getRecord().toString();
+    }
+}

--- a/mr/src/main/java/org/elasticsearch/hadoop/serialization/handler/write/impl/SerializationHandlerLoader.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/serialization/handler/write/impl/SerializationHandlerLoader.java
@@ -25,6 +25,7 @@ import org.elasticsearch.hadoop.handler.ErrorHandler;
 import org.elasticsearch.hadoop.handler.impl.AbortOnFailure;
 import org.elasticsearch.hadoop.handler.impl.AbstractHandlerLoader;
 import org.elasticsearch.hadoop.handler.impl.DropAndLog;
+import org.elasticsearch.hadoop.handler.impl.elasticsearch.ElasticsearchHandler;
 import org.elasticsearch.hadoop.serialization.handler.write.ISerializationErrorHandler;
 import org.elasticsearch.hadoop.serialization.handler.write.SerializationFailure;
 
@@ -53,14 +54,18 @@ public class SerializationHandlerLoader extends AbstractHandlerLoader<ISerializa
         switch (handlerName) {
             case FAIL:
                 genericHandler = AbortOnFailure.create();
-                return new DelegatingErrorHandler(genericHandler);
+                break;
             case LOG:
                 genericHandler = DropAndLog.create(new SerializationLogRenderer());
-                return new DelegatingErrorHandler(genericHandler);
+                break;
+            case ES:
+                genericHandler = ElasticsearchHandler.create(getSettings(), new SerializationEventConverter());
+                break;
             default:
                 throw new EsHadoopIllegalArgumentException(
                         "Could not find default implementation for built in handler type [" + handlerName + "]"
                 );
         }
+        return new DelegatingErrorHandler(genericHandler);
     }
 }

--- a/mr/src/main/java/org/elasticsearch/hadoop/util/ecs/ElasticCommonSchema.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/util/ecs/ElasticCommonSchema.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.hadoop.util.ecs;
+
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+public class ElasticCommonSchema {
+
+    public static final String V0_992 = "0.992";
+
+    private final String version;
+
+    public ElasticCommonSchema() {
+        this(V0_992);
+    }
+
+    public ElasticCommonSchema(String version) {
+        this.version = version;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public TemplateBuilder buildTemplate() {
+        return new TemplateBuilder(this);
+    }
+
+    public static final class TemplateBuilder {
+        private ElasticCommonSchema schema;
+        private Map<String, String> labels;
+        private Set<String> tags;
+        private HostData host;
+        private String userName;
+        private String eventCategory;
+//        private String eventModule;
+        private String eventType;
+
+        private TemplateBuilder(ElasticCommonSchema schema) {
+            this.schema = schema;
+            this.labels = new LinkedHashMap<String, String>();
+            this.tags = new LinkedHashSet<String>();
+            this.host = null;
+            this.userName = null;
+            this.eventCategory = null;
+//            this.eventModule = null;
+            this.eventType = null;
+        }
+
+        public TemplateBuilder addLabel(String label, String value) {
+            this.labels.put(label, value);
+            return this;
+        }
+
+        public TemplateBuilder addLabels(Map<String, String> labels) {
+            this.labels.putAll(labels);
+            return this;
+        }
+
+        public TemplateBuilder addTag(String tag) {
+            this.tags.add(tag);
+            return this;
+        }
+
+        public TemplateBuilder addTags(Iterable<String> tags) {
+            for (String tag : tags) {
+                addTag(tag);
+            }
+            return this;
+        }
+
+        public TemplateBuilder setEventCategory(String eventCategory) {
+            this.eventCategory = eventCategory;
+            return this;
+        }
+
+//        public TemplateBuilder setEventModule(String eventModule) {
+//            this.eventModule = eventModule;
+//            return this;
+//        }
+
+        public TemplateBuilder setEventType(String eventType) {
+            this.eventType = eventType;
+            return this;
+        }
+
+        public MessageTemplate build() {
+            if (host == null) {
+                host = HostData.getInstance();
+            }
+
+            return new MessageTemplate(schema, labels, tags, host, eventCategory, eventType);
+        }
+    }
+}

--- a/mr/src/main/java/org/elasticsearch/hadoop/util/ecs/ElasticCommonSchema.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/util/ecs/ElasticCommonSchema.java
@@ -51,9 +51,7 @@ public class ElasticCommonSchema {
         private Map<String, String> labels;
         private Set<String> tags;
         private HostData host;
-        private String userName;
         private String eventCategory;
-//        private String eventModule;
         private String eventType;
 
         private TemplateBuilder(ElasticCommonSchema schema) {
@@ -61,9 +59,7 @@ public class ElasticCommonSchema {
             this.labels = new LinkedHashMap<String, String>();
             this.tags = new LinkedHashSet<String>();
             this.host = null;
-            this.userName = null;
             this.eventCategory = null;
-//            this.eventModule = null;
             this.eventType = null;
         }
 
@@ -93,11 +89,6 @@ public class ElasticCommonSchema {
             this.eventCategory = eventCategory;
             return this;
         }
-
-//        public TemplateBuilder setEventModule(String eventModule) {
-//            this.eventModule = eventModule;
-//            return this;
-//        }
 
         public TemplateBuilder setEventType(String eventType) {
             this.eventType = eventType;

--- a/mr/src/main/java/org/elasticsearch/hadoop/util/ecs/FieldNames.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/util/ecs/FieldNames.java
@@ -77,13 +77,4 @@ public final class FieldNames {
     public static final String FIELD_HOST_TIMEZONE = "timezone";
     public static final String FIELD_HOST_TIMEZONE_OFFSET = "offset";
     public static final String FIELD_HOST_TIMEZONE_OFFSET_SEC = "sec";
-
-    // User: TBD (Could collect this from the UGI maybe?)
-    public static final String FIELD_USER = "user";
-    // user.name - (keyword) perhaps? This isn't as useful probably.
-    public static final String FIELD_USER_NAME = "name";
-
-    // Extensions:
-    public static final String FIELD_ERROR_HANDLER = "handler";
-    public static final String FIELD_ERROR_HANDLER_PASSES = "passes";
 }

--- a/mr/src/main/java/org/elasticsearch/hadoop/util/ecs/FieldNames.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/util/ecs/FieldNames.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.hadoop.util.ecs;
+
+public final class FieldNames {
+
+    private FieldNames() {
+        // No instances
+    }
+
+    // Fields Used:
+
+    // Base:
+    // @timestamp - (date) Current time when event is passed in to handler
+    public static final String FIELD_TIMESTAMP = "@timestamp";
+    // tags - ([keyword]) User providable field
+    public static final String FIELD_TAGS = "tags";
+    // labels - (object{keyword}) User providable fields
+    public static final String FIELD_LABELS = "labels";
+    // message - (text) Concatenated message data. TBD
+    public static final String FIELD_MESSAGE= "message";
+
+    // Error:
+    public static final String FIELD_ERROR = "error";
+    // error.message - (text) Original error message.
+    public static final String FIELD_ERROR_MESSAGE = "message";
+    // error.code - (keyword) (TBD) Can this be the exception type?
+    public static final String FIELD_ERROR_CODE = "code";
+
+    // Event:
+    public static final String FIELD_EVENT = "event";
+    // event.category - (keyword) TBD should this just be "error"?
+    public static final String FIELD_EVENT_CATEGORY = "category";
+    // event.type - (keyword) type of error handler
+    public static final String FIELD_EVENT_TYPE = "type";
+    // event.module - (keyword) does this make sense?
+    public static final String FIELD_EVENT_MODULE = "module";
+    // event.raw - (keyword) This might end up being the stringafied original cause (json data/bulk entry/record info)
+    public static final String FIELD_EVENT_RAW = "raw";
+    // event.version - (keyword) version of ECS used.
+    public static final String FIELD_EVENT_VERSION = "version";
+
+    // Host:
+    public static final String FIELD_HOST = "host";
+    // host.name - (keyword) Can we get this easily?
+    public static final String FIELD_HOST_NAME = "name";
+    // host.ip - (ip) Could do a reverse lookup?
+    public static final String FIELD_HOST_IP = "ip";
+    // host.architecture - (keyword) Get this from Java (x86_64)
+    public static final String FIELD_HOST_ARCHITECTURE = "architecture";
+
+    // Host OS:
+    public static final String FIELD_HOST_OS = "os";
+    // host.os.name - (keyword) Get from Java. (Mac OS X)
+    public static final String FIELD_HOST_OS_NAME = "name";
+    // host.os.version - (keyword) Get from java (10.12.6)
+    public static final String FIELD_HOST_OS_VERSION = "version";
+
+    // host.timezone.offset.sec - (long) default timezone
+    public static final String FIELD_HOST_TIMEZONE = "timezone";
+    public static final String FIELD_HOST_TIMEZONE_OFFSET = "offset";
+    public static final String FIELD_HOST_TIMEZONE_OFFSET_SEC = "sec";
+
+    // User: TBD (Could collect this from the UGI maybe?)
+    public static final String FIELD_USER = "user";
+    // user.name - (keyword) perhaps? This isn't as useful probably.
+    public static final String FIELD_USER_NAME = "name";
+
+    // Extensions:
+    public static final String FIELD_ERROR_HANDLER = "handler";
+    public static final String FIELD_ERROR_HANDLER_PASSES = "passes";
+}

--- a/mr/src/main/java/org/elasticsearch/hadoop/util/ecs/HostData.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/util/ecs/HostData.java
@@ -1,0 +1,197 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.hadoop.util.ecs;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.TimeZone;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+/**
+ * Collects and stores Host information for use across the entire active JVM
+ */
+public final class HostData {
+
+    private static final Log LOG = LogFactory.getLog(HostData.class);
+    private static volatile HostData INSTANCE;
+
+    public static HostData getInstance() {
+        if (INSTANCE == null) {
+            synchronized (HostData.class) {
+                if (INSTANCE == null) {
+                    INSTANCE = collectHostData();
+                }
+            }
+        }
+        return INSTANCE;
+    }
+
+    private static HostData collectHostData() {
+        String osName = getPropOrNull("os.name");
+        String osVersion = getPropOrNull("os.version");
+        String osArch = getPropOrNull("os.arch");
+
+        InetAddress localAddress;
+        try {
+            localAddress = InetAddress.getLocalHost();
+        } catch (UnknownHostException e) {
+            // Swallow and set the host info to null;
+            LOG.warn("Could not collect host information for error tracing. Continuing with null host info.", e);
+            localAddress = null;
+        }
+
+        String hostName;
+        String hostip;
+        if (localAddress != null) {
+            hostName = localAddress.getHostName();
+            hostip = localAddress.getHostAddress();
+        } else {
+            hostName = null;
+            hostip = null;
+        }
+
+        Long hostTz = TimeUnit.SECONDS.convert(TimeZone.getDefault().getRawOffset(), TimeUnit.MILLISECONDS);
+
+        return new HostData(hostName, hostip, hostTz, osName, osVersion, osArch);
+    }
+
+    private static String getPropOrNull(String prop) {
+        try {
+            // TODO: Should these privileged blocks be moved further up the call stack?
+            return AccessController.doPrivileged(new GetPropAction(prop));
+        } catch (SecurityException se) {
+            return null;
+        }
+    }
+
+    private static class GetPropAction implements PrivilegedAction<String>{
+        private final String propName;
+
+        GetPropAction(String propName) {
+            this.propName = propName;
+        }
+
+        @Override
+        public String run() {
+            return System.getProperty(propName);
+        }
+    }
+
+    public static HostData emptyHostData() {
+        return new HostData(null, null, null, null, null, null);
+    }
+
+    private final boolean hasData;
+    private final String name;
+    private final String ip;
+    private final Long timezoneOffsetSec;
+    private final String osName;
+    private final String osVersion;
+    private final String architecture;
+
+    private HostData(String hostName, String hostIp, Long hostTzOffset, String osName, String osVersion, String osArch) {
+        this.name = hostName;
+        this.ip = hostIp;
+        this.timezoneOffsetSec = hostTzOffset;
+        this.osName = osName;
+        this.osVersion = osVersion;
+        this.architecture = osArch;
+
+        boolean hasData = (hostName != null);
+        hasData |= (hostIp != null);
+        hasData |= (hostTzOffset != null);
+        hasData |= (osName != null);
+        hasData |= (osVersion != null);
+        hasData |= (osArch != null);
+        this.hasData = hasData;
+    }
+
+    public boolean hasData() {
+        return hasData;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getIp() {
+        return ip;
+    }
+
+    public Long getTimezoneOffsetSec() {
+        return timezoneOffsetSec;
+    }
+
+    public String getOsName() {
+        return osName;
+    }
+
+    public String getOsVersion() {
+        return osVersion;
+    }
+
+    public String getArchitecture() {
+        return architecture;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        HostData hostData = (HostData) o;
+
+        if (name != null ? !name.equals(hostData.name) : hostData.name != null) return false;
+        if (ip != null ? !ip.equals(hostData.ip) : hostData.ip != null) return false;
+        if (timezoneOffsetSec != null ? !timezoneOffsetSec.equals(hostData.timezoneOffsetSec) : hostData.timezoneOffsetSec != null)
+            return false;
+        if (osName != null ? !osName.equals(hostData.osName) : hostData.osName != null) return false;
+        if (osVersion != null ? !osVersion.equals(hostData.osVersion) : hostData.osVersion != null) return false;
+        return architecture != null ? architecture.equals(hostData.architecture) : hostData.architecture == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = name != null ? name.hashCode() : 0;
+        result = 31 * result + (ip != null ? ip.hashCode() : 0);
+        result = 31 * result + (timezoneOffsetSec != null ? timezoneOffsetSec.hashCode() : 0);
+        result = 31 * result + (osName != null ? osName.hashCode() : 0);
+        result = 31 * result + (osVersion != null ? osVersion.hashCode() : 0);
+        result = 31 * result + (architecture != null ? architecture.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "HostData{" +
+                "hostName='" + name + '\'' +
+                ", hostIp='" + ip + '\'' +
+                ", hostTzOffset=" + timezoneOffsetSec +
+                ", osName='" + osName + '\'' +
+                ", osVersion='" + osVersion + '\'' +
+                ", osArch='" + architecture + '\'' +
+                '}';
+    }
+}

--- a/mr/src/main/java/org/elasticsearch/hadoop/util/ecs/MessageTemplate.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/util/ecs/MessageTemplate.java
@@ -1,0 +1,180 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.hadoop.util.ecs;
+
+import java.util.Map;
+import java.util.Set;
+
+import org.codehaus.jackson.map.annotate.JacksonStdImpl;
+import org.elasticsearch.hadoop.serialization.Generator;
+import org.elasticsearch.hadoop.serialization.json.JacksonJsonGenerator;
+import org.elasticsearch.hadoop.util.Assert;
+import org.elasticsearch.hadoop.util.BytesArray;
+import org.elasticsearch.hadoop.util.FastByteArrayOutputStream;
+
+public class MessageTemplate {
+
+    // Parent
+    private ElasticCommonSchema schema;
+
+    // Base
+    private Map<String, String> labels;
+    private Set<String> tags;
+
+    // Host
+    private HostData host;
+
+    // Event
+    private String eventCategory;
+    private String eventModule;
+    private String eventType;
+
+    // User
+    // TODO: TBD
+    public String userName;
+    // userName = System.getProperty("user.name");
+
+    public MessageTemplate(ElasticCommonSchema schema, Map<String, String> labels, Set<String> tags, HostData host,
+                           String eventCategory, String eventType) {
+        Assert.hasText(eventCategory, "Missing " + FieldNames.FIELD_EVENT_CATEGORY + " value for ECS template.");
+//        Assert.hasText(eventModule, "Missing " + FieldNames.FIELD_EVENT_MODULE + " value for ECS template.");
+        Assert.hasText(eventType, "Missing " + FieldNames.FIELD_EVENT_TYPE + " value for ECS template.");
+        this.schema = schema;
+        this.labels = labels;
+        this.tags = tags;
+        this.host = host;
+        this.eventCategory = eventCategory;
+//        this.eventModule = eventModule;
+        this.eventType = eventType;
+    }
+
+    public BytesArray generateMessage(String ts, String message, String exceptionType, String exceptionMessage, String rawEvent) {
+        Assert.hasText(ts, "Missing " + FieldNames.FIELD_TIMESTAMP + " value for ECS template.");
+        Assert.hasText(message, "Missing " + FieldNames.FIELD_MESSAGE + " value for ECS template.");
+        Assert.hasText(exceptionType, "Missing " + FieldNames.FIELD_ERROR_CODE + " value for ECS template.");
+        Assert.hasText(exceptionMessage, "Missing " + FieldNames.FIELD_ERROR_MESSAGE + " value for ECS template.");
+        Assert.hasText(rawEvent, "Missing " + FieldNames.FIELD_EVENT_RAW + " value for ECS template.");
+
+        FastByteArrayOutputStream outputStream = new FastByteArrayOutputStream();
+        JacksonJsonGenerator generator = new JacksonJsonGenerator(outputStream);
+        generator.usePrettyPrint();
+
+        generator.writeBeginObject();
+        {
+            // TS
+            generator.writeFieldName(FieldNames.FIELD_TIMESTAMP).writeString(ts);
+
+            // Tags
+            if (tags != null && !tags.isEmpty()) {
+                generator.writeFieldName(FieldNames.FIELD_TAGS).writeBeginArray();
+                for (String tag : tags) {
+                    generator.writeString(tag);
+                }
+                generator.writeEndArray();
+            }
+
+            // Labels
+            if (labels != null && !labels.isEmpty()) {
+                generator.writeFieldName(FieldNames.FIELD_LABELS).writeBeginObject();
+                for (Map.Entry<String, String> label : labels.entrySet()) {
+                    generator.writeFieldName(label.getKey()).writeString(label.getValue());
+                }
+                generator.writeEndObject();
+            }
+
+            // Message
+            generator.writeFieldName(FieldNames.FIELD_MESSAGE).writeString(message);
+
+            // Host
+            if (host != null && host.hasData()) {
+                generator.writeFieldName(FieldNames.FIELD_HOST).writeBeginObject();
+                {
+                    // Host info
+                    writeNullable(generator, FieldNames.FIELD_HOST_NAME, host.getName());
+                    writeNullable(generator, FieldNames.FIELD_HOST_IP, host.getIp());
+                    writeNullable(generator, FieldNames.FIELD_HOST_ARCHITECTURE, host.getArchitecture());
+
+                    // OS block
+                    if (host.getOsName() != null || host.getOsVersion() != null) {
+                        generator.writeFieldName(FieldNames.FIELD_HOST_OS).writeBeginObject();
+                        {
+                            writeNullable(generator, FieldNames.FIELD_HOST_OS_NAME, host.getOsName());
+                            writeNullable(generator, FieldNames.FIELD_HOST_OS_VERSION, host.getOsVersion());
+                        }
+                        generator.writeEndObject();
+                    }
+
+                    // TZ
+                    if (host.getTimezoneOffsetSec() != null) {
+                        generator.writeFieldName(FieldNames.FIELD_HOST_TIMEZONE).writeBeginObject();
+                        {
+                            generator.writeFieldName(FieldNames.FIELD_HOST_TIMEZONE_OFFSET).writeBeginObject();
+                            {
+                                generator.writeFieldName(FieldNames.FIELD_HOST_TIMEZONE_OFFSET_SEC)
+                                        .writeNumber(host.getTimezoneOffsetSec());
+                            }
+                            generator.writeEndObject();
+                        }
+                        generator.writeEndObject();
+                    }
+                }
+                generator.writeEndObject();
+            }
+
+            // Error
+            generator.writeFieldName(FieldNames.FIELD_ERROR).writeBeginObject();
+            {
+                generator.writeFieldName(FieldNames.FIELD_ERROR_CODE).writeString(exceptionType);
+                generator.writeFieldName(FieldNames.FIELD_ERROR_MESSAGE).writeString(exceptionMessage);
+            }
+            generator.writeEndObject();
+
+            // Event
+            generator.writeFieldName(FieldNames.FIELD_EVENT).writeBeginObject();
+            {
+                generator.writeFieldName(FieldNames.FIELD_EVENT_CATEGORY).writeString(eventCategory);
+//                generator.writeFieldName(FieldNames.FIELD_EVENT_MODULE).writeString(eventModule);
+                generator.writeFieldName(FieldNames.FIELD_EVENT_TYPE).writeString(eventType);
+                generator.writeFieldName(FieldNames.FIELD_EVENT_RAW).writeString(rawEvent);
+                generator.writeFieldName(FieldNames.FIELD_EVENT_VERSION).writeString(schema.getVersion());
+            }
+            generator.writeEndObject();
+
+//            // User TBD
+//            if (userName != null) {
+//                generator.writeFieldName(FieldNames.FIELD_USER).writeBeginObject();
+//                {
+//                    generator.writeFieldName(FieldNames.FIELD_USER_NAME).writeString(userName);
+//                }
+//                generator.writeEndObject();
+//            }
+        }
+        generator.writeEndObject();
+
+        generator.close();
+        return outputStream.bytes();
+    }
+
+    private void writeNullable(Generator generator, String key, String value) {
+        if (value != null) {
+            generator.writeFieldName(key).writeString(value);
+        }
+    }
+}

--- a/mr/src/main/java/org/elasticsearch/hadoop/util/ecs/MessageTemplate.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/util/ecs/MessageTemplate.java
@@ -43,25 +43,17 @@ public class MessageTemplate {
 
     // Event
     private String eventCategory;
-    private String eventModule;
     private String eventType;
-
-    // User
-    // TODO: TBD
-    public String userName;
-    // userName = System.getProperty("user.name");
 
     public MessageTemplate(ElasticCommonSchema schema, Map<String, String> labels, Set<String> tags, HostData host,
                            String eventCategory, String eventType) {
         Assert.hasText(eventCategory, "Missing " + FieldNames.FIELD_EVENT_CATEGORY + " value for ECS template.");
-//        Assert.hasText(eventModule, "Missing " + FieldNames.FIELD_EVENT_MODULE + " value for ECS template.");
         Assert.hasText(eventType, "Missing " + FieldNames.FIELD_EVENT_TYPE + " value for ECS template.");
         this.schema = schema;
         this.labels = labels;
         this.tags = tags;
         this.host = host;
         this.eventCategory = eventCategory;
-//        this.eventModule = eventModule;
         this.eventType = eventType;
     }
 
@@ -150,21 +142,11 @@ public class MessageTemplate {
             generator.writeFieldName(FieldNames.FIELD_EVENT).writeBeginObject();
             {
                 generator.writeFieldName(FieldNames.FIELD_EVENT_CATEGORY).writeString(eventCategory);
-//                generator.writeFieldName(FieldNames.FIELD_EVENT_MODULE).writeString(eventModule);
                 generator.writeFieldName(FieldNames.FIELD_EVENT_TYPE).writeString(eventType);
                 generator.writeFieldName(FieldNames.FIELD_EVENT_RAW).writeString(rawEvent);
                 generator.writeFieldName(FieldNames.FIELD_EVENT_VERSION).writeString(schema.getVersion());
             }
             generator.writeEndObject();
-
-//            // User TBD
-//            if (userName != null) {
-//                generator.writeFieldName(FieldNames.FIELD_USER).writeBeginObject();
-//                {
-//                    generator.writeFieldName(FieldNames.FIELD_USER_NAME).writeString(userName);
-//                }
-//                generator.writeEndObject();
-//            }
         }
         generator.writeEndObject();
 

--- a/mr/src/test/java/org/elasticsearch/hadoop/cfg/CompositeSettingsTest.java
+++ b/mr/src/test/java/org/elasticsearch/hadoop/cfg/CompositeSettingsTest.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.hadoop.cfg;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Properties;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class CompositeSettingsTest {
+
+    @Test
+    public void testGetProperty() {
+        Settings set1 = new PropertiesSettings();
+        set1.setProperty("test.prop.one", "val1");
+
+        Settings set2 = new PropertiesSettings();
+        set2.setProperty("test.prop.one", "val2");
+        set2.setProperty("test.prop.two", "val2");
+
+        Settings set3 = new PropertiesSettings();
+        set3.setProperty("test.prop.one", "val3");
+        set3.setProperty("test.prop.two", "val3");
+        set3.setProperty("test.prop.three", "val3");
+
+        Settings composite = new CompositeSettings(Arrays.asList(set1, set2, set3));
+
+        assertEquals("val1", composite.getProperty("test.prop.one"));
+        assertEquals("val2", composite.getProperty("test.prop.two"));
+        assertEquals("val3", composite.getProperty("test.prop.three"));
+    }
+
+    @Test
+    public void testSetProperty() {
+        Settings set1 = new PropertiesSettings();
+        set1.setProperty("test.prop.one", "val1");
+
+        Settings set2 = new PropertiesSettings();
+        set2.setProperty("test.prop.one", "val2");
+        set2.setProperty("test.prop.two", "val2");
+
+        Settings set3 = new PropertiesSettings();
+        set3.setProperty("test.prop.one", "val3");
+        set3.setProperty("test.prop.two", "val3");
+        set3.setProperty("test.prop.three", "val3");
+
+        Settings composite = new CompositeSettings(Arrays.asList(set1, set2, set3));
+        composite.setProperty("test.prop.zero", "val0");
+
+        assertEquals("val0", composite.getProperty("test.prop.zero"));
+        assertEquals("val1", composite.getProperty("test.prop.one"));
+        assertEquals("val2", composite.getProperty("test.prop.two"));
+        assertEquals("val3", composite.getProperty("test.prop.three"));
+
+        assertNull("Subconfigs contaminated", set1.getProperty("test.prop.zero"));
+        assertNull("Subconfigs contaminated", set2.getProperty("test.prop.zero"));
+        assertNull("Subconfigs contaminated", set3.getProperty("test.prop.zero"));
+    }
+
+    @Test
+    public void testCopy() {
+        Settings set1 = new PropertiesSettings();
+        set1.setProperty("test.prop.one", "val1");
+
+        Settings set2 = new PropertiesSettings();
+        set2.setProperty("test.prop.one", "val2");
+        set2.setProperty("test.prop.two", "val2");
+
+        Settings set3 = new PropertiesSettings();
+        set3.setProperty("test.prop.one", "val3");
+        set3.setProperty("test.prop.two", "val3");
+        set3.setProperty("test.prop.three", "val3");
+
+        Settings composite = new CompositeSettings(Arrays.asList(set1, set2, set3));
+        composite.setProperty("test.prop.zero", "val0");
+
+        Settings clonedComposite = composite.copy();
+
+        composite.setProperty("test.prop.zero", "nval0");
+        set1.setProperty("test.prop.one", "nval1");
+        set2.setProperty("test.prop.two", "nval2");
+        set3.setProperty("test.prop.three", "nval3");
+
+        assertEquals("val0", clonedComposite.getProperty("test.prop.zero"));
+        assertEquals("val1", clonedComposite.getProperty("test.prop.one"));
+        assertEquals("val2", clonedComposite.getProperty("test.prop.two"));
+        assertEquals("val3", clonedComposite.getProperty("test.prop.three"));
+
+        assertEquals("nval0", composite.getProperty("test.prop.zero"));
+        assertEquals("nval1", composite.getProperty("test.prop.one"));
+        assertEquals("nval2", composite.getProperty("test.prop.two"));
+        assertEquals("nval3", composite.getProperty("test.prop.three"));
+    }
+
+    @Test
+    public void testAsProperties() {
+        Settings set1 = new PropertiesSettings();
+        set1.setProperty("test.prop.one", "val1");
+
+        Settings set2 = new PropertiesSettings();
+        set2.setProperty("test.prop.one", "val2");
+        set2.setProperty("test.prop.two", "val2");
+
+        Settings set3 = new PropertiesSettings();
+        set3.setProperty("test.prop.one", "val3");
+        set3.setProperty("test.prop.two", "val3");
+        set3.setProperty("test.prop.three", "val3");
+
+        Settings composite = new CompositeSettings(Arrays.asList(set1, set2, set3));
+        composite.setProperty("test.prop.zero", "val0");
+
+        Properties props = composite.asProperties();
+
+        composite.setProperty("test.prop.zero", "nval0");
+        set1.setProperty("test.prop.one", "nval1");
+        set2.setProperty("test.prop.two", "nval2");
+        set3.setProperty("test.prop.three", "nval3");
+
+        assertEquals("val0", props.getProperty("test.prop.zero"));
+        assertEquals("val1", props.getProperty("test.prop.one"));
+        assertEquals("val2", props.getProperty("test.prop.two"));
+        assertEquals("val3", props.getProperty("test.prop.three"));
+
+        assertEquals("nval0", composite.getProperty("test.prop.zero"));
+        assertEquals("nval1", composite.getProperty("test.prop.one"));
+        assertEquals("nval2", composite.getProperty("test.prop.two"));
+        assertEquals("nval3", composite.getProperty("test.prop.three"));
+    }
+}

--- a/mr/src/test/java/org/elasticsearch/hadoop/cfg/FilteredSettingsTest.java
+++ b/mr/src/test/java/org/elasticsearch/hadoop/cfg/FilteredSettingsTest.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.hadoop.cfg;
+
+import java.util.Properties;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class FilteredSettingsTest {
+
+    @Test
+    public void copy() {
+        Properties baseProperties = new Properties();
+        baseProperties.put("test.key.one", "value1");
+        baseProperties.put("test.key.two", "value2");
+        baseProperties.put("test.config.one", "confValue1");
+
+        Settings base = new PropertiesSettings(baseProperties);
+        Settings filtered = base.excludeFilter("test.config");
+        Settings copied = filtered.copy();
+
+        filtered.setProperty("test.key.three", "value3");
+
+        assertNull("Copy operation was not a deep copy", copied.getProperty("test.key.three"));
+    }
+
+    @Test
+    public void getProperty() {
+        Properties baseProperties = new Properties();
+        baseProperties.put("test.key.one", "value1");
+        baseProperties.put("test.key.two", "value2");
+        baseProperties.put("test.config.one", "confValue1");
+
+        Settings base = new PropertiesSettings(baseProperties);
+        Settings filtered = base.excludeFilter("test.config");
+
+        assertNull("Property should be filtered out", filtered.getProperty("test.config.one"));
+        assertEquals("Could not read unfiltered property", "value1", filtered.getProperty("test.key.one"));
+    }
+
+    @Test
+    public void setProperty() {
+        Properties baseProperties = new Properties();
+        baseProperties.put("test.key.one", "value1");
+        baseProperties.put("test.key.two", "value2");
+        baseProperties.put("test.config.one", "confValue1");
+
+        Settings base = new PropertiesSettings(baseProperties);
+        Settings filtered = base.excludeFilter("test.config");
+
+        filtered.setProperty("test.config.two", "confValue2");
+
+        assertNull("Property should be filtered out", filtered.getProperty("test.config.one"));
+        assertNull("Property should be filtered out", filtered.getProperty("test.config.two"));
+        assertEquals("Could not read unfiltered property", "value1", filtered.getProperty("test.key.one"));
+    }
+
+    @Test
+    public void asProperties() {
+        Properties baseProperties = new Properties();
+        baseProperties.put("test.key.one", "value1");
+        baseProperties.put("test.key.two", "value2");
+        baseProperties.put("test.config.one", "confValue1");
+
+        Settings base = new PropertiesSettings(baseProperties);
+        Settings filtered = base.excludeFilter("test.config");
+
+        Properties filteredProperties = filtered.asProperties();
+
+        assertNull("Property should be filtered out", filteredProperties.getProperty("test.config.one"));
+        assertNull("Property should be filtered out", filteredProperties.getProperty("test.config.two"));
+        assertEquals("Could not read unfiltered property", "value1", filteredProperties.getProperty("test.key.one"));
+    }
+}

--- a/mr/src/test/java/org/elasticsearch/hadoop/rest/RestClientTest.java
+++ b/mr/src/test/java/org/elasticsearch/hadoop/rest/RestClientTest.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.hadoop.rest;
+
+import org.elasticsearch.hadoop.util.BytesArray;
+import org.elasticsearch.hadoop.util.FastByteArrayInputStream;
+import org.elasticsearch.hadoop.util.TestSettings;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class RestClientTest {
+
+    @Test
+    public void testPostDocumentSuccess() throws Exception {
+        String index = "index/type";
+        BytesArray document = new BytesArray("{\"field\":\"value\"}");
+        SimpleRequest request = new SimpleRequest(Request.Method.POST, null, index, null, document);
+        String response =
+                "{\n" +
+                "  \"_index\": \"index\",\n" +
+                "  \"_type\": \"type\",\n" +
+                "  \"_id\": \"AbcDefGhiJklMnoPqrS_\",\n" +
+                "  \"_version\": 1,\n" +
+                "  \"result\": \"created\",\n" +
+                "  \"_shards\": {\n" +
+                "    \"total\": 2,\n" +
+                "    \"successful\": 1,\n" +
+                "    \"failed\": 0\n" +
+                "  },\n" +
+                "  \"_seq_no\": 0,\n" +
+                "  \"_primary_term\": 1\n" +
+                "}";
+
+        NetworkClient mock = Mockito.mock(NetworkClient.class);
+        Mockito.when(mock.execute(Mockito.eq(request))).thenReturn(new SimpleResponse(201, new FastByteArrayInputStream(new BytesArray(response)), "localhost:9200"));
+
+        RestClient client = new RestClient(new TestSettings(), mock);
+
+        String id = client.postDocument(index, document);
+
+        assertEquals("AbcDefGhiJklMnoPqrS_", id);
+    }
+
+    @Test(expected = EsHadoopInvalidRequest.class)
+    public void testPostDocumentFailure() throws Exception {
+        String index = "index/type";
+        BytesArray document = new BytesArray("{\"field\":\"value\"}");
+        SimpleRequest request = new SimpleRequest(Request.Method.POST, null, index, null, document);
+        String response =
+                "{\n" +
+                "  \"error\": {\n" +
+                "    \"root_cause\": [\n" +
+                "      {\n" +
+                "        \"type\": \"io_exception\",\n" +
+                "        \"reason\": \"test failure\"\n" +
+                "      }\n" +
+                "    ],\n" +
+                "    \"type\": \"io_exception\",\n" +
+                "    \"reason\": \"test failure\",\n" +
+                "    \"caused_by\": {\n" +
+                "      \"type\": \"io_exception\",\n" +
+                "      \"reason\": \"This test needs to fail\"\n" +
+                "    }\n" +
+                "  },\n" +
+                "  \"status\": 400\n" +
+                "}";
+
+        NetworkClient mock = Mockito.mock(NetworkClient.class);
+        Mockito.when(mock.execute(Mockito.eq(request))).thenReturn(new SimpleResponse(400, new FastByteArrayInputStream(new BytesArray(response)), "localhost:9200"));
+
+        RestClient client = new RestClient(new TestSettings(), mock);
+
+        client.postDocument(index, document);
+
+        fail("Request should have failed");
+    }
+
+    @Test(expected = EsHadoopInvalidRequest.class)
+    public void testPostDocumentWeirdness() throws Exception {
+        String index = "index/type";
+        BytesArray document = new BytesArray("{\"field\":\"value\"}");
+        SimpleRequest request = new SimpleRequest(Request.Method.POST, null, index, null, document);
+        String response =
+                "{\n" +
+                "  \"_index\": \"index\",\n" +
+                "  \"_type\": \"type\",\n" +
+                "  \"definitely_not_an_id\": \"AbcDefGhiJklMnoPqrS_\",\n" + // Make the ID go away
+                "  \"_version\": 1,\n" +
+                "  \"result\": \"created\",\n" +
+                "  \"_shards\": {\n" +
+                "    \"total\": 2,\n" +
+                "    \"successful\": 1,\n" +
+                "    \"failed\": 0\n" +
+                "  },\n" +
+                "  \"_seq_no\": 0,\n" +
+                "  \"_primary_term\": 1\n" +
+                "}";
+
+        NetworkClient mock = Mockito.mock(NetworkClient.class);
+        Mockito.when(mock.execute(Mockito.eq(request))).thenReturn(new SimpleResponse(201, new FastByteArrayInputStream(new BytesArray(response)), "localhost:9200"));
+
+        RestClient client = new RestClient(new TestSettings(), mock);
+
+        String id = client.postDocument(index, document);
+
+        assertEquals("AbcDefGhiJklMnoPqrS_", id);
+    }
+}

--- a/mr/src/test/java/org/elasticsearch/hadoop/rest/RestClientTest.java
+++ b/mr/src/test/java/org/elasticsearch/hadoop/rest/RestClientTest.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.hadoop.rest;
 
+import org.elasticsearch.hadoop.cfg.Settings;
 import org.elasticsearch.hadoop.util.BytesArray;
 import org.elasticsearch.hadoop.util.FastByteArrayInputStream;
 import org.elasticsearch.hadoop.util.TestSettings;
@@ -33,6 +34,9 @@ public class RestClientTest {
     @Test
     public void testPostDocumentSuccess() throws Exception {
         String index = "index/type";
+        Settings settings = new TestSettings();
+        settings.setResourceWrite(index);
+        Resource writeResource = new Resource(settings, false);
         BytesArray document = new BytesArray("{\"field\":\"value\"}");
         SimpleRequest request = new SimpleRequest(Request.Method.POST, null, index, null, document);
         String response =
@@ -56,7 +60,7 @@ public class RestClientTest {
 
         RestClient client = new RestClient(new TestSettings(), mock);
 
-        String id = client.postDocument(index, document);
+        String id = client.postDocument(writeResource, document);
 
         assertEquals("AbcDefGhiJklMnoPqrS_", id);
     }
@@ -64,6 +68,9 @@ public class RestClientTest {
     @Test(expected = EsHadoopInvalidRequest.class)
     public void testPostDocumentFailure() throws Exception {
         String index = "index/type";
+        Settings settings = new TestSettings();
+        settings.setResourceWrite(index);
+        Resource writeResource = new Resource(settings, false);
         BytesArray document = new BytesArray("{\"field\":\"value\"}");
         SimpleRequest request = new SimpleRequest(Request.Method.POST, null, index, null, document);
         String response =
@@ -90,7 +97,7 @@ public class RestClientTest {
 
         RestClient client = new RestClient(new TestSettings(), mock);
 
-        client.postDocument(index, document);
+        client.postDocument(writeResource, document);
 
         fail("Request should have failed");
     }
@@ -98,6 +105,9 @@ public class RestClientTest {
     @Test(expected = EsHadoopInvalidRequest.class)
     public void testPostDocumentWeirdness() throws Exception {
         String index = "index/type";
+        Settings settings = new TestSettings();
+        settings.setResourceWrite(index);
+        Resource writeResource = new Resource(settings, false);
         BytesArray document = new BytesArray("{\"field\":\"value\"}");
         SimpleRequest request = new SimpleRequest(Request.Method.POST, null, index, null, document);
         String response =
@@ -121,7 +131,7 @@ public class RestClientTest {
 
         RestClient client = new RestClient(new TestSettings(), mock);
 
-        String id = client.postDocument(index, document);
+        String id = client.postDocument(writeResource, document);
 
         assertEquals("AbcDefGhiJklMnoPqrS_", id);
     }

--- a/mr/src/test/java/org/elasticsearch/hadoop/rest/bulk/handler/impl/BulkErrorEventConverterTest.java
+++ b/mr/src/test/java/org/elasticsearch/hadoop/rest/bulk/handler/impl/BulkErrorEventConverterTest.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.hadoop.rest.bulk.handler.impl;
+
+import java.io.IOException;
+import java.util.ArrayList;
+
+import org.elasticsearch.hadoop.rest.EsHadoopRemoteException;
+import org.elasticsearch.hadoop.rest.bulk.handler.BulkWriteFailure;
+import org.elasticsearch.hadoop.util.BytesArray;
+import org.elasticsearch.hadoop.util.DateUtils;
+import org.elasticsearch.hadoop.util.StringUtils;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class BulkErrorEventConverterTest {
+
+    @Test
+    public void generateEvent() throws IOException {
+        BytesArray bytes = new BytesArray("{\"action\":\"index\"}\n{\"field\":\"value\"}\n");
+
+        BulkErrorEventConverter eventConverter = new BulkErrorEventConverter();
+
+        BulkWriteFailure iaeFailure = new BulkWriteFailure(400, new IllegalArgumentException("garbage"), bytes, 4, new ArrayList<String>());
+        BulkWriteFailure remoteFailure = new BulkWriteFailure(400, new EsHadoopRemoteException("io_exception", "Faiiiil"), bytes, 4, new ArrayList<String>());
+
+        String rawEvent = eventConverter.getRawEvent(iaeFailure);
+        assertEquals(bytes.toString(), rawEvent);
+        String timestamp = eventConverter.getTimestamp(iaeFailure);
+        assertTrue(StringUtils.hasText(timestamp));
+        assertTrue(DateUtils.parseDate(timestamp).getTime().getTime() > 1L);
+        {
+            String exceptionType = eventConverter.renderExceptionType(iaeFailure);
+            assertEquals("illegal_argument_exception", exceptionType);
+        }
+        {
+            String exceptionType = eventConverter.renderExceptionType(remoteFailure);
+            assertEquals("io_exception", exceptionType);
+        }
+        {
+            String exceptionMessage = eventConverter.renderExceptionMessage(iaeFailure);
+            assertEquals("garbage", exceptionMessage);
+        }
+        {
+            String exceptionMessage = eventConverter.renderExceptionMessage(remoteFailure);
+            assertEquals("Faiiiil", exceptionMessage);
+        }
+        String eventMessage = eventConverter.renderEventMessage(iaeFailure);
+        assertEquals("Encountered Bulk Failure", eventMessage);
+
+    }
+}

--- a/mr/src/test/java/org/elasticsearch/hadoop/serialization/JsonUtils.java
+++ b/mr/src/test/java/org/elasticsearch/hadoop/serialization/JsonUtils.java
@@ -11,6 +11,8 @@ import org.codehaus.jackson.map.ObjectMapper;
 import org.codehaus.jackson.map.SerializationConfig;
 import org.elasticsearch.hadoop.rest.EsHadoopParsingException;
 import org.elasticsearch.hadoop.util.Assert;
+import org.elasticsearch.hadoop.util.BytesArray;
+import org.elasticsearch.hadoop.util.FastByteArrayInputStream;
 
 /**
  * A set of utilities to parse JSON in tests, the same way that the RestClient might parse json data.
@@ -26,6 +28,10 @@ public final class JsonUtils {
     }
 
     private JsonUtils() { }
+
+    public static Map<String, Object> asMap(BytesArray bytesArray) {
+        return asMap(new FastByteArrayInputStream(bytesArray));
+    }
 
     public static Map<String, Object> asMap(InputStream inputStream) {
         Map<String, Object> map;

--- a/mr/src/test/java/org/elasticsearch/hadoop/serialization/JsonUtils.java
+++ b/mr/src/test/java/org/elasticsearch/hadoop/serialization/JsonUtils.java
@@ -29,6 +29,10 @@ public final class JsonUtils {
 
     private JsonUtils() { }
 
+    public static Map<String, Object> asMap(String data) {
+        return asMap(new BytesArray(data));
+    }
+
     public static Map<String, Object> asMap(BytesArray bytesArray) {
         return asMap(new FastByteArrayInputStream(bytesArray));
     }

--- a/mr/src/test/java/org/elasticsearch/hadoop/serialization/handler/read/impl/DeserializationEventConverterTest.java
+++ b/mr/src/test/java/org/elasticsearch/hadoop/serialization/handler/read/impl/DeserializationEventConverterTest.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.hadoop.serialization.handler.read.impl;
+
+import java.util.ArrayList;
+
+import org.elasticsearch.hadoop.serialization.handler.read.DeserializationFailure;
+import org.elasticsearch.hadoop.util.BytesArray;
+import org.elasticsearch.hadoop.util.DateUtils;
+import org.elasticsearch.hadoop.util.StringUtils;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class DeserializationEventConverterTest {
+
+    @Test
+    public void generateEvent() throws Exception {
+        BytesArray bytes = new BytesArray("{\"_index\":\"index\",\"_source\":{\"field\":\"value\"}}");
+
+        DeserializationEventConverter eventConverter = new DeserializationEventConverter();
+
+        DeserializationFailure iaeFailure = new DeserializationFailure(new IllegalArgumentException("garbage"), bytes, new ArrayList<String>());
+
+        String rawEvent = eventConverter.getRawEvent(iaeFailure);
+        assertEquals(bytes.toString(), rawEvent);
+        String timestamp = eventConverter.getTimestamp(iaeFailure);
+        assertTrue(StringUtils.hasText(timestamp));
+        assertTrue(DateUtils.parseDate(timestamp).getTime().getTime() > 1L);
+        String exceptionType = eventConverter.renderExceptionType(iaeFailure);
+        assertEquals("illegal_argument_exception", exceptionType);
+        String exceptionMessage = eventConverter.renderExceptionMessage(iaeFailure);
+        assertEquals("garbage", exceptionMessage);
+        String eventMessage = eventConverter.renderEventMessage(iaeFailure);
+        assertEquals("Could not read record", eventMessage);
+    }
+}

--- a/mr/src/test/java/org/elasticsearch/hadoop/serialization/handler/write/impl/SerializationEventConverterTest.java
+++ b/mr/src/test/java/org/elasticsearch/hadoop/serialization/handler/write/impl/SerializationEventConverterTest.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.hadoop.serialization.handler.write.impl;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.elasticsearch.hadoop.serialization.handler.write.SerializationFailure;
+import org.elasticsearch.hadoop.util.DateUtils;
+import org.elasticsearch.hadoop.util.StringUtils;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class SerializationEventConverterTest {
+
+    @Test
+    public void generateEvent() throws Exception {
+        Map<String, Object> document = new HashMap<String, Object>();
+        document.put("field", "value");
+
+        SerializationEventConverter eventConverter = new SerializationEventConverter();
+
+        SerializationFailure iaeFailure = new SerializationFailure(new IllegalArgumentException("garbage"), document, new ArrayList<String>());
+
+        String rawEvent = eventConverter.getRawEvent(iaeFailure);
+        assertEquals("{field=value}", rawEvent);
+        String timestamp = eventConverter.getTimestamp(iaeFailure);
+        assertTrue(StringUtils.hasText(timestamp));
+        assertTrue(DateUtils.parseDate(timestamp).getTime().getTime() > 1L);
+        String exceptionType = eventConverter.renderExceptionType(iaeFailure);
+        assertEquals("illegal_argument_exception", exceptionType);
+        String exceptionMessage = eventConverter.renderExceptionMessage(iaeFailure);
+        assertEquals("garbage", exceptionMessage);
+        String eventMessage = eventConverter.renderEventMessage(iaeFailure);
+        assertEquals("Could not construct bulk entry from record", eventMessage);
+    }
+}

--- a/mr/src/test/java/org/elasticsearch/hadoop/util/ecs/ElasticCommonSchemaTest.java
+++ b/mr/src/test/java/org/elasticsearch/hadoop/util/ecs/ElasticCommonSchemaTest.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.hadoop.util.ecs;
+
+import org.elasticsearch.hadoop.util.BytesArray;
+import org.junit.Test;
+
+import static org.junit.Assert.assertNotNull;
+
+public class ElasticCommonSchemaTest {
+
+    @Test
+    public void testRenderMessage() throws Exception {
+        ElasticCommonSchema ecs = new ElasticCommonSchema(ElasticCommonSchema.V0_992);
+
+        MessageTemplate messageTemplate = ecs.buildTemplate()
+                .setEventCategory("error")
+                .setEventType("bulk")
+                .build();
+
+        BytesArray message = messageTemplate.generateMessage("2018-06-15T18:30:45-0500", "Boom!", "remote_exception", "BOOOOOM!", "{\"raw\":\"json\"}");
+
+        assertNotNull(message);
+        System.out.println(message);
+    }
+}

--- a/spark/core/test/scala/org/elasticsearch/spark/serialization/handler/write/imple/ScalaSerializationEventConverterTest.scala
+++ b/spark/core/test/scala/org/elasticsearch/spark/serialization/handler/write/imple/ScalaSerializationEventConverterTest.scala
@@ -1,0 +1,57 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.spark.serialization.handler.write.imple
+
+import java.util
+
+import org.elasticsearch.hadoop.serialization.handler.write.SerializationFailure
+import org.elasticsearch.hadoop.serialization.handler.write.impl.SerializationEventConverter
+import org.elasticsearch.hadoop.util.DateUtils
+import org.elasticsearch.hadoop.util.StringUtils
+import org.hamcrest.Matchers
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThat
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ScalaSerializationEventConverterTest {
+
+  @Test
+  def generateEvent(): Unit = {
+    val map = Map("field" -> "value")
+
+    val eventConverter = new SerializationEventConverter
+
+    val iaeFailure = new SerializationFailure(new IllegalArgumentException("garbage"), map, new util.ArrayList[String])
+
+    val rawEvent = eventConverter.getRawEvent(iaeFailure)
+    assertThat(rawEvent, Matchers.startsWith("Map(field -> value)"))
+    val timestamp = eventConverter.getTimestamp(iaeFailure)
+    assertTrue(StringUtils.hasText(timestamp))
+    assertTrue(DateUtils.parseDate(timestamp).getTime.getTime > 1L)
+    val exceptionType = eventConverter.renderExceptionType(iaeFailure)
+    assertEquals("illegal_argument_exception", exceptionType)
+    val exceptionMessage = eventConverter.renderExceptionMessage(iaeFailure)
+    assertEquals("garbage", exceptionMessage)
+    val eventMessage = eventConverter.renderEventMessage(iaeFailure)
+    assertEquals("Could not construct bulk entry from record", eventMessage)
+  }
+
+}

--- a/spark/sql-20/src/test/scala/org/elasticsearch/spark/sql/RowSerializationEventConverterTest.scala
+++ b/spark/sql-20/src/test/scala/org/elasticsearch/spark/sql/RowSerializationEventConverterTest.scala
@@ -1,0 +1,68 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.spark.sql
+
+import java.util
+
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.types.StringType
+import org.apache.spark.sql.types.StructField
+import org.apache.spark.sql.types.StructType
+import org.elasticsearch.hadoop.serialization.handler.write.SerializationFailure
+import org.elasticsearch.hadoop.serialization.handler.write.impl.SerializationEventConverter
+import org.elasticsearch.hadoop.util.DateUtils
+import org.elasticsearch.hadoop.util.StringUtils
+import org.hamcrest.Matchers.equalTo
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThat
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class RowSerializationEventConverterTest {
+
+  @Test
+  def generateEvent(): Unit = {
+    val schema = StructType(Seq(
+      StructField("field1", StringType),
+      StructField("field2", StringType),
+      StructField("field3", StringType)
+    ))
+    val row = Row("value1", "value2", "value3")
+
+    val eventConverter = new SerializationEventConverter
+
+    val iaeFailure = new SerializationFailure(new IllegalArgumentException("garbage"), (schema, row),
+      new util.ArrayList[String])
+
+    val rawEvent = eventConverter.getRawEvent(iaeFailure)
+    assertThat(rawEvent, equalTo("(StructType(StructField(field1,StringType,true), " +
+      "StructField(field2,StringType,true), StructField(field3,StringType,true)),[value1,value2,value3])"))
+    val timestamp = eventConverter.getTimestamp(iaeFailure)
+    assertTrue(StringUtils.hasText(timestamp))
+    assertTrue(DateUtils.parseDate(timestamp).getTime.getTime > 1L)
+    val exceptionType = eventConverter.renderExceptionType(iaeFailure)
+    assertEquals("illegal_argument_exception", exceptionType)
+    val exceptionMessage = eventConverter.renderExceptionMessage(iaeFailure)
+    assertEquals("garbage", exceptionMessage)
+    val eventMessage = eventConverter.renderEventMessage(iaeFailure)
+    assertEquals("Could not construct bulk entry from record", eventMessage)
+  }
+
+}


### PR DESCRIPTION
This PR adds a generic error handler implementation that captures error events from any of
the three error handler API's we support and sends them to an Elasticsearch index. Error
information is captured using the Elastic Common Schema (an early version of it), and may
be updated in the future as that specification solidifies.

```json
{
  "_index":"cascading-hadoop-pattern-errors",
  "_type":"data",
  "_id":"ZQ0NPmQBIDJ2Cy5AQlUG",
  "_score":1.0,
  "_source":{
    "@timestamp" : "2018-06-26T17:43:33.636-04:00",
    "message" : "Could not construct bulk entry from record",
    "host" : {
      "name" : "host",
      "ip" : "127.0.0.1",
      "architecture" : "x86_64",
      "os" : {
        "name" : "Mac OS X",
        "version" : "10.11.6"
      },
      "timezone" : {
        "offset" : {
          "sec" : -18000
        }
      }
    },
    "error" : {
      "code" : "fields_resolver_exception",
      "message" : "could not select fields: [{1}:'nonexistent'], from: [{5}:'id', 'name', 'url', 'picture', 'tag']"
    },
    "event" : {
      "category" : "error",
      "type" : "serialization_failure",
      "raw" : "cascading.scheme.ConcreteCall@2b64338e",
      "version" : "0.992"
    }
  }
}
```