### PR TITLE
Fix DateIndexFormatterTest

### DIFF
--- a/mr/src/test/java/org/elasticsearch/hadoop/serialization/field/DateIndexFormatterTest.java
+++ b/mr/src/test/java/org/elasticsearch/hadoop/serialization/field/DateIndexFormatterTest.java
@@ -31,7 +31,7 @@ public class DateIndexFormatterTest {
     @Test
     public void testTimeYMDFormat() {
         formatter.configure("YYYY.MM.dd");
-        assertThat(formatter.format("2014-10-06T19:20:25.000Z"), is("2014.10.06"));
+        assertThat(formatter.format("2014-10-06T19:20:25.000"), is("2014.10.06"));
     }
 
     @Test

--- a/pig/src/test/java/org/elasticsearch/hadoop/pig/DateIndexFormatterTest.java
+++ b/pig/src/test/java/org/elasticsearch/hadoop/pig/DateIndexFormatterTest.java
@@ -33,7 +33,7 @@ public class DateIndexFormatterTest {
     @Test
     public void testTimeYMDFormat() {
         formatter.configure("YYYY.MM.dd");
-        String date = convertPigDate("2014-10-05T19:09:52.000Z");
+        String date = convertPigDate("2014-10-05T19:09:52.000");
         assertThat(formatter.format(date), is("2014.10.05"));
     }
 


### PR DESCRIPTION
Now pulling the code and doing `./gradlew test` fails `DateIndexFormatterTest`:
```
org.elasticsearch.hadoop.serialization.field.DateIndexFormatterTest > testTimeYMDFormat FAILED
    java.lang.AssertionError at DateIndexFormatterTest.java:34

1348 tests completed, 1 failed, 470 skipped
```

It is due to timezone difference. I think it is better to make the test passed no matter timezone.

- [X] I have signed the [Contributor License Agreement (CLA)][]

[Contributor License Agreement (CLA)]: https://www.elastic.co/contributor-agreement/
