### PR TITLE
make sure the RestRepository is initialized when calling delete() method

### DIFF
--- a/mr/src/main/java/org/elasticsearch/hadoop/rest/RestRepository.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/rest/RestRepository.java
@@ -369,6 +369,8 @@ public class RestRepository implements Closeable, StatsAware {
             client.delete(resources.getResourceWrite().index() + "/" + resources.getResourceWrite().type());
         }
         else {
+            lazyInitWriting();
+
             // try first a blind delete by query (since the plugin might be installed)
             try {
                 client.delete(resources.getResourceWrite().index() + "/" + resources.getResourceWrite().type() + "/_query?q=*");


### PR DESCRIPTION
This pull request is a fix for the following bug. When trying to create an index from a Spark job, by using the overwrite flag, the method delete() of RestRepository is called. However the bulk processor/writer are not initialized, thus causing an exception.

PS: I have signed the [Contributor License Agreement (CLA)][]
[Contributor License Agreement (CLA)]: https://www.elastic.co/contributor-agreement/
