### PR TITLE
Add a build qualifier system property to the build

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -10,16 +10,31 @@ boolean localRepo = project.getProperties().containsKey("localRepo")
 
 Properties props = new Properties()
 props.load(project.file('esh-version.properties').newDataInputStream())
-version = props.getProperty('eshadoop')
+String eshVersion = props.getProperty('eshadoop')
 String esVersion = props.getProperty('elasticsearch')
+
+// TODO: This default should be removed when ES stops using alpha1 as its default qualifier
+String qualifier = System.getProperty("build.version_qualifier", "alpha1")
+if (qualifier.isEmpty() == false) {
+    if (qualifier.matches("(alpha|beta|rc)\\d+") == false) {
+        throw new IllegalStateException("Invalid qualifier: " + qualifier)
+    }
+    eshVersion += "-" + qualifier
+    esVersion += "-" + qualifier
+}
 
 // determine if we're building a snapshot or not (by default we will be)
 boolean snapshot = "true".equals(System.getProperty("build.snapshot", "true"))
 if (snapshot) {
     // we update the version property to reflect if we are building a snapshot or a release build
-    version += "-SNAPSHOT"
-    props.put("eshadoop", version)
+    eshVersion += "-SNAPSHOT"
+    esVersion += "-SNAPSHOT"
 }
+
+props.put("eshadoop", eshVersion)
+props.put("elasticsearch", eshVersion)
+
+// determine if we're building a prerelease or candidate (alpha1/rc1/
 
 repositories {
     jcenter()
@@ -45,7 +60,7 @@ dependencies {
     compile 'org.springframework.build.gradle:propdeps-plugin:0.0.7'
 
     if (localRepo) {
-        compile name: "build-tools-${version}"
+        compile name: "build-tools-${esVersion}"
     } else {
         compile group: 'org.elasticsearch.gradle', name: 'build-tools', version: esVersion
     }

--- a/buildSrc/esh-version.properties
+++ b/buildSrc/esh-version.properties
@@ -1,2 +1,2 @@
-eshadoop        = 7.0.0-alpha1
-elasticsearch   = 7.0.0-alpha1-SNAPSHOT
+eshadoop        = 7.0.0
+elasticsearch   = 7.0.0


### PR DESCRIPTION
Allows build processes to pick up a qualifier to add into the version
at build time instead of depending on it from a version file. By
default, it will continue to use alpha1 as the qualifier until the ES
build changes the master branch to ship an unqualified snapshot version
during the 7 prerelease period.
