### PR TITLE
change match to terms

### DIFF
--- a/spark/sql-13/src/main/scala/org/elasticsearch/spark/sql/DefaultSource.scala
+++ b/spark/sql-13/src/main/scala/org/elasticsearch/spark/sql/DefaultSource.scala
@@ -455,10 +455,10 @@ private[sql] case class ElasticsearchRelation(parameters: Map[String, String], @
        StringUtils.EMPTY
      } else  {
        if (SettingsUtils.isEs50(cfg)) {
-         s"""{"match":{"$attribute":${strings.mkString("\"", " ", "\"")}}}"""
+         s"""{"terms":{"$attribute":${strings.mkString("[\"", "\",\"", "\"]")}}}"""
        }
        else {
-         s"""{"query":{"match":{"$attribute":${strings.mkString("\"", " ", "\"")}}}}"""  
+         s"""{"query":{"terms":{"$attribute":${strings.mkString("[\"", "\",\"", "\"]")}}}}"""
        }
      }
     } else {
@@ -469,10 +469,10 @@ private[sql] case class ElasticsearchRelation(parameters: Map[String, String], @
       // if needed, add the strings as a match query
       } else str + {
         if (SettingsUtils.isEs50(cfg)) {
-          s""",{"match":{"$attribute":${strings.mkString("\"", " ", "\"")}}}"""
+          s""",{"terms":{"$attribute":${strings.mkString("[\"", "\",\"", "\"]")}}}"""
         }
         else {
-          s""",{"query":{"match":{"$attribute":${strings.mkString("\"", " ", "\"")}}}}"""
+          s""",{"query":{"terms":{"$attribute":${strings.mkString("[\"", "\",\"", "\"]")}}}}"""
         }
       }
     }

--- a/spark/sql-20/src/main/scala/org/elasticsearch/spark/sql/DefaultSource.scala
+++ b/spark/sql-20/src/main/scala/org/elasticsearch/spark/sql/DefaultSource.scala
@@ -524,10 +524,10 @@ private[sql] case class ElasticsearchRelation(parameters: Map[String, String], @
         StringUtils.EMPTY
      } else {
        if (SettingsUtils.isEs50(cfg)) {
-         s"""{"match":{"$attribute":${strings.mkString("\"", " ", "\"")}}}"""
+         s"""{"terms":{"$attribute":${strings.mkString("[\"", "\",\"", "\"]")}}}"""
        }
        else {
-         s"""{"query":{"match":{"$attribute":${strings.mkString("\"", " ", "\"")}}}}"""  
+         s"""{"query":{"terms":{"$attribute":${strings.mkString("[\"", "\",\"", "\"]")}}}}"""
        }
      }
     } else {
@@ -538,10 +538,10 @@ private[sql] case class ElasticsearchRelation(parameters: Map[String, String], @
       // if needed, add the strings as a match query
       } else str + {
         if (SettingsUtils.isEs50(cfg)) {
-          s""",{"match":{"$attribute":${strings.mkString("\"", " ", "\"")}}}"""
+          s""",{"terms":{"$attribute":${strings.mkString("[\"", "\",\"", "\"]")}}}"""
         }
         else {
-          s""",{"query":{"match":{"$attribute":${strings.mkString("\"", " ", "\"")}}}}"""
+          s""",{"query":{"terms":{"$attribute":${strings.mkString("[\"", "\",\"", "\"]")}}}}"""
         }
       }
     }


### PR DESCRIPTION
I created an external table for hive and I intend to read data from ES through HQL. 
When I run the following code. I can't find the data.

val sparkConf = new SparkConf()
val builder = SparkSession.builder().config(sparkConf).enableHiveSupport()
val spark1 = builder.getOrCreateBigquerySparkSession()
spark1.sql("set spark.bigquery.fullScan.enable=true")
spark1.sql("use olap")
spark1.sql("show tables").collect.foreach(println)
spark1.sparkContext.setLogLevel("fatal")  
spark1.sql("select * from table_name where city_code in ('010', '791') limit 100").show


But the following two HQL can all find data.
1. select * from table_name where city_code in ('010')
2. select * from table_name where city_code in ('791')

Reading source found that:  
When HQL was parsed into DSL,  in ('010','791') was parsed into "match": {"city_code": "010 791"}，

The right thing to do is： 
    "terms": {
      "city_code": ["010","791"]
    }