### PR TITLE
Add ability to specify sensitive settings through a keystore

### DIFF
--- a/docs/src/reference/asciidoc/core/configuration.adoc
+++ b/docs/src/reference/asciidoc/core/configuration.adoc
@@ -498,7 +498,7 @@ es.net.http.header.Max-Forwards = 10
 ==== Secure Settings
 
 added[6.4]
-`es.keystore.location`:: location of the secure settings keystore file (typically a URL, without a prefix it is interpreted as a classpath entry).
+`es.keystore.location`:: location of the secure settings keystore file (typically a URL, without a prefix it is interpreted as a classpath entry). See <<keystore>> for more info.
 
 added[2.1]
 [float]
@@ -679,6 +679,7 @@ Username/Password:: Set these through `es.net.http.auth.user` and `es.net.http.a
 PKI/X.509:: Use X.509 certificates to authenticate {eh} to {eh}. For this, one would need to setup the `keystore` containing the private key and certificate to the appropriate user (configured in {es}) and the `truststore` with the CA certificate used to sign the SSL/TLS certificates in the {es} cluster. That is one setup the key to authenticate {eh} and also to verify that is the right one. To do so, one should setup the `es.net.ssl.keystore.location` and `es.net.ssl.truststore.location` properties to indicate the `keystore` and `truststore` to use. It is recommended to have these secured through a password in which case `es.net.ssl.keystore.pass` and `es.net.ssl.truststore.pass` properties are required.
 
 [float]
+[[keystore]]
 ==== Secure Settings
 added[6.4.0]
 

--- a/docs/src/reference/asciidoc/core/configuration.adoc
+++ b/docs/src/reference/asciidoc/core/configuration.adoc
@@ -494,6 +494,11 @@ For example, here the user is setting the `Max-Forwards` HTTP header:
 es.net.http.header.Max-Forwards = 10
 ----
 
+[float]
+==== Secure Settings
+
+added[6.4]
+`es.keystore.location`:: location of the secure settings keystore file (typically a URL, without a prefix it is interpreted as a classpath entry)
 
 added[2.1]
 [float]
@@ -673,6 +678,66 @@ The authentication support in {eh} is of two types:
 Username/Password:: Set these through `es.net.http.auth.user` and `es.net.http.auth.pass` properties.
 PKI/X.509:: Use X.509 certificates to authenticate {eh} to {eh}. For this, one would need to setup the `keystore` containing the private key and certificate to the appropriate user (configured in {es}) and the `truststore` with the CA certificate used to sign the SSL/TLS certificates in the {es} cluster. That is one setup the key to authenticate {eh} and also to verify that is the right one. To do so, one should setup the `es.net.ssl.keystore.location` and `es.net.ssl.truststore.location` properties to indicate the `keystore` and `truststore` to use. It is recommended to have these secured through a password in which case `es.net.ssl.keystore.pass` and `es.net.ssl.truststore.pass` properties are required.
 
+[float]
+==== Secure Settings
+added[6.4.0]
+
+{eh} is configured using settings that sometimes contain sensitive information such as passwords. It may not be
+desirable for those property values to appear in the job configuration as plain text. For these situations, {eh} supports
+reading some secure properties from a keystore file.
+
+NOTE: The {eh} keystore currently only provides obfuscation. In the future, password protection will be added.
+
+Only the following configurations can be read from the secure settings:
+* `es.net.http.auth.pass`
+* `es.net.ssl.keystore.pass`
+* `es.net.ssl.truststore.pass`
+* `es.net.proxy.http.pass`
+* `es.net.proxy.https.pass`
+* `es.net.proxy.socks.pass`
+
+Provided with {eh} is a keytool program that will allow you to create and add entries to a compatible keystore file.
+[source,bash]
+----
+$> java -classpath path/to/eshadoop.jar org.elasticsearch.hadoop.cli.Keytool <command> <args>
+----
+
+To create a keystore file in your working directory, run the `create` command:
+[source,bash]
+----
+$> java -classpath path/to/eshadoop.jar org.elasticsearch.hadoop.cli.Keytool create
+$> ls
+esh.keystore
+----
+
+A list of the settings in the keystore is available with the `list` command:
+[source,bash]
+----
+$> java -classpath path/to/eshadoop.jar org.elasticsearch.hadoop.cli.Keytool list
+----
+
+Once a keystore file has been created, your sensitive settings can be added using the `add` command:
+[source,bash]
+----
+$> java -classpath path/to/eshadoop.jar org.elasticsearch.hadoop.cli.Keytool add the.setting.name.to.set
+----
+A prompt will appear and request the value for the setting. To pass the value through stdin, use the `--stdin` flag:
+[source,bash]
+----
+$> cat /file/containing/setting/value | java -classpath path/to/eshadoop.jar org.elasticsearch.hadoop.cli.Keytool add --stdin the.setting.name.to.set
+----
+
+To remove a setting from the keystore, use the `remove` command:
+[source,bash]
+----
+$> java -classpath path/to/eshadoop.jar org.elasticsearch.hadoop.cli.Keytool remove the.setting.name.to.set
+----
+
+Once your settings are all specified, you must make sure that the keystore is available on every node. This can
+be done by placing it on each node's local file system, or by adding the keystore to the job's classpath. Once the
+keystore has been added, its location must be specified with the `es.keystore.location`. To reference a local file,
+use a fully qualified file URL (ex `file:///path/to/file`). If the secure store is propagated using the command line, just
+use the file's name.
 
 [[logging]]
 == Logging

--- a/docs/src/reference/asciidoc/core/configuration.adoc
+++ b/docs/src/reference/asciidoc/core/configuration.adoc
@@ -505,7 +505,7 @@ added[2.1]
 ==== Basic Authentication
 
 `es.net.http.auth.user`:: Basic Authentication user name
-`es.net.http.auth.pass`:: Basic Authentication password
+`es.net.http.auth.pass`:: <<keystore,Securable>>. Basic Authentication password
 
 added[2.1]
 [float]
@@ -515,13 +515,13 @@ added[2.1]
 
 `es.net.ssl.keystore.location`:: key store (if used) location (typically a URL, without a prefix it is interpreted as a classpath entry)
 
-`es.net.ssl.keystore.pass`:: key store password
+`es.net.ssl.keystore.pass`:: <<keystore,Securable>>. key store password
 
 `es.net.ssl.keystore.type` (default JKS):: key store type. PK12 is a common, alternative format
 
 `es.net.ssl.truststore.location`:: trust store location (typically a URL, without a prefix it is interpreted as a classpath entry)
 
-`es.net.ssl.truststore.pass`:: trust store password
+`es.net.ssl.truststore.pass`:: <<keystore,Securable>>. trust store password
 
 `es.net.ssl.cert.allow.self.signed` (default false):: Whether or not to allow self signed certificates
 
@@ -533,7 +533,7 @@ added[2.1]
 `es.net.proxy.http.host`:: Http proxy host name
 `es.net.proxy.http.port`:: Http proxy port
 `es.net.proxy.http.user`:: Http proxy user name
-`es.net.proxy.http.pass`:: Http proxy password
+`es.net.proxy.http.pass`:: <<keystore,Securable>>. Http proxy password
 `es.net.proxy.http.use.system.props`(default yes):: Whether the use the system Http proxy properties (namely `http.proxyHost` and `http.proxyPort`) or not
 
 added[2.2]
@@ -543,14 +543,14 @@ added[2.2]
 added[2.2]
 `es.net.proxy.https.user`:: Https proxy user name
 added[2.2]
-`es.net.proxy.https.pass`:: Https proxy password
+`es.net.proxy.https.pass`:: <<keystore,Securable>>. Https proxy password
 added[2.2]
 `es.net.proxy.https.use.system.props`(default yes):: Whether the use the system Https proxy properties (namely `https.proxyHost` and `https.proxyPort`) or not
 
 `es.net.proxy.socks.host`:: Http proxy host name
 `es.net.proxy.socks.port`:: Http proxy port
 `es.net.proxy.socks.user`:: Http proxy user name
-`es.net.proxy.socks.pass`:: Http proxy password
+`es.net.proxy.socks.pass`:: <<keystore,Securable>>. Http proxy password
 `es.net.proxy.socks.use.system.props`(default yes):: Whether the use the system Socks proxy properties (namely `socksProxyHost` and `socksProxyHost`) or not
 
 NOTE: {eh} allows proxy settings to be applied only to its connection using the setting above. Take extra care when there is already a JVM-wide proxy setting (typically through system properties) to avoid unexpected behavior.

--- a/docs/src/reference/asciidoc/core/configuration.adoc
+++ b/docs/src/reference/asciidoc/core/configuration.adoc
@@ -498,7 +498,7 @@ es.net.http.header.Max-Forwards = 10
 ==== Secure Settings
 
 added[6.4]
-`es.keystore.location`:: location of the secure settings keystore file (typically a URL, without a prefix it is interpreted as a classpath entry)
+`es.keystore.location`:: location of the secure settings keystore file (typically a URL, without a prefix it is interpreted as a classpath entry).
 
 added[2.1]
 [float]

--- a/mr/src/itest/java/org/elasticsearch/hadoop/rest/pooling/AbstractTransportPoolTest.java
+++ b/mr/src/itest/java/org/elasticsearch/hadoop/rest/pooling/AbstractTransportPoolTest.java
@@ -21,6 +21,7 @@ package org.elasticsearch.hadoop.rest.pooling;
 
 import org.elasticsearch.hadoop.cfg.Settings;
 import org.elasticsearch.hadoop.rest.Transport;
+import org.elasticsearch.hadoop.security.SecureSettings;
 import org.elasticsearch.hadoop.util.SettingsUtils;
 import org.elasticsearch.hadoop.util.TestSettings;
 import org.junit.Test;
