### PR TITLE
Bump the 6.x branch to 6.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,14 +19,14 @@ ES-Hadoop 2.0.x and 2.1.x are compatible with Elasticsearch __1.X__ *only*
 
 ## Installation
 
-### Stable Release (currently `6.6.0`)
+### Stable Release (currently `6.7.0`)
 Available through any Maven-compatible tool:
 
 ```xml
 <dependency>
   <groupId>org.elasticsearch</groupId>
   <artifactId>elasticsearch-hadoop</artifactId>
-  <version>6.6.0</version>
+  <version>6.7.0</version>
 </dependency>
 ```
 or as a stand-alone [ZIP](http://www.elastic.co/downloads/hadoop).
@@ -38,7 +38,7 @@ Grab the latest nightly build from the [repository](http://oss.sonatype.org/cont
 <dependency>
   <groupId>org.elasticsearch</groupId>
   <artifactId>elasticsearch-hadoop</artifactId>
-  <version>6.6.0-SNAPSHOT</version>
+  <version>6.7.0-SNAPSHOT</version>
 </dependency>
 ```
 

--- a/buildSrc/esh-version.properties
+++ b/buildSrc/esh-version.properties
@@ -1,2 +1,2 @@
-eshadoop        = 6.6.0
-elasticsearch   = 6.6.0-SNAPSHOT
+eshadoop        = 6.7.0
+elasticsearch   = 6.7.0-SNAPSHOT

--- a/docs/src/reference/asciidoc/index.adoc
+++ b/docs/src/reference/asciidoc/index.adoc
@@ -10,9 +10,9 @@
 :ey:	Elasticsearch on YARN
 :ref:  	http://www.elastic.co/guide/en/elasticsearch/reference/5.0
 :description: Reference documentation of {eh}
-:ver:	6.6.0
-:ver-d: 6.6.0.BUILD-SNAPSHOT
-:es-v:	6.6.0
+:ver:	6.7.0
+:ver-d: 6.7.0.BUILD-SNAPSHOT
+:es-v:	6.7.0
 :sp-v:	2.2.0
 :st-v:	1.0.1
 :pg-v:	0.15.0


### PR DESCRIPTION
This commit bumps the 6.x branch to 6.7.0 now that the 6.6 branch is cut from 6.x.

