### PR TITLE
#1213 Add es.read.shard.preference configuration option to enable Elasticse…

### DIFF
--- a/mr/src/main/java/org/elasticsearch/hadoop/cfg/ConfigurationOptions.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/cfg/ConfigurationOptions.java
@@ -70,10 +70,6 @@ public interface ConfigurationOptions {
     /** Secure Settings Keystore */
     String ES_KEYSTORE_LOCATION = "es.keystore.location";
 
-    /** Elasticsearch shard search preference */
-    String ES_READ_SHARD_PREFERENCE = "es.read.shard.preference";
-    String ES_READ_SHARD_PREFERENCE_DEFAULT = "";
-
     /** Elasticsearch batch size given in bytes */
     String ES_BATCH_SIZE_BYTES = "es.batch.size.bytes";
     String ES_BATCH_SIZE_BYTES_DEFAULT = "1mb";
@@ -155,6 +151,10 @@ public interface ConfigurationOptions {
 
     String ES_INDEX_READ_ALLOW_RED_STATUS = "es.index.read.allow.red.status";
     String ES_INDEX_READ_ALLOW_RED_STATUS_DEFAULT = "false";
+
+    /** Elasticsearch shard search preference */
+    String ES_READ_SHARD_PREFERENCE = "es.read.shard.preference";
+    String ES_READ_SHARD_PREFERENCE_DEFAULT = "";
 
     /** Mapping types */
     String ES_MAPPING_DEFAULT_EXTRACTOR_CLASS = "es.mapping.default.extractor.class";

--- a/mr/src/main/java/org/elasticsearch/hadoop/cfg/ConfigurationOptions.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/cfg/ConfigurationOptions.java
@@ -70,6 +70,10 @@ public interface ConfigurationOptions {
     /** Secure Settings Keystore */
     String ES_KEYSTORE_LOCATION = "es.keystore.location";
 
+    /** Elasticsearch shard search preference */
+    String ES_READ_SHARD_PREFERENCE = "es.read.shard.preference";
+    String ES_READ_SHARD_PREFERENCE_DEFAULT = "";
+
     /** Elasticsearch batch size given in bytes */
     String ES_BATCH_SIZE_BYTES = "es.batch.size.bytes";
     String ES_BATCH_SIZE_BYTES_DEFAULT = "1mb";

--- a/mr/src/main/java/org/elasticsearch/hadoop/cfg/Settings.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/cfg/Settings.java
@@ -79,6 +79,8 @@ public abstract class Settings {
         return Booleans.parseBoolean(getProperty(ES_NODES_DISCOVERY), !getNodesWANOnly());
     }
 
+    public String getShardPreference() { return getProperty(ES_READ_SHARD_PREFERENCE, ES_READ_SHARD_PREFERENCE_DEFAULT); }
+
     public String getNodesPathPrefix() {
         return getProperty(ES_NODES_PATH_PREFIX, ES_NODES_PATH_PREFIX_DEFAULT);
     }

--- a/mr/src/main/java/org/elasticsearch/hadoop/rest/RestService.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/rest/RestService.java
@@ -452,6 +452,7 @@ public abstract class RestService implements Serializable {
                         .shard(Integer.toString(partition.getShardId()))
                         .readMetadata(settings.getReadMetadata())
                         .local(true)
+                        .preference(settings.getShardPreference())
                         .excludeSource(settings.getExcludeSource());
         if (partition.getSlice() != null && partition.getSlice().max > 1) {
             requestBuilder.slice(partition.getSlice().id, partition.getSlice().max);

--- a/mr/src/main/java/org/elasticsearch/hadoop/rest/SearchRequestBuilder.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/rest/SearchRequestBuilder.java
@@ -215,7 +215,7 @@ public class SearchRequestBuilder {
             pref.append("_shards:");
             pref.append(shard);
         }
-        if (!preference.isEmpty() || local) {
+        if (!StringUtils.hasText(preference) || local) {
             if (pref.length() > 0) {
                 if (version.onOrAfter(EsMajorVersion.V_5_X)) {
                     pref.append("|");
@@ -223,7 +223,7 @@ public class SearchRequestBuilder {
                     pref.append(";");
                 }
             }
-            if (!preference.isEmpty()) {
+            if (!StringUtils.hasText(preference)) {
                 pref.append(preference);
             } else {
                 pref.append("_local");

--- a/mr/src/main/java/org/elasticsearch/hadoop/rest/SearchRequestBuilder.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/rest/SearchRequestBuilder.java
@@ -215,7 +215,7 @@ public class SearchRequestBuilder {
             pref.append("_shards:");
             pref.append(shard);
         }
-        if (!StringUtils.hasText(preference) || local) {
+        if (local || StringUtils.hasText(preference)) {
             if (pref.length() > 0) {
                 if (version.onOrAfter(EsMajorVersion.V_5_X)) {
                     pref.append("|");
@@ -223,7 +223,7 @@ public class SearchRequestBuilder {
                     pref.append(";");
                 }
             }
-            if (!StringUtils.hasText(preference)) {
+            if (StringUtils.hasText(preference)) {
                 pref.append(preference);
             } else {
                 pref.append("_local");

--- a/mr/src/main/java/org/elasticsearch/hadoop/rest/SearchRequestBuilder.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/rest/SearchRequestBuilder.java
@@ -68,6 +68,7 @@ public class SearchRequestBuilder {
     private String routing;
     private Slice slice;
     private boolean local = false;
+    private String preference = "";
     private boolean excludeSource = false;
     private boolean readMetadata = false;
 
@@ -165,6 +166,11 @@ public class SearchRequestBuilder {
         return this;
     }
 
+    public SearchRequestBuilder preference(String preference) {
+        this.preference = preference;
+        return this;
+    }
+
     public SearchRequestBuilder excludeSource(boolean value) {
         if (value) {
             Assert.hasNoText(this.fields, String.format("_source section can't be excluded if fields [%s] are requested", this.fields));
@@ -209,7 +215,7 @@ public class SearchRequestBuilder {
             pref.append("_shards:");
             pref.append(shard);
         }
-        if (local) {
+        if (!preference.isEmpty() || local) {
             if (pref.length() > 0) {
                 if (version.onOrAfter(EsMajorVersion.V_5_X)) {
                     pref.append("|");
@@ -217,7 +223,11 @@ public class SearchRequestBuilder {
                     pref.append(";");
                 }
             }
-            pref.append("_local");
+            if (!preference.isEmpty()) {
+                pref.append(preference);
+            } else {
+                pref.append("_local");
+            }
         }
 
         if (pref.length() > 0) {

--- a/mr/src/test/java/org/elasticsearch/hadoop/rest/SearchRequestBuilderTest.java
+++ b/mr/src/test/java/org/elasticsearch/hadoop/rest/SearchRequestBuilderTest.java
@@ -19,6 +19,7 @@
 package org.elasticsearch.hadoop.rest;
 
 import org.elasticsearch.hadoop.util.EsMajorVersion;
+import org.elasticsearch.hadoop.util.encoding.HttpEncodingTools;
 import org.junit.Test;
 
 import static org.junit.Assert.assertTrue;
@@ -41,6 +42,7 @@ public class SearchRequestBuilderTest {
     @Test
     public void testPreference() {
         String preferenceString = "_only_nodes:abc*";
+        String encodedPreferenceString = HttpEncodingTools.encode(preferenceString);
 
         EsMajorVersion esVersion = EsMajorVersion.LATEST;
         SearchRequestBuilder localOnlyBuilder = new SearchRequestBuilder(esVersion, true)
@@ -56,10 +58,10 @@ public class SearchRequestBuilderTest {
         // If local=false and a preference is specified then query string contains the preference and not "_local"
         String preferenceOnlyString = preferenceOnlyBuilder.toString();
         assertFalse(preferenceOnlyString.contains("_local"));
-        assertTrue(preferenceOnlyString.contains(preferenceString));
+        assertTrue(preferenceOnlyString.contains(encodedPreferenceString));
         // If local=true and a preference is specified then query string contains the preference and not "_local"
         String localWithPreferenceString = localWithPreferenceBuilder.toString();
         assertFalse(localWithPreferenceString.contains("_local"));
-        assertTrue(localWithPreferenceString.contains(preferenceString));
+        assertTrue(localWithPreferenceString.contains(encodedPreferenceString));
     }
 }

--- a/mr/src/test/java/org/elasticsearch/hadoop/rest/SearchRequestBuilderTest.java
+++ b/mr/src/test/java/org/elasticsearch/hadoop/rest/SearchRequestBuilderTest.java
@@ -22,6 +22,7 @@ import org.elasticsearch.hadoop.util.EsMajorVersion;
 import org.junit.Test;
 
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 
 public class SearchRequestBuilderTest {
 
@@ -35,5 +36,30 @@ public class SearchRequestBuilderTest {
 
         assertTrue(includeVersionBuilder.toString().contains(versionQueryParam));
         assertTrue(!noVersionBuilder.toString().contains(versionQueryParam));
+    }
+
+    @Test
+    public void testPreference() {
+        String preferenceString = "_only_nodes:abc*";
+
+        EsMajorVersion esVersion = EsMajorVersion.LATEST;
+        SearchRequestBuilder localOnlyBuilder = new SearchRequestBuilder(esVersion, true)
+                .local(true);
+        SearchRequestBuilder preferenceOnlyBuilder = new SearchRequestBuilder(esVersion, true)
+                .preference(preferenceString);
+        SearchRequestBuilder localWithPreferenceBuilder = new SearchRequestBuilder(esVersion, true)
+                .local(true)
+                .preference(preferenceString);
+
+        // If local=true and no preference is specified then query string contains "_local"
+        assertTrue(localOnlyBuilder.toString().contains("_local"));
+        // If local=false and a preference is specified then query string contains the preference and not "_local"
+        String preferenceOnlyString = preferenceOnlyBuilder.toString();
+        assertFalse(preferenceOnlyString.contains("_local"));
+        assertTrue(preferenceOnlyString.contains(preferenceString));
+        // If local=true and a preference is specified then query string contains the preference and not "_local"
+        String localWithPreferenceString = localWithPreferenceBuilder.toString();
+        assertFalse(localWithPreferenceString.contains("_local"));
+        assertTrue(localWithPreferenceString.contains(preferenceString));
     }
 }


### PR DESCRIPTION
…arch preference query string parameter to be set on searches.

Thank you for submitting a pull request! 

Please make sure you have signed our [Contributor License Agreement (CLA)][].  
We are not asking you to assign copyright to us, but to give us the right to distribute your code without restriction. We ask this of all contributors in order to assure our users of the origin and continuing existence of the code.  
You only need to sign the CLA once.

- [ ] I have signed the [Contributor License Agreement (CLA)][]

[Contributor License Agreement (CLA)]: https://www.elastic.co/contributor-agreement/