@@ -38,7 +39,7 @@ public class AbstractTransportPoolTest {
 
         String host = SettingsUtils.discoveredOrDeclaredNodes(settings).get(0);
 
-        TransportPool pool = new TransportPool(UUID.randomUUID().toString(), host, settings);
+        TransportPool pool = new TransportPool(UUID.randomUUID().toString(), host, settings, new SecureSettings(settings));
 
         Transport transport1 = null;
         Transport transport2 = null;

--- a/mr/src/main/java/org/elasticsearch/hadoop/cfg/ConfigurationOptions.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/cfg/ConfigurationOptions.java
@@ -67,6 +67,9 @@ public interface ConfigurationOptions {
 
     String ES_NODES_RESOLVE_HOST_NAME = "es.nodes.resolve.hostname";
 
+    /** Secure Settings Keystore */
+    String ES_KEYSTORE_LOCATION = "es.keystore.location";
+
     /** Elasticsearch batch size given in bytes */
     String ES_BATCH_SIZE_BYTES = "es.batch.size.bytes";
     String ES_BATCH_SIZE_BYTES_DEFAULT = "1mb";

--- a/mr/src/main/java/org/elasticsearch/hadoop/cfg/Settings.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/cfg/Settings.java
@@ -408,6 +408,7 @@ public abstract class Settings {
         return getProperty(ES_NET_SSL_KEYSTORE_TYPE, ES_NET_SSL_KEYSTORE_TYPE_DEFAULT);
     }
 
+    @Deprecated
     public String getNetworkSSLKeyStorePass() {
         return getProperty(ES_NET_SSL_KEYSTORE_PASS);
     }
@@ -416,6 +417,7 @@ public abstract class Settings {
         return getProperty(ES_NET_SSL_TRUST_STORE_LOCATION);
     }
 
+    @Deprecated
     public String getNetworkSSLTrustStorePass() {
         return getProperty(ES_NET_SSL_TRUST_STORE_PASS);
     }
@@ -428,6 +430,7 @@ public abstract class Settings {
         return getProperty(ES_NET_HTTP_AUTH_USER);
     }
 
+    @Deprecated
     public String getNetworkHttpAuthPass() {
         return getProperty(ES_NET_HTTP_AUTH_PASS);
     }
@@ -444,6 +447,7 @@ public abstract class Settings {
         return getProperty(ES_NET_PROXY_HTTP_USER);
     }
 
+    @Deprecated
     public String getNetworkProxyHttpPass() {
         return getProperty(ES_NET_PROXY_HTTP_PASS);
     }
@@ -464,6 +468,7 @@ public abstract class Settings {
         return getProperty(ES_NET_PROXY_HTTPS_USER);
     }
 
+    @Deprecated
     public String getNetworkProxyHttpsPass() {
         return getProperty(ES_NET_PROXY_HTTPS_PASS);
     }
@@ -484,6 +489,7 @@ public abstract class Settings {
         return getProperty(ES_NET_PROXY_SOCKS_USER);
     }
 
+    @Deprecated
     public String getNetworkProxySocksPass() {
         return getProperty(ES_NET_PROXY_SOCKS_PASS);
     }

--- a/mr/src/main/java/org/elasticsearch/hadoop/cli/ConsolePrompt.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/cli/ConsolePrompt.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.hadoop.cli;
+
+import java.io.BufferedReader;
+import java.io.Console;
+import java.io.IOError;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class ConsolePrompt implements Prompt {
+    private final Console console;
+
+    public ConsolePrompt() {
+        this.console = System.console();
+    }
+
+    @Override
+    public void println() {
+        System.out.println();
+    }
+
+    @Override
+    public void println(String s) {
+        System.out.println(s);
+    }
+
+    @Override
+    public void printf(String format, Object... args) {
+        System.out.printf(format, args);
+    }
+
+    @Override
+    public String readLine() {
+        if (console == null) {
+            try {
+                return new BufferedReader(new InputStreamReader(System.in)).readLine();
+            } catch (IOException e) {
+                throw new IOError(e);
+            }
+        } else {
+            return this.console.readLine();
+        }
+    }
+
+    @Override
+    public String readLine(String format, Object... args) {
+        printf(format, args);
+        return readLine();
+    }
+
+    @Override
+    public char[] readPassword(String prompt, Object... args) {
+        if (console == null) {
+            throw new IllegalStateException("Cannot disable console echo to read password");
+        }
+        return this.console.readPassword(prompt, args);
+    }
+}

--- a/mr/src/main/java/org/elasticsearch/hadoop/cli/Keytool.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/cli/Keytool.java
@@ -1,0 +1,298 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.hadoop.cli;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.elasticsearch.hadoop.security.EsHadoopSecurityException;
+import org.elasticsearch.hadoop.security.KeystoreWrapper;
+
+public class Keytool {
+
+    private static final String KEYSTORE_FILE_NAME = "esh.keystore";
+
+    public static void main(String[] args) {
+        System.exit(execute(new ConsolePrompt(), args));
+    }
+
+    public static int execute(Prompt console, String[] args) {
+        Command command = null;
+        String commandArg = null;
+        boolean hasSTDIN = false;
+        boolean force = false;
+        for (int idx = 0; idx < args.length; idx++) {
+            String arg = args[idx];
+            if (arg.equals(FLAG_H) || arg.equals(FLAG_HELP)) {
+                printUsage(console);
+                return 0;
+            } else if (hasSTDIN == false && (arg.equals(FLAG_STDIN))) {
+                hasSTDIN = true;
+            } else if (force == false && (arg.equals(FLAG_F) || arg.equals(FLAG_FORCE))) {
+                force = true;
+            } else if (command == null) {
+                command = Command.byName(arg.toLowerCase());
+                if (command == null) {
+                    printUsage(console);
+                    error(console, "Unknown command [" + arg + "]");
+                    return 2;
+                }
+            } else if (command.hasArgs() && commandArg == null) {
+                commandArg = arg;
+            } else {
+                printUsage(console);
+                error(console, "Unexpected argument [" + arg + "]");
+                return 3;
+            }
+        }
+        if (command == null) {
+            printUsage(console);
+            error(console, "No command specified");
+            return 1;
+        }
+        if (command.hasArgs && commandArg == null) {
+            printUsage(console);
+            error(console, "Settings name required for command [" + command.text + "]");
+            return 4;
+        }
+        // If stdin is from a pipe, then the console will be null. Treat this like --stdin.
+        hasSTDIN |= (System.console() == null);
+        try {
+            return new Keytool(console, command).run(commandArg, hasSTDIN, force);
+        } catch (IOException e) {
+            console.println("ERROR: " + e.getMessage());
+            return 11;
+        }
+    }
+
+    private static final String TBLFRMT = "%-15s%-19s%n";
+
+    private static void printUsage(Prompt prompt) {
+        prompt.println("A tool for managing settings stored in an ES-Hadoop keystore");
+        prompt.println();
+        prompt.println("Commands");
+        prompt.println("--------");
+        prompt.println(Command.CREATE.getText() + " - Creates a new elasticsearch keystore");
+        prompt.println(Command.LIST.getText() + " - List entries in the keystore");
+        prompt.println(Command.ADD.getText() + " - Add a setting to the keystore");
+        prompt.println(Command.REMOVE.getText() + " - Remove a setting from the keystore");
+        prompt.println();
+        prompt.printf(TBLFRMT, "Option", "Description");
+        prompt.printf(TBLFRMT, "------", "-----------");
+        prompt.printf(TBLFRMT, FLAG_H + ", " + FLAG_HELP, "show help");
+        prompt.printf(TBLFRMT, FLAG_F + ", " + FLAG_FORCE, "ignore overwriting warnings when adding to the keystore");
+    }
+
+    private static void error(Prompt prompt, String error) {
+        prompt.println("ERROR: " + error);
+    }
+
+    private static final String FLAG_HELP = "--help";
+    private static final String FLAG_H = "-h";
+
+    private static final String FLAG_FORCE = "--force";
+    private static final String FLAG_F = "-f";
+
+    private static final String FLAG_STDIN = "--stdin";
+
+    enum Command {
+        CREATE("create", false),
+        LIST("list", false),
+        ADD("add", true),
+        REMOVE("remove", true);
+
+        private final String text;
+        private final boolean hasArgs;
+
+        Command(String text, boolean hasArgs) {
+            this.text = text;
+            this.hasArgs = hasArgs;
+        }
+
+        public String getText() {
+            return text;
+        }
+
+        public boolean hasArgs() {
+            return hasArgs;
+        }
+
+        private static Map<String, Command> lookup = new HashMap<String, Command>();
+
+        static {
+            lookup.put(CREATE.text, CREATE);
+            lookup.put(LIST.text, LIST);
+            lookup.put(ADD.text, ADD);
+            lookup.put(REMOVE.text, REMOVE);
+        }
+
+        public static Command byName(String name) {
+            return lookup.get(name);
+        }
+    }
+
+    private final Prompt prompt;
+    private final Command command;
+
+    Keytool(Prompt prompt, Command command) {
+        this.prompt = prompt;
+        this.command = command;
+    }
+
+    /**
+     * Run the program with the given arguments
+     *
+     * @param arg   Usually the name of the property to set. Can be empty for some commands
+     * @param stdin Flag to state that the input should be read from stdin
+     * @param force Flag to state that overwriting a key should be ignored
+     * @return exit code
+     */
+    public int run(String arg, boolean stdin, boolean force) throws IOException {
+        OutputStream outputStream = null;
+        InputStream inputStream = null;
+        KeystoreWrapper keystoreWrapper;
+        try {
+            switch (command) {
+                case CREATE:
+                    if (ksExists()) {
+                        boolean proceed = promptYesNo("An es-hadoop keystore already exists. Overwrite? [y/N]");
+                        if (proceed == false) {
+                            prompt.println("Exiting without creating keystore");
+                            return 0;
+                        }
+                    }
+                    keystoreWrapper = KeystoreWrapper.newStore().build();
+                    outputStream = openWrite();
+                    keystoreWrapper.saveKeystore(outputStream);
+                    return 0;
+                case LIST:
+                    if (!ksExists()) {
+                        prompt.printf("ERROR: ES-Hadoop keystore not found. Use '%s' command to create one.%n", Command.CREATE.getText());
+                        return 5;
+                    }
+                    inputStream = openRead();
+                    keystoreWrapper = KeystoreWrapper.loadStore(inputStream).build();
+                    for (String entry : keystoreWrapper.listEntries()) {
+                        prompt.println(entry);
+                    }
+                    return 0;
+                case ADD:
+                    if (!ksExists()) {
+                        prompt.printf("ERROR: ES-Hadoop keystore not found. Use '%s' command to create one.%n", Command.CREATE.getText());
+                        return 5;
+                    }
+                    inputStream = openRead();
+                    keystoreWrapper = KeystoreWrapper.loadStore(inputStream).build();
+                    if (keystoreWrapper.containsEntry(arg) && force == false) {
+                        boolean proceed = promptYesNo("Setting %s already exists. Overwrite? [y/N]", arg);
+                        if (proceed == false) {
+                            prompt.println("Exiting without modifying keystore");
+                            return 0;
+                        }
+                    }
+                    if (stdin) {
+                        String data = prompt.readLine();
+                        keystoreWrapper.setSecureSetting(arg, data);
+                    } else {
+                        char[] data = prompt.readPassword("Enter value for %s:", arg);
+                        keystoreWrapper.setSecureSetting(arg, new String(data));
+                        Arrays.fill(data, (char) 0);
+                    }
+                    outputStream = openWrite();
+                    keystoreWrapper.saveKeystore(outputStream);
+                    return 0;
+                case REMOVE:
+                    if (!ksExists()) {
+                        prompt.printf("ERROR: ES-Hadoop keystore not found. Use '%s' command to create one.%n", Command.CREATE.getText());
+                        return 5;
+                    }
+                    inputStream = openRead();
+                    keystoreWrapper = KeystoreWrapper.loadStore(inputStream).build();
+                    if (keystoreWrapper.containsEntry(arg) == false) {
+                        prompt.printf("ERROR: Setting [%s] does not exist in the keystore.%n", arg);
+                        return 6;
+                    }
+                    keystoreWrapper.removeSecureSetting(arg);
+                    outputStream = openWrite();
+                    keystoreWrapper.saveKeystore(outputStream);
+                    return 0;
+                default:
+                    prompt.println("ERROR: Unsupported command " + command.getText());
+                    return 7;
+            }
+        } catch (EsHadoopSecurityException ehse) {
+            prompt.println("ERRORCould not load keystore file: " + ehse.getMessage());
+            return 8;
+        } catch (FileNotFoundException fnfe) {
+            prompt.println("ERROR: Could not load keystore file: " + fnfe.getMessage());
+            return 9;
+        } catch (IOException ioe) {
+            prompt.println("ERROR: " + ioe.getMessage());
+            return 10;
+        } finally {
+            if (outputStream != null) {
+                outputStream.close();
+            }
+            if (inputStream != null) {
+                inputStream.close();
+            }
+        }
+    }
+
+    private boolean promptYesNo(String msgFormat, Object... args) {
+        while (true) {
+            String response = prompt.readLine(msgFormat, args);
+            if (response == null || response.isEmpty() || response.equalsIgnoreCase("n")) {
+                return false;
+            } else if (response.equalsIgnoreCase("y")) {
+                return true;
+            } else {
+                prompt.printf("Did not understand answer '%s'%n", response);
+            }
+        }
+    }
+
+    protected boolean ksExists() {
+        File file = new File(KEYSTORE_FILE_NAME);
+        return file.exists();
+    }
+
+    protected InputStream openRead() throws FileNotFoundException {
+        File file = new File(KEYSTORE_FILE_NAME);
+        return new FileInputStream(file);
+    }
+
+    protected OutputStream openWrite() throws IOException {
+        File file = new File(KEYSTORE_FILE_NAME);
+        if (file.exists()) {
+            // Ignore return value
+            file.createNewFile();
+        }
+        return new FileOutputStream(file);
+    }
+}

--- a/mr/src/main/java/org/elasticsearch/hadoop/cli/Prompt.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/cli/Prompt.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.hadoop.cli;
+
+public interface Prompt {
+
+    void println();
+
+    void println(String s);
+
+    void printf(String format, Object... args);
+
+    String readLine();
+
+    String readLine(String format, Object... args);
+
+    char[] readPassword(String prompt, Object... args);
+}

--- a/mr/src/main/java/org/elasticsearch/hadoop/rest/NetworkClient.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/rest/NetworkClient.java
@@ -36,6 +36,7 @@ import org.elasticsearch.hadoop.rest.commonshttp.CommonsHttpTransportFactory;
 import org.elasticsearch.hadoop.rest.pooling.PooledTransportManager;
 import org.elasticsearch.hadoop.rest.stats.Stats;
 import org.elasticsearch.hadoop.rest.stats.StatsAware;
+import org.elasticsearch.hadoop.security.SecureSettings;
 import org.elasticsearch.hadoop.util.Assert;
 import org.elasticsearch.hadoop.util.ByteSequence;
 import org.elasticsearch.hadoop.util.SettingsUtils;
@@ -45,6 +46,7 @@ public class NetworkClient implements StatsAware, Closeable {
     private static Log log = LogFactory.getLog(NetworkClient.class);
 
     private final Settings settings;
+    private final SecureSettings secureSettings;
     private final List<String> nodes;
     private final Map<String, Throwable> failedNodes = new LinkedHashMap<String, Throwable>();
 
@@ -61,6 +63,7 @@ public class NetworkClient implements StatsAware, Closeable {
 
     public NetworkClient(Settings settings, TransportFactory transportFactory) {
         this.settings = settings.copy();
+        this.secureSettings = new SecureSettings(settings);
         this.nodes = SettingsUtils.discoveredOrDeclaredNodes(settings);
         this.transportFactory = transportFactory;
 
@@ -96,7 +99,7 @@ public class NetworkClient implements StatsAware, Closeable {
         closeTransport();
         currentNode = nodes.get(nextClient++);
         SettingsUtils.pinNode(settings, currentNode);
-        currentTransport = transportFactory.create(settings, currentNode);
+        currentTransport = transportFactory.create(settings, secureSettings, currentNode);
         return true;
     }
 

--- a/mr/src/main/java/org/elasticsearch/hadoop/rest/TransportFactory.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/rest/TransportFactory.java
@@ -19,6 +19,7 @@
 package org.elasticsearch.hadoop.rest;
 
 import org.elasticsearch.hadoop.cfg.Settings;
+import org.elasticsearch.hadoop.security.SecureSettings;
 
 /**
  * Creates {@link Transport} Objects
@@ -27,7 +28,8 @@ public interface TransportFactory {
     /**
      * Creates a {@link Transport} object
      * @param settings Specifies the Transport's properties
+     * @param secureSettings Any secure settings that should be provided
      * @param hostInfo Host to connect to
      */
-    Transport create(Settings settings, String hostInfo);
+    Transport create(Settings settings, SecureSettings secureSettings, String hostInfo);
 }

--- a/mr/src/main/java/org/elasticsearch/hadoop/rest/commonshttp/CommonsHttpTransport.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/rest/commonshttp/CommonsHttpTransport.java
@@ -480,9 +480,9 @@ public class CommonsHttpTransport implements Transport, StatsAware {
         headers.applyTo(http);
 
         // when tracing, log everything
-//        if (log.isTraceEnabled()) {
-            log.info(String.format("Tx %s[%s]@[%s][%s]?[%s] w/ payload [%s]", proxyInfo, request.method().name(), httpInfo, request.path(), request.params(), request.body()));
-//        }
+        if (log.isTraceEnabled()) {
+            log.trace(String.format("Tx %s[%s]@[%s][%s]?[%s] w/ payload [%s]", proxyInfo, request.method().name(), httpInfo, request.path(), request.params(), request.body()));
+        }
 
         long start = System.currentTimeMillis();
         try {
@@ -491,11 +491,11 @@ public class CommonsHttpTransport implements Transport, StatsAware {
             stats.netTotalTime += (System.currentTimeMillis() - start);
         }
 
-//        if (log.isTraceEnabled()) {
+        if (log.isTraceEnabled()) {
             Socket sk = ReflectionUtils.invoke(GET_SOCKET, conn, (Object[]) null);
             String addr = sk.getLocalAddress().getHostAddress();
-            log.info(String.format("Rx %s@[%s] [%s-%s] [%s]", proxyInfo, addr, http.getStatusCode(), HttpStatus.getStatusText(http.getStatusCode()), http.getResponseBodyAsString()));
-//        }
+            log.trace(String.format("Rx %s@[%s] [%s-%s] [%s]", proxyInfo, addr, http.getStatusCode(), HttpStatus.getStatusText(http.getStatusCode()), http.getResponseBodyAsString()));
+        }
 
         // the request URI is not set (since it is retried across hosts), so use the http info instead for source
         return new SimpleResponse(http.getStatusCode(), new ResponseInputStream(http), httpInfo);

--- a/mr/src/main/java/org/elasticsearch/hadoop/rest/commonshttp/CommonsHttpTransport.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/rest/commonshttp/CommonsHttpTransport.java
@@ -36,6 +36,7 @@ import org.elasticsearch.hadoop.cfg.Settings;
 import org.elasticsearch.hadoop.rest.*;
 import org.elasticsearch.hadoop.rest.stats.Stats;
 import org.elasticsearch.hadoop.rest.stats.StatsAware;
+import org.elasticsearch.hadoop.security.SecureSettings;
 import org.elasticsearch.hadoop.util.ByteSequence;
 import org.elasticsearch.hadoop.util.ReflectionUtils;
 import org.elasticsearch.hadoop.util.StringUtils;
@@ -71,6 +72,7 @@ public class CommonsHttpTransport implements Transport, StatsAware {
     private final boolean sslEnabled;
     private final String pathPrefix;
     private final Settings settings;
+    private final SecureSettings secureSettings;
 
     private static class ResponseInputStream extends DelegatingInputStream implements ReusableInputStream {
 
@@ -138,7 +140,12 @@ public class CommonsHttpTransport implements Transport, StatsAware {
     }
 
     public CommonsHttpTransport(Settings settings, String host) {
+        this(settings, new SecureSettings(settings), host);
+    }
+
+    public CommonsHttpTransport(Settings settings, SecureSettings secureSettings, String host) {
         this.settings = settings;
+        this.secureSettings = secureSettings;
         httpInfo = host;
         sslEnabled = settings.getNetworkSSLEnabled();
 
@@ -169,9 +176,9 @@ public class CommonsHttpTransport implements Transport, StatsAware {
 
         HostConfiguration hostConfig = new HostConfiguration();
 
-        hostConfig = setupSSLIfNeeded(settings, hostConfig);
-        hostConfig = setupSocksProxy(settings, hostConfig);
-        Object[] authSettings = setupHttpOrHttpsProxy(settings, hostConfig);
+        hostConfig = setupSSLIfNeeded(settings, secureSettings, hostConfig);
+        hostConfig = setupSocksProxy(settings, secureSettings, hostConfig);
+        Object[] authSettings = setupHttpOrHttpsProxy(settings, secureSettings, hostConfig);
         hostConfig = (HostConfiguration) authSettings[0];
 
         try {
@@ -182,7 +189,7 @@ public class CommonsHttpTransport implements Transport, StatsAware {
         client = new HttpClient(params, new SocketTrackingConnectionManager());
         client.setHostConfiguration(hostConfig);
 
-        addHttpAuth(settings, authSettings);
+        addHttpAuth(settings, secureSettings, authSettings);
         completeAuth(authSettings);
 
         HttpConnectionManagerParams connectionParams = client.getHttpConnectionManager().getParams();
@@ -198,7 +205,7 @@ public class CommonsHttpTransport implements Transport, StatsAware {
         }
     }
 
-    private HostConfiguration setupSSLIfNeeded(Settings settings, HostConfiguration hostConfig) {
+    private HostConfiguration setupSSLIfNeeded(Settings settings, SecureSettings secureSettings, HostConfiguration hostConfig) {
         if (!sslEnabled) {
             return hostConfig;
         }
@@ -214,18 +221,18 @@ public class CommonsHttpTransport implements Transport, StatsAware {
         //
         String schema = "https";
         int port = 443;
-        SecureProtocolSocketFactory sslFactory = new SSLSocketFactory(settings);
+        SecureProtocolSocketFactory sslFactory = new SSLSocketFactory(settings, secureSettings);
 
         replaceProtocol(sslFactory, schema, port);
 
         return hostConfig;
     }
 
-    private void addHttpAuth(Settings settings, Object[] authSettings) {
+    private void addHttpAuth(Settings settings, SecureSettings secureSettings, Object[] authSettings) {
         if (StringUtils.hasText(settings.getNetworkHttpAuthUser())) {
             HttpState state = (authSettings[1] != null ? (HttpState) authSettings[1] : new HttpState());
             authSettings[1] = state;
-            state.setCredentials(AuthScope.ANY, new UsernamePasswordCredentials(settings.getNetworkHttpAuthUser(), settings.getNetworkHttpAuthPass()));
+            state.setCredentials(AuthScope.ANY, new UsernamePasswordCredentials(settings.getNetworkHttpAuthUser(), secureSettings.getSecureProperty(ConfigurationOptions.ES_NET_HTTP_AUTH_PASS)));
             if (log.isDebugEnabled()) {
                 log.info("Using detected HTTP Auth credentials...");
             }
@@ -239,7 +246,7 @@ public class CommonsHttpTransport implements Transport, StatsAware {
         }
     }
 
-    private Object[] setupHttpOrHttpsProxy(Settings settings, HostConfiguration hostConfig) {
+    private Object[] setupHttpOrHttpsProxy(Settings settings, SecureSettings secureSettings, HostConfiguration hostConfig) {
         // return HostConfiguration + HttpState
         Object[] results = new Object[2];
         results[0] = hostConfig;
@@ -279,11 +286,11 @@ public class CommonsHttpTransport implements Transport, StatsAware {
             // client is not yet initialized so postpone state
             if (sslEnabled) {
                 if (StringUtils.hasText(settings.getNetworkProxyHttpsUser())) {
-                    if (!StringUtils.hasText(settings.getNetworkProxyHttpsPass())) {
+                    if (!StringUtils.hasText(secureSettings.getSecureProperty(ConfigurationOptions.ES_NET_PROXY_HTTPS_PASS))) {
                         log.warn(String.format("HTTPS proxy user specified but no/empty password defined - double check the [%s] property", ConfigurationOptions.ES_NET_PROXY_HTTPS_PASS));
                     }
                     HttpState state = new HttpState();
-                    state.setProxyCredentials(AuthScope.ANY, new UsernamePasswordCredentials(settings.getNetworkProxyHttpsUser(), settings.getNetworkProxyHttpsPass()));
+                    state.setProxyCredentials(AuthScope.ANY, new UsernamePasswordCredentials(settings.getNetworkProxyHttpsUser(), secureSettings.getSecureProperty(ConfigurationOptions.ES_NET_PROXY_HTTPS_PASS)));
                     // client is not yet initialized so simply save the object for later
                     results[1] = state;
                 }
@@ -299,11 +306,11 @@ public class CommonsHttpTransport implements Transport, StatsAware {
             }
             else {
                 if (StringUtils.hasText(settings.getNetworkProxyHttpUser())) {
-                    if (!StringUtils.hasText(settings.getNetworkProxyHttpPass())) {
+                    if (!StringUtils.hasText(secureSettings.getSecureProperty(ConfigurationOptions.ES_NET_PROXY_HTTP_PASS))) {
                         log.warn(String.format("HTTP proxy user specified but no/empty password defined - double check the [%s] property", ConfigurationOptions.ES_NET_PROXY_HTTP_PASS));
                     }
                     HttpState state = new HttpState();
-                    state.setProxyCredentials(AuthScope.ANY, new UsernamePasswordCredentials(settings.getNetworkProxyHttpUser(), settings.getNetworkProxyHttpPass()));
+                    state.setProxyCredentials(AuthScope.ANY, new UsernamePasswordCredentials(settings.getNetworkProxyHttpUser(), secureSettings.getSecureProperty(ConfigurationOptions.ES_NET_PROXY_HTTP_PASS)));
                     // client is not yet initialized so simply save the object for later
                     results[1] = state;
                 }
@@ -322,7 +329,7 @@ public class CommonsHttpTransport implements Transport, StatsAware {
         return results;
     }
 
-    private HostConfiguration setupSocksProxy(Settings settings, HostConfiguration hostConfig) {
+    private HostConfiguration setupSocksProxy(Settings settings, SecureSettings secureSettings, HostConfiguration hostConfig) {
         // set proxy settings
         String proxyHost = null;
         int proxyPort = -1;
@@ -344,8 +351,8 @@ public class CommonsHttpTransport implements Transport, StatsAware {
         if (StringUtils.hasText(settings.getNetworkProxySocksUser())) {
             proxyUser = settings.getNetworkProxySocksUser();
         }
-        if (StringUtils.hasText(settings.getNetworkProxySocksPass())) {
-            proxyPass = settings.getNetworkProxySocksPass();
+        if (StringUtils.hasText(secureSettings.getSecureProperty(ConfigurationOptions.ES_NET_PROXY_SOCKS_PASS))) {
+            proxyPass = secureSettings.getSecureProperty(ConfigurationOptions.ES_NET_PROXY_SOCKS_PASS);
         }
 
         // we actually have a socks proxy, let's start the setup
@@ -473,9 +480,9 @@ public class CommonsHttpTransport implements Transport, StatsAware {
         headers.applyTo(http);
 
         // when tracing, log everything
-        if (log.isTraceEnabled()) {
-            log.trace(String.format("Tx %s[%s]@[%s][%s]?[%s] w/ payload [%s]", proxyInfo, request.method().name(), httpInfo, request.path(), request.params(), request.body()));
-        }
+//        if (log.isTraceEnabled()) {
+            log.info(String.format("Tx %s[%s]@[%s][%s]?[%s] w/ payload [%s]", proxyInfo, request.method().name(), httpInfo, request.path(), request.params(), request.body()));
+//        }
 
         long start = System.currentTimeMillis();
         try {
@@ -484,11 +491,11 @@ public class CommonsHttpTransport implements Transport, StatsAware {
             stats.netTotalTime += (System.currentTimeMillis() - start);
         }
 
-        if (log.isTraceEnabled()) {
+//        if (log.isTraceEnabled()) {
             Socket sk = ReflectionUtils.invoke(GET_SOCKET, conn, (Object[]) null);
             String addr = sk.getLocalAddress().getHostAddress();
-            log.trace(String.format("Rx %s@[%s] [%s-%s] [%s]", proxyInfo, addr, http.getStatusCode(), HttpStatus.getStatusText(http.getStatusCode()), http.getResponseBodyAsString()));
-        }
+            log.info(String.format("Rx %s@[%s] [%s-%s] [%s]", proxyInfo, addr, http.getStatusCode(), HttpStatus.getStatusText(http.getStatusCode()), http.getResponseBodyAsString()));
+//        }
 
         // the request URI is not set (since it is retried across hosts), so use the http info instead for source
         return new SimpleResponse(http.getStatusCode(), new ResponseInputStream(http), httpInfo);

--- a/mr/src/main/java/org/elasticsearch/hadoop/rest/commonshttp/CommonsHttpTransportFactory.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/rest/commonshttp/CommonsHttpTransportFactory.java
@@ -23,6 +23,7 @@ import org.apache.commons.logging.LogFactory;
 import org.elasticsearch.hadoop.cfg.Settings;
 import org.elasticsearch.hadoop.rest.Transport;
 import org.elasticsearch.hadoop.rest.TransportFactory;
+import org.elasticsearch.hadoop.security.SecureSettings;
 
 /**
  * Creates regular instances of {@link CommonsHttpTransport}
@@ -32,10 +33,10 @@ public class CommonsHttpTransportFactory implements TransportFactory {
     private final Log log = LogFactory.getLog(this.getClass());
 
     @Override
-    public Transport create(Settings settings, String hostInfo) {
+    public Transport create(Settings settings, SecureSettings secureSettings, String hostInfo) {
         if (log.isDebugEnabled()) {
             log.debug("Creating new CommonsHttpTransport");
         }
-        return new CommonsHttpTransport(settings, hostInfo);
+        return new CommonsHttpTransport(settings, secureSettings, hostInfo);
     }
 }

--- a/mr/src/main/java/org/elasticsearch/hadoop/rest/commonshttp/SSLSocketFactory.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/rest/commonshttp/SSLSocketFactory.java
@@ -46,7 +46,9 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.elasticsearch.hadoop.EsHadoopIllegalArgumentException;
 import org.elasticsearch.hadoop.EsHadoopIllegalStateException;
+import org.elasticsearch.hadoop.cfg.ConfigurationOptions;
 import org.elasticsearch.hadoop.cfg.Settings;
+import org.elasticsearch.hadoop.security.SecureSettings;
 import org.elasticsearch.hadoop.util.IOUtils;
 import org.elasticsearch.hadoop.util.StringUtils;
 
@@ -105,15 +107,15 @@ class SSLSocketFactory implements SecureProtocolSocketFactory {
     private final String trustStorePass;
     private final TrustStrategy trust;
 
-    SSLSocketFactory(Settings settings) {
+    SSLSocketFactory(Settings settings, SecureSettings secureSettings) {
         sslProtocol = settings.getNetworkSSLProtocol();
 
         keyStoreLocation = settings.getNetworkSSLKeyStoreLocation();
-        keyStorePass = settings.getNetworkSSLKeyStorePass();
+        keyStorePass = secureSettings.getSecureProperty(ConfigurationOptions.ES_NET_SSL_KEYSTORE_PASS);
         keyStoreType = settings.getNetworkSSLKeyStoreType();
 
         trustStoreLocation = settings.getNetworkSSLTrustStoreLocation();
-        trustStorePass = settings.getNetworkSSLTrustStorePass();
+        trustStorePass = secureSettings.getSecureProperty(ConfigurationOptions.ES_NET_SSL_TRUST_STORE_PASS);
 
         trust = (settings.getNetworkSSLAcceptSelfSignedCert() ? new SelfSignedStrategy() : null);
     }

--- a/mr/src/main/java/org/elasticsearch/hadoop/rest/pooling/TransportPool.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/rest/pooling/TransportPool.java
@@ -28,6 +28,7 @@ import org.elasticsearch.hadoop.rest.SimpleRequest;
 import org.elasticsearch.hadoop.rest.Transport;
 import org.elasticsearch.hadoop.rest.commonshttp.CommonsHttpTransport;
 import org.elasticsearch.hadoop.rest.stats.Stats;
+import org.elasticsearch.hadoop.security.SecureSettings;
 import org.elasticsearch.hadoop.util.unit.TimeValue;
 
 import java.io.IOException;
@@ -47,6 +48,7 @@ final class TransportPool {
     private final Log log = LogFactory.getLog(this.getClass());
 
     private final Settings transportSettings;
+    private final SecureSettings secureSettings;
     private final String hostName;
     private final String jobPoolingKey;
     private final TimeValue idleTransportTimeout;
@@ -60,11 +62,13 @@ final class TransportPool {
      * @param jobPoolingKey Unique key for all pooled connections for this job
      * @param hostName Host name to pool transports for
      * @param transportSettings Settings to use for this pool and for new transports
+     * @param secureSettings Secure settings to use for new transports
      */
-    TransportPool(String jobPoolingKey, String hostName, Settings transportSettings) {
+    TransportPool(String jobPoolingKey, String hostName, Settings transportSettings, SecureSettings secureSettings) {
         this.jobPoolingKey = jobPoolingKey;
         this.hostName = hostName;
         this.transportSettings = transportSettings;
+        this.secureSettings = secureSettings;
         this.leased = new HashMap<PooledTransport, Long>();
         this.idle = new HashMap<PooledTransport, Long>();
 
@@ -85,7 +89,7 @@ final class TransportPool {
         if (log.isDebugEnabled()) {
             log.debug("Creating new pooled CommonsHttpTransport for host ["+hostName+"] belonging to job ["+jobPoolingKey+"]");
         }
-        return new PooledCommonsHttpTransport(transportSettings, hostName);
+        return new PooledCommonsHttpTransport(transportSettings, secureSettings, hostName);
     }
 
     /**
@@ -266,8 +270,8 @@ final class TransportPool {
     private final class PooledCommonsHttpTransport extends CommonsHttpTransport implements PooledTransport {
         private final String loggingHostInformation;
 
-        PooledCommonsHttpTransport(Settings settings, String host) {
-            super(settings, host);
+        PooledCommonsHttpTransport(Settings settings, SecureSettings secureSettings, String host) {
+            super(settings, secureSettings, host);
             this.loggingHostInformation = host;
         }
 

--- a/mr/src/main/java/org/elasticsearch/hadoop/security/EsHadoopSecurityException.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/security/EsHadoopSecurityException.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.hadoop.security;
+
+import java.security.GeneralSecurityException;
+
+public class EsHadoopSecurityException extends GeneralSecurityException {
+    public EsHadoopSecurityException() {
+    }
+
+    public EsHadoopSecurityException(String msg) {
+        super(msg);
+    }
+
+    public EsHadoopSecurityException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public EsHadoopSecurityException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/mr/src/main/java/org/elasticsearch/hadoop/security/KeystoreWrapper.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/security/KeystoreWrapper.java
@@ -1,0 +1,168 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.hadoop.security;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.UnrecoverableEntryException;
+import java.security.cert.CertificateException;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+
+import org.elasticsearch.hadoop.util.Assert;
+import org.elasticsearch.hadoop.util.IOUtils;
+import org.elasticsearch.hadoop.util.StringUtils;
+
+public class KeystoreWrapper {
+
+    private static final String PKCS12 = "PKCS12";
+    private static final String AES = "AES";
+    private static final String DEFAULT_PASS = "changeme";
+
+    private final KeyStore keyStore;
+    private final KeyStore.PasswordProtection protection;
+
+    private KeystoreWrapper(InputStream inputStream, String type, String password) throws EsHadoopSecurityException, IOException {
+        Assert.hasText(password);
+        try {
+            char[] pwd = password.toCharArray();
+            protection = new KeyStore.PasswordProtection(pwd);
+            keyStore = KeyStore.getInstance(type);
+            keyStore.load(inputStream, pwd);
+        } catch (CertificateException e) {
+            throw new EsHadoopSecurityException("Could not create keystore", e);
+        } catch (NoSuchAlgorithmException e) {
+            throw new EsHadoopSecurityException("Could not create keystore", e);
+        } catch (KeyStoreException e) {
+            throw new EsHadoopSecurityException("Could not create keystore", e);
+        }
+    }
+
+    public void setSecureSetting(String alias, String key) throws EsHadoopSecurityException {
+        SecretKey spec = new SecretKeySpec(key.getBytes(), AES);
+        KeyStore.SecretKeyEntry entry = new KeyStore.SecretKeyEntry(spec);
+        try {
+            keyStore.setEntry(alias, entry, protection);
+        } catch (KeyStoreException e) {
+            throw new EsHadoopSecurityException(String.format("Could not store secret key (alias : [%s]) in keystore", alias), e);
+        }
+    }
+
+    public String getSecureSetting(String alias) throws EsHadoopSecurityException {
+        try {
+            if (!keyStore.containsAlias(alias)) {
+                return null;
+            }
+            KeyStore.Entry entry = keyStore.getEntry(alias, protection);
+            KeyStore.SecretKeyEntry secretKeyEntry = ((KeyStore.SecretKeyEntry) entry);
+            return new String(secretKeyEntry.getSecretKey().getEncoded());
+        } catch (NoSuchAlgorithmException e) {
+            throw new EsHadoopSecurityException(String.format("Could not read alias [%s] from keystore", alias), e);
+        } catch (UnrecoverableEntryException e) {
+            throw new EsHadoopSecurityException(String.format("Could not read alias [%s] from keystore", alias), e);
+        } catch (KeyStoreException e) {
+            throw new EsHadoopSecurityException(String.format("Could not read alias [%s] from keystore", alias), e);
+        }
+    }
+
+    public void saveKeystore(OutputStream outputStream) throws EsHadoopSecurityException, IOException {
+        try {
+            keyStore.store(outputStream, protection.getPassword());
+        } catch (KeyStoreException e) {
+            throw new EsHadoopSecurityException("Could not persist keystore", e);
+        } catch (NoSuchAlgorithmException e) {
+            throw new EsHadoopSecurityException("Could not persist keystore", e);
+        } catch (CertificateException e) {
+            throw new EsHadoopSecurityException("Could not persist keystore", e);
+        }
+    }
+
+    public void saveKeystore(String path) throws EsHadoopSecurityException, IOException {
+        OutputStream stream = null;
+        try {
+            stream = new FileOutputStream(new File(path));
+            saveKeystore(stream);
+        } finally {
+            if (stream != null) {
+                stream.close();
+            }
+        }
+    }
+
+    public static KeystoreBuilder loadStore(String path) {
+        return new KeystoreBuilder(path);
+    }
+
+    public static KeystoreBuilder loadStore(InputStream stream) {
+        return new KeystoreBuilder(stream);
+    }
+
+    public static KeystoreBuilder newStore() {
+        return new KeystoreBuilder();
+    }
+
+    public static final class KeystoreBuilder {
+        private String type;
+        private String password;
+        private String path;
+        private InputStream keystoreFile;
+
+        private KeystoreBuilder(InputStream keystoreFile) {
+            this.keystoreFile = keystoreFile;
+        }
+
+        private KeystoreBuilder(String path) {
+            this.path = path;
+        }
+
+        private KeystoreBuilder() {
+            // New keystore
+        }
+
+        public KeystoreBuilder setType(String type) {
+            this.type = type;
+            return this;
+        }
+
+        public KeystoreBuilder setPassword(String password) {
+            this.password = password;
+            return this;
+        }
+
+        public KeystoreWrapper build() throws EsHadoopSecurityException, IOException {
+            if (StringUtils.hasText(path)) {
+                keystoreFile = IOUtils.open(path);
+            }
+            if (!StringUtils.hasText(type)) {
+                type = PKCS12;
+            }
+            if (!StringUtils.hasText(password)) {
+                password = DEFAULT_PASS;
+            }
+            return new KeystoreWrapper(keystoreFile, type, password);
+        }
+    }
+}

--- a/mr/src/main/java/org/elasticsearch/hadoop/security/KeystoreWrapper.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/security/KeystoreWrapper.java
@@ -29,6 +29,9 @@ import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.UnrecoverableEntryException;
 import java.security.cert.CertificateException;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.List;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 
@@ -71,6 +74,14 @@ public class KeystoreWrapper {
         }
     }
 
+    public void removeSecureSetting(String alias) throws EsHadoopSecurityException {
+        try {
+            keyStore.deleteEntry(alias);
+        } catch (KeyStoreException e) {
+            throw new EsHadoopSecurityException(String.format("Could not delete secret key (alias : [%s]) from keystore", alias), e);
+        }
+    }
+
     public String getSecureSetting(String alias) throws EsHadoopSecurityException {
         try {
             if (!keyStore.containsAlias(alias)) {
@@ -85,6 +96,28 @@ public class KeystoreWrapper {
             throw new EsHadoopSecurityException(String.format("Could not read alias [%s] from keystore", alias), e);
         } catch (KeyStoreException e) {
             throw new EsHadoopSecurityException(String.format("Could not read alias [%s] from keystore", alias), e);
+        }
+    }
+
+    public boolean containsEntry(String alias) throws EsHadoopSecurityException {
+        try {
+            return keyStore.containsAlias(alias);
+        } catch (KeyStoreException e) {
+            throw new EsHadoopSecurityException(String.format("Could not read existence of alias [%s]", alias), e);
+        }
+    }
+
+    public List<String> listEntries() throws EsHadoopSecurityException {
+        try {
+            List<String> entries = new ArrayList<String>(keyStore.size());
+            Enumeration<String> aliases = keyStore.aliases();
+            while (aliases.hasMoreElements()) {
+                String alias = aliases.nextElement();
+                entries.add(alias);
+            }
+            return entries;
+        } catch (KeyStoreException e) {
+            throw new EsHadoopSecurityException("Could not read aliases from keystore", e);
         }
     }
 

--- a/mr/src/main/java/org/elasticsearch/hadoop/security/KeystoreWrapper.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/security/KeystoreWrapper.java
@@ -35,6 +35,7 @@ import java.util.List;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 
+import org.elasticsearch.hadoop.EsHadoopIllegalArgumentException;
 import org.elasticsearch.hadoop.util.Assert;
 import org.elasticsearch.hadoop.util.IOUtils;
 import org.elasticsearch.hadoop.util.StringUtils;
@@ -187,7 +188,16 @@ public class KeystoreWrapper {
 
         public KeystoreWrapper build() throws EsHadoopSecurityException, IOException {
             if (StringUtils.hasText(path)) {
-                keystoreFile = IOUtils.open(path);
+                try {
+                    keystoreFile = IOUtils.open(path);
+                    if (keystoreFile == null) {
+                        throw new EsHadoopIllegalArgumentException(String.format("Could not locate [%s] on classpath", path));
+                    }
+                } catch (Exception e) {
+                    throw new EsHadoopIllegalArgumentException(String.format("Expected to find keystore file at [%s] but " +
+                            "was unable to. Make sure that it is available on the classpath, or if not, that you have " +
+                            "specified a valid file URI.", path));
+                }
             }
             if (!StringUtils.hasText(type)) {
                 type = PKCS12;

--- a/mr/src/main/java/org/elasticsearch/hadoop/security/KeystoreWrapper.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/security/KeystoreWrapper.java
@@ -44,13 +44,15 @@ public class KeystoreWrapper {
 
     private static final String PKCS12 = "PKCS12";
     private static final String AES = "AES";
-    private static final String DEFAULT_PASS = "changeme";
+
+    // TODO: Eventually support password protected keystores when Elasticsearch does.
+    private static final String DEFAULT_PASS = "";
 
     private final KeyStore keyStore;
     private final KeyStore.PasswordProtection protection;
 
     private KeystoreWrapper(InputStream inputStream, String type, String password) throws EsHadoopSecurityException, IOException {
-        Assert.hasText(password);
+        Assert.notNull(password, "Password should not be null");
         try {
             char[] pwd = password.toCharArray();
             protection = new KeyStore.PasswordProtection(pwd);

--- a/mr/src/main/java/org/elasticsearch/hadoop/security/SecureSettings.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/security/SecureSettings.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.hadoop.security;
+
+import java.io.IOException;
+
+import org.elasticsearch.hadoop.EsHadoopException;
+import org.elasticsearch.hadoop.cfg.ConfigurationOptions;
+import org.elasticsearch.hadoop.cfg.Settings;
+import org.elasticsearch.hadoop.security.KeystoreWrapper.KeystoreBuilder;
+
+/**
+ * Loads a keystore to retrieve secure settings, falling back to the settings object if the
+ * keystore is not configured or the property cannot be found.
+ */
+public class SecureSettings {
+
+    private final Settings settings;
+    private KeystoreWrapper keystoreWrapper;
+
+    public SecureSettings(Settings settings) {
+        this.settings = settings;
+
+        String keystoreLocation = settings.getProperty(ConfigurationOptions.ES_KEYSTORE_LOCATION);
+        if (keystoreLocation != null) {
+            KeystoreBuilder builder = KeystoreWrapper.loadStore(keystoreLocation);
+            try {
+                this.keystoreWrapper = builder.build();
+            } catch (EsHadoopSecurityException e) {
+                throw new EsHadoopException("Could not load keystore", e);
+            } catch (IOException e) {
+                throw new EsHadoopException("Could not load keystore", e);
+            }
+        }
+    }
+
+    /**
+     *
+     * @param key property name
+     * @return secure property value or null
+     */
+    public String getSecureProperty(String key) {
+        String value = null;
+        if (keystoreWrapper != null) {
+            try {
+                value = keystoreWrapper.getSecureSetting(key);
+            } catch (EsHadoopSecurityException e) {
+                throw new EsHadoopException("Could not read secure setting [" + key + "]", e);
+            }
+        }
+        if (value == null) {
+            value = settings.getProperty(key);
+        }
+        return value;
+    }
+}

--- a/mr/src/main/java/org/elasticsearch/hadoop/security/SecureSettings.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/security/SecureSettings.java
@@ -48,6 +48,8 @@ public class SecureSettings {
             } catch (IOException e) {
                 throw new EsHadoopException("Could not load keystore", e);
             }
+        } else {
+            this.keystoreWrapper = null;
         }
     }
 

--- a/mr/src/test/java/org/elasticsearch/hadoop/cli/KeytoolTest.java
+++ b/mr/src/test/java/org/elasticsearch/hadoop/cli/KeytoolTest.java
@@ -1,0 +1,413 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.hadoop.cli;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import org.elasticsearch.hadoop.security.KeystoreWrapper;
+import org.elasticsearch.hadoop.util.BytesArray;
+import org.elasticsearch.hadoop.util.FastByteArrayInputStream;
+import org.elasticsearch.hadoop.util.FastByteArrayOutputStream;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertThat;
+
+public class KeytoolTest {
+
+    @Test
+    public void executeNoCommand() {
+        TestPrompt console = new TestPrompt();
+        assertThat(Keytool.execute(console, new String[]{}), equalTo(1));
+        assertHelpMessage(console.getOutput());
+    }
+
+    @Test
+    public void executeNoCommandWithArgs() {
+        TestPrompt console = new TestPrompt();
+        assertThat(Keytool.execute(console, new String[]{"--stdin"}), equalTo(1));
+        assertHelpMessage(console.getOutput());
+    }
+
+    @Test
+    public void executeHelp() {
+        TestPrompt console = new TestPrompt();
+        assertThat(Keytool.execute(console, new String[]{"-h"}), equalTo(0));
+        assertHelpMessage(console.getOutput());
+    }
+
+    @Test
+    public void executeHelpExt() {
+        TestPrompt console = new TestPrompt();
+        assertThat(Keytool.execute(console, new String[]{"--help"}), equalTo(0));
+        assertHelpMessage(console.getOutput());
+    }
+
+    @Test
+    public void executeCommandFail() {
+        TestPrompt console = new TestPrompt();
+        assertThat(Keytool.execute(console, new String[]{"blah"}), equalTo(2));
+        assertHelpMessage(console.getOutput());
+    }
+
+    @Test
+    public void executeCommandFailWithHelp() {
+        TestPrompt console = new TestPrompt();
+        assertThat(Keytool.execute(console, new String[]{"blah", "--help"}), equalTo(2));
+        assertHelpMessage(console.getOutput());
+    }
+
+    @Test
+    public void executeAddFailNoArgument() {
+        TestPrompt console = new TestPrompt();
+        assertThat(Keytool.execute(console, new String[]{"add"}), equalTo(4));
+        assertHelpMessage(console.getOutput());
+    }
+
+    @Test
+    public void executeAddFailNoSettingsName() {
+        TestPrompt console = new TestPrompt();
+        assertThat(Keytool.execute(console, new String[]{"add", "--stdin"}), equalTo(4));
+        assertHelpMessage(console.getOutput());
+    }
+
+    @Test
+    public void executeAddFailUnknownArgument() {
+        TestPrompt console = new TestPrompt();
+        assertThat(Keytool.execute(console, new String[]{"add", "--stdin", "property.name", "someOtherTHing"}), equalTo(3));
+        assertHelpMessage(console.getOutput());
+    }
+
+    @Test
+    public void executeAdd() {
+        TestPrompt console = new TestPrompt();
+        assertThat(Keytool.execute(console, new String[]{"add", "--stdin", "property.name", "someOtherTHing"}), equalTo(3));
+        assertHelpMessage(console.getOutput());
+    }
+
+    @Test
+    public void executeListFailUnknownArgument() {
+        TestPrompt console = new TestPrompt();
+        assertThat(Keytool.execute(console, new String[]{"list", "property.name"}), equalTo(3));
+        assertHelpMessage(console.getOutput());
+    }
+
+    private static final String HELP = "A tool for managing settings stored in an ES-Hadoop keystore\n" +
+            "\n" +
+            "Commands\n" +
+            "--------\n" +
+            "create - Creates a new elasticsearch keystore\n" +
+            "list - List entries in the keystore\n" +
+            "add - Add a setting to the keystore\n" +
+            "remove - Remove a setting from the keystore\n" +
+            "\n" +
+            "Option         Description        \n" +
+            "------         -----------        \n" +
+            "-h, --help     show help          \n" +
+            "-f, --force    ignore overwriting warnings when adding to the keystore";
+
+    private static void assertHelpMessage(String output) {
+        assertThat(output, containsString(HELP));
+    }
+
+    private static class KeytoolHarness extends Keytool {
+        private boolean exists;
+        private BytesArray fileBytes;
+
+        KeytoolHarness(Prompt prompt, Keytool.Command command, boolean exists, BytesArray fileBytes) {
+            super(prompt, command);
+            this.exists = exists;
+            this.fileBytes = fileBytes;
+        }
+
+        @Override
+        protected InputStream openRead() throws FileNotFoundException {
+            return new FastByteArrayInputStream(fileBytes);
+        }
+
+        @Override
+        protected OutputStream openWrite() throws IOException {
+            this.exists = true;
+            this.fileBytes.reset();
+            return new FastByteArrayOutputStream(fileBytes);
+        }
+
+        @Override
+        protected boolean ksExists() {
+            return exists;
+        }
+
+        public BytesArray getFileBytes() {
+            return fileBytes;
+        }
+    }
+
+    @Test
+    public void createKeystore() throws Exception {
+        TestPrompt console = new TestPrompt();
+        KeytoolHarness keytool = new KeytoolHarness(console, Keytool.Command.CREATE, false, new BytesArray(128));
+        assertThat(keytool.run(null, false, false), equalTo(0));
+        assertThat(console.getOutput(), equalTo(""));
+        assertThat(console.hasInputLeft(), is(false));
+        assertThat(keytool.ksExists(), is(true));
+        assertThat(keytool.fileBytes.length(), is(not(0)));
+    }
+
+    @Test
+    public void createKeystoreExistsAlreadyOverwrite() throws Exception {
+        TestPrompt console = new TestPrompt();
+        console.addInput("y");
+        KeytoolHarness keytool = new KeytoolHarness(console, Keytool.Command.CREATE, true, new BytesArray(128));
+        assertThat(keytool.run(null, false, false), equalTo(0));
+        assertThat(console.getOutput(), equalTo(""));
+        assertThat(console.hasInputLeft(), is(false));
+        assertThat(keytool.ksExists(), is(true));
+        assertThat(keytool.fileBytes.length(), is(not(0)));
+    }
+
+    @Test
+    public void createKeystoreExistsAlreadyCancel() throws Exception {
+        TestPrompt console = new TestPrompt();
+        console.addInput("n");
+        KeytoolHarness keytool = new KeytoolHarness(console, Keytool.Command.CREATE, true, new BytesArray(128));
+        assertThat(keytool.run(null, false, false), equalTo(0));
+        assertThat(console.getOutput(), equalTo("Exiting without creating keystore\n"));
+        assertThat(console.hasInputLeft(), is(false));
+        assertThat(keytool.ksExists(), is(true));
+        assertThat(keytool.fileBytes.length(), is(0));
+    }
+
+    @Test
+    public void createKeystoreExistsAlreadyCancelAfterGarbage() throws Exception {
+        TestPrompt console = new TestPrompt();
+        console.addInput("nope")
+                .addInput("yup")
+                .addInput("blahblahblah")
+                .addInput("n");
+        KeytoolHarness keytool = new KeytoolHarness(console, Keytool.Command.CREATE, true, new BytesArray(128));
+        assertThat(keytool.run(null, false, false), equalTo(0));
+        assertThat(
+                console.getOutput(),
+                equalTo("Did not understand answer 'nope'\n" +
+                        "Did not understand answer 'yup'\n" +
+                        "Did not understand answer 'blahblahblah'\n" +
+                        "Exiting without creating keystore\n"
+                )
+        );
+        assertThat(console.hasInputLeft(), is(false));
+        assertThat(keytool.ksExists(), is(true));
+        assertThat(keytool.fileBytes.length(), is(0));
+    }
+
+    @Test
+    public void listKeystoreNonExistant() throws Exception {
+        TestPrompt console = new TestPrompt();
+        KeytoolHarness keytool = new KeytoolHarness(console, Keytool.Command.LIST, false, new BytesArray(128));
+        assertThat(keytool.run(null, false, false), equalTo(5));
+        assertThat(console.getOutput(), equalTo("ERROR: ES-Hadoop keystore not found. Use 'create' command to create one.\n"));
+        assertThat(console.hasInputLeft(), is(false));
+        assertThat(keytool.ksExists(), is(false));
+        assertThat(keytool.fileBytes.length(), is(0));
+    }
+
+    @Test
+    public void listKeystoreEmpty() throws Exception {
+        BytesArray storeData = new BytesArray(128);
+        KeystoreWrapper.newStore().build().saveKeystore(new FastByteArrayOutputStream(storeData));
+        TestPrompt console = new TestPrompt();
+        KeytoolHarness keytool = new KeytoolHarness(console, Keytool.Command.LIST, true, storeData);
+        assertThat(keytool.run(null, false, false), equalTo(0));
+        assertThat(console.getOutput(), equalTo(""));
+        assertThat(console.hasInputLeft(), is(false));
+        assertThat(keytool.ksExists(), is(true));
+        assertThat(keytool.fileBytes.length(), is(not(0)));
+    }
+
+    @Test
+    public void listKeystore() throws Exception {
+        BytesArray storeData = new BytesArray(128);
+        KeystoreWrapper ks = KeystoreWrapper.newStore().build();
+        ks.setSecureSetting("test.password.1", "blah");
+        ks.setSecureSetting("test.password.2", "blah");
+        ks.saveKeystore(new FastByteArrayOutputStream(storeData));
+        TestPrompt console = new TestPrompt();
+        KeytoolHarness keytool = new KeytoolHarness(console, Keytool.Command.LIST, true, storeData);
+        assertThat(keytool.run(null, false, false), equalTo(0));
+        assertThat(
+                console.getOutput(),
+                equalTo(
+                        "test.password.1\n" +
+                        "test.password.2\n"
+                )
+        );
+        assertThat(console.hasInputLeft(), is(false));
+        assertThat(keytool.ksExists(), is(true));
+        assertThat(keytool.fileBytes.length(), is(not(0)));
+    }
+
+    @Test
+    public void addNonExistant() throws Exception {
+        TestPrompt console = new TestPrompt();
+        console.addInput("blah");
+        KeytoolHarness keytool = new KeytoolHarness(console, Keytool.Command.ADD, false, new BytesArray(128));
+        assertThat(keytool.run("test.password.1", false, false), equalTo(5));
+        assertThat(console.getOutput(), equalTo("ERROR: ES-Hadoop keystore not found. Use 'create' command to create one.\n"));
+        assertThat(console.hasInputLeft(), is(true));
+        assertThat(keytool.ksExists(), is(false));
+        assertThat(keytool.fileBytes.length(), is(0));
+    }
+
+    @Test
+    public void addExistingKeyCancel() throws Exception {
+        BytesArray storeData = new BytesArray(128);
+        KeystoreWrapper ks = KeystoreWrapper.newStore().build();
+        ks.setSecureSetting("test.password.1", "blah");
+        ks.saveKeystore(new FastByteArrayOutputStream(storeData));
+        TestPrompt console = new TestPrompt();
+        console.addInput("n");
+        KeytoolHarness keytool = new KeytoolHarness(console, Keytool.Command.ADD, true, storeData);
+        assertThat(keytool.run("test.password.1", false, false), equalTo(0));
+        assertThat(console.getOutput(), equalTo("Exiting without modifying keystore\n"));
+        assertThat(console.hasInputLeft(), is(false));
+        assertThat(keytool.ksExists(), is(true));
+        assertThat(keytool.fileBytes.length(), is(not(0)));
+    }
+
+    @Test
+    public void addExistingKeyOverwrite() throws Exception {
+        BytesArray storeData = new BytesArray(128);
+        KeystoreWrapper ks = KeystoreWrapper.newStore().build();
+        ks.setSecureSetting("test.password.1", "blah");
+        ks.saveKeystore(new FastByteArrayOutputStream(storeData));
+        TestPrompt console = new TestPrompt();
+        console.addInput("y").addInput("blerb");
+        KeytoolHarness keytool = new KeytoolHarness(console, Keytool.Command.ADD, true, storeData);
+        assertThat(keytool.run("test.password.1", false, false), equalTo(0));
+        assertThat(console.getOutput(), equalTo(""));
+        assertThat(console.hasInputLeft(), is(false));
+        assertThat(keytool.ksExists(), is(true));
+        assertThat(keytool.fileBytes.length(), is(not(0)));
+        ks = KeystoreWrapper.loadStore(new FastByteArrayInputStream(keytool.fileBytes)).build();
+        assertThat(ks.getSecureSetting("test.password.1"), equalTo("blerb"));
+    }
+
+    @Test
+    public void addExistingKeyForce() throws Exception {
+        BytesArray storeData = new BytesArray(128);
+        KeystoreWrapper ks = KeystoreWrapper.newStore().build();
+        ks.setSecureSetting("test.password.1", "blah");
+        ks.saveKeystore(new FastByteArrayOutputStream(storeData));
+        TestPrompt console = new TestPrompt();
+        console.addInput("blerb");
+        KeytoolHarness keytool = new KeytoolHarness(console, Keytool.Command.ADD, true, storeData);
+        assertThat(keytool.run("test.password.1", false, true), equalTo(0));
+        assertThat(console.getOutput(), equalTo(""));
+        assertThat(console.hasInputLeft(), is(false));
+        assertThat(keytool.ksExists(), is(true));
+        assertThat(keytool.fileBytes.length(), is(not(0)));
+        ks = KeystoreWrapper.loadStore(new FastByteArrayInputStream(keytool.fileBytes)).build();
+        assertThat(ks.getSecureSetting("test.password.1"), equalTo("blerb"));
+    }
+
+    @Test
+    public void addKey() throws Exception {
+        BytesArray storeData = new BytesArray(128);
+        KeystoreWrapper ks = KeystoreWrapper.newStore().build();
+        ks.saveKeystore(new FastByteArrayOutputStream(storeData));
+        TestPrompt console = new TestPrompt();
+        console.addInput("blahh");
+        KeytoolHarness keytool = new KeytoolHarness(console, Keytool.Command.ADD, true, storeData);
+        assertThat(keytool.run("test.password.1", false, false), equalTo(0));
+        assertThat(console.getOutput(), equalTo(""));
+        assertThat(console.hasInputLeft(), is(false));
+        assertThat(keytool.ksExists(), is(true));
+        assertThat(keytool.fileBytes.length(), is(not(0)));
+        ks = KeystoreWrapper.loadStore(new FastByteArrayInputStream(keytool.fileBytes)).build();
+        assertThat(ks.getSecureSetting("test.password.1"), equalTo("blahh"));
+    }
+
+    @Test
+    public void addKeyStdIn() throws Exception {
+        BytesArray storeData = new BytesArray(128);
+        KeystoreWrapper ks = KeystoreWrapper.newStore().build();
+        ks.saveKeystore(new FastByteArrayOutputStream(storeData));
+        TestPrompt console = new TestPrompt();
+        console.addInput("blahh");
+        KeytoolHarness keytool = new KeytoolHarness(console, Keytool.Command.ADD, true, storeData);
+        assertThat(keytool.run("test.password.1", true, false), equalTo(0));
+        assertThat(console.getOutput(), equalTo(""));
+        assertThat(console.hasInputLeft(), is(false));
+        assertThat(keytool.ksExists(), is(true));
+        assertThat(keytool.fileBytes.length(), is(not(0)));
+        ks = KeystoreWrapper.loadStore(new FastByteArrayInputStream(keytool.fileBytes)).build();
+        assertThat(ks.getSecureSetting("test.password.1"), equalTo("blahh"));
+    }
+
+    @Test
+    public void removeNonExistant() throws Exception {
+        TestPrompt console = new TestPrompt();
+        KeytoolHarness keytool = new KeytoolHarness(console, Keytool.Command.REMOVE, false, new BytesArray(128));
+        assertThat(keytool.run("test.password.1", false, false), equalTo(5));
+        assertThat(console.getOutput(), equalTo("ERROR: ES-Hadoop keystore not found. Use 'create' command to create one.\n"));
+        assertThat(console.hasInputLeft(), is(false));
+        assertThat(keytool.ksExists(), is(false));
+        assertThat(keytool.fileBytes.length(), is(0));
+    }
+
+    @Test
+    public void removeMissingKey() throws Exception {
+        BytesArray storeData = new BytesArray(128);
+        KeystoreWrapper ks = KeystoreWrapper.newStore().build();
+        ks.saveKeystore(new FastByteArrayOutputStream(storeData));
+        TestPrompt console = new TestPrompt();
+        KeytoolHarness keytool = new KeytoolHarness(console, Keytool.Command.REMOVE, true, storeData);
+        assertThat(keytool.run("test.password.1", false, false), equalTo(6));
+        assertThat(console.getOutput(), equalTo("ERROR: Setting [test.password.1] does not exist in the keystore.\n"));
+        assertThat(console.hasInputLeft(), is(false));
+        assertThat(keytool.ksExists(), is(true));
+        assertThat(keytool.fileBytes.length(), is(not(0)));
+    }
+
+    @Test
+    public void removeKey() throws Exception {
+        BytesArray storeData = new BytesArray(128);
+        KeystoreWrapper ks = KeystoreWrapper.newStore().build();
+        ks.setSecureSetting("test.password.1", "bar");
+        ks.setSecureSetting("test.password.2", "foo");
+        ks.saveKeystore(new FastByteArrayOutputStream(storeData));
+        TestPrompt console = new TestPrompt();
+        KeytoolHarness keytool = new KeytoolHarness(console, Keytool.Command.REMOVE, true, storeData);
+        assertThat(keytool.run("test.password.1", false, false), equalTo(0));
+        assertThat(console.getOutput(), equalTo(""));
+        assertThat(console.hasInputLeft(), is(false));
+        assertThat(keytool.ksExists(), is(true));
+        assertThat(keytool.fileBytes.length(), is(not(0)));
+        ks = KeystoreWrapper.loadStore(new FastByteArrayInputStream(keytool.fileBytes)).build();
+        assertThat(ks.containsEntry("test.password.1"), is(false));
+        assertThat(ks.getSecureSetting("test.password.2"), equalTo("foo"));
+    }
+
+}

--- a/mr/src/test/java/org/elasticsearch/hadoop/cli/TestPrompt.java
+++ b/mr/src/test/java/org/elasticsearch/hadoop/cli/TestPrompt.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.hadoop.cli;
+
+import java.util.Deque;
+import java.util.Iterator;
+import java.util.LinkedList;
+
+public class TestPrompt implements Prompt {
+
+    private StringBuilder builder = new StringBuilder();
+    private Deque<String> inputLines = new LinkedList<String>();
+
+    @Override
+    public void println() {
+        builder.append("\n");
+    }
+
+    @Override
+    public void println(String s) {
+        builder.append(s).append("\n");
+    }
+
+    @Override
+    public void printf(String format, Object... args) {
+        builder.append(String.format(format, args));
+    }
+
+    @Override
+    public String readLine() {
+        String data = inputLines.pollFirst();
+        if (data == null) {
+            throw new AssertionError("Tried to read data beyond test specifications");
+        }
+        return data;
+    }
+
+    @Override
+    public String readLine(String format, Object... args) {
+        return readLine();
+    }
+
+    @Override
+    public char[] readPassword(String prompt, Object... args) {
+        return readLine().toCharArray();
+    }
+
+    TestPrompt addInput(String inputLine) {
+        inputLines.add(inputLine);
+        return this;
+    }
+
+    boolean hasInputLeft() {
+        return !inputLines.isEmpty();
+    }
+
+    String getOutput() {
+        return builder.toString();
+    }
+}

--- a/mr/src/test/java/org/elasticsearch/hadoop/security/KeystoreWrapperTest.java
+++ b/mr/src/test/java/org/elasticsearch/hadoop/security/KeystoreWrapperTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.hadoop.security;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+public class KeystoreWrapperTest {
+
+    @Test
+    public void testSetValue() throws Exception {
+        KeystoreWrapper keystoreWrapper = KeystoreWrapper.newStore().build();
+        keystoreWrapper.setSecureSetting("key", "swordfish");
+        assertThat(keystoreWrapper.getSecureSetting("key"), is("swordfish"));
+    }
+
+    @Test
+    public void testEmptyKeystore() throws Exception {
+        assertThat(KeystoreWrapper.newStore().build().getSecureSetting("anything"), is(nullValue()));
+    }
+
+    @Test
+    public void testStoreLoad() throws Exception {
+        KeystoreWrapper keystoreWrapper = KeystoreWrapper.newStore().build();
+        keystoreWrapper.setSecureSetting("key", "swordfish");
+        assertThat(keystoreWrapper.getSecureSetting("key"), is("swordfish"));
+
+        ByteArrayOutputStream stream = new ByteArrayOutputStream(1024);
+
+        keystoreWrapper.saveKeystore(stream);
+        byte[] data = stream.toByteArray();
+
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(data);
+
+        KeystoreWrapper loaded = KeystoreWrapper.loadStore(inputStream).build();
+        assertThat(loaded.getSecureSetting("key"), is("swordfish"));
+    }
+}


### PR DESCRIPTION
ES-Hadoop operates based on the configuration for a given job in Hadoop/Spark. In many cases, users need to provide passwords in these configurations. Since these settings are kept as plain text, providing them in the job configuration can be a potential security hazard. This PR adds support for storing password fields in a keystore file, as well as a tool for generating the keystore file.