### PR TITLE
Fix the integration test suites usage of typeless api calls

### DIFF
--- a/hive/src/itest/java/org/elasticsearch/hadoop/integration/hive/AbstractHiveExtraTests.java
+++ b/hive/src/itest/java/org/elasticsearch/hadoop/integration/hive/AbstractHiveExtraTests.java
@@ -53,7 +53,7 @@ public class AbstractHiveExtraTests {
     @Test
     public void testQuery() throws Exception {
         String resource;
-        if (TestUtils.getEsClusterInfo().getMajorVersion().onOrAfter(EsMajorVersion.V_8_X)) {
+        if (TestUtils.isTypelessVersion(TestUtils.getEsClusterInfo().getMajorVersion())) {
             resource = "cars";
         } else {
             resource = "cars/transactions";
@@ -90,7 +90,7 @@ public class AbstractHiveExtraTests {
         RestUtils.touch("hive-date-as-long");
         RestUtils.putMapping("hive-date-as-long", "data", "org/elasticsearch/hadoop/hive/hive-date-typeless-mapping.json");
 
-        if (TestUtils.getEsClusterInfo().getMajorVersion().onOrAfter(EsMajorVersion.V_8_X)) {
+        if (TestUtils.isTypelessVersion(TestUtils.getEsClusterInfo().getMajorVersion())) {
             RestUtils.postData(resource + "/_doc/1", "{\"type\" : 1, \"&t\" : 1407239910771}".getBytes());
         } else {
             RestUtils.postData(resource + "/data/1", "{\"type\" : 1, \"&t\" : 1407239910771}".getBytes());

--- a/hive/src/itest/java/org/elasticsearch/hadoop/integration/hive/AbstractHiveReadJsonTest.java
+++ b/hive/src/itest/java/org/elasticsearch/hadoop/integration/hive/AbstractHiveReadJsonTest.java
@@ -40,6 +40,7 @@ import java.util.List;
 
 import static org.elasticsearch.hadoop.integration.hive.HiveSuite.provisionEsLib;
 import static org.elasticsearch.hadoop.integration.hive.HiveSuite.server;
+import static org.elasticsearch.hadoop.util.TestUtils.resource;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 
@@ -80,7 +81,7 @@ public class AbstractHiveReadJsonTest {
     public void basicLoad() throws Exception {
 
         String create = "CREATE EXTERNAL TABLE jsonartistsread" + testInstance + " (data INT, garbage INT, garbage2 STRING) "
-                + tableProps(resource("json-hive-artists", "data"), "'es.output.json' = 'true'", "'es.mapping.names'='garbage2:refuse'");
+                + tableProps(resource("json-hive-artists", "data", targetVersion), "'es.output.json' = 'true'", "'es.mapping.names'='garbage2:refuse'");
 
         String select = "SELECT * FROM jsonartistsread" + testInstance;
 
@@ -96,7 +97,7 @@ public class AbstractHiveReadJsonTest {
     public void basicLoadWithNameMappings() throws Exception {
 
         String create = "CREATE EXTERNAL TABLE jsonartistsread" + testInstance + " (refuse INT, garbage INT, data STRING) "
-                + tableProps(resource("json-hive-artists", "data"), "'es.output.json' = 'true'", "'es.mapping.names'='data:boomSomethingYouWerentExpecting'");
+                + tableProps(resource("json-hive-artists", "data", targetVersion), "'es.output.json' = 'true'", "'es.mapping.names'='data:boomSomethingYouWerentExpecting'");
 
         String select = "SELECT * FROM jsonartistsread" + testInstance;
 
@@ -112,7 +113,7 @@ public class AbstractHiveReadJsonTest {
     public void basicLoadWithNoGoodCandidateField() throws Exception {
 
         String create = "CREATE EXTERNAL TABLE jsonartistsread" + testInstance + " (refuse INT, garbage INT) "
-                + tableProps(resource("json-hive-artists", "data"), "'es.output.json' = 'true'");
+                + tableProps(resource("json-hive-artists", "data", targetVersion), "'es.output.json' = 'true'");
 
         String select = "SELECT * FROM jsonartistsread" + testInstance;
 
@@ -125,7 +126,7 @@ public class AbstractHiveReadJsonTest {
     @Test
     public void testMissingIndex() throws Exception {
         String create = "CREATE EXTERNAL TABLE jsonmissingread" + testInstance + " (data STRING) "
-                + tableProps(resource("foobar", "missing"), "'es.index.read.missing.as.empty' = 'true'", "'es.output.json' = 'true'");
+                + tableProps(resource("foobar", "missing", targetVersion), "'es.index.read.missing.as.empty' = 'true'", "'es.output.json' = 'true'");
 
         String select = "SELECT * FROM jsonmissingread" + testInstance;
 
@@ -156,7 +157,7 @@ public class AbstractHiveReadJsonTest {
 
         String create = "CREATE EXTERNAL TABLE jsonartistscollisionread" + testInstance + " (data INT, garbage INT, garbage2 STRING) "
                 + tableProps(
-                    resource("json-hive-artists", "data"),
+                    resource("json-hive-artists", "data", targetVersion),
                     "'es.output.json' = 'true'",
                     "'es.read.source.filter'='name'"
                 );
@@ -170,14 +171,6 @@ public class AbstractHiveReadJsonTest {
         assertContains(result, "Marilyn");
         assertThat(result, not(hasItem(containsString("last.fm/music/MALICE"))));
         assertThat(result, not(hasItem(containsString("last.fm/serve/252/5872875.jpg"))));
-    }
-
-    private String resource(String index, String type) {
-        if (TestUtils.isTypelessVersion(targetVersion)) {
-            return index;
-        } else {
-            return index + "/" + type;
-        }
     }
 
     private static boolean containsNoNull(List<String> str) {

--- a/hive/src/itest/java/org/elasticsearch/hadoop/integration/hive/AbstractHiveReadJsonTest.java
+++ b/hive/src/itest/java/org/elasticsearch/hadoop/integration/hive/AbstractHiveReadJsonTest.java
@@ -173,7 +173,7 @@ public class AbstractHiveReadJsonTest {
     }
 
     private String resource(String index, String type) {
-        if (targetVersion.onOrAfter(EsMajorVersion.V_8_X)) {
+        if (TestUtils.isTypelessVersion(targetVersion)) {
             return index;
         } else {
             return index + "/" + type;

--- a/hive/src/itest/java/org/elasticsearch/hadoop/integration/hive/AbstractHiveSaveJsonTest.java
+++ b/hive/src/itest/java/org/elasticsearch/hadoop/integration/hive/AbstractHiveSaveJsonTest.java
@@ -28,6 +28,7 @@ import org.elasticsearch.hadoop.mr.EsAssume;
 import org.elasticsearch.hadoop.mr.RestUtils;
 import org.elasticsearch.hadoop.util.EsMajorVersion;
 import org.elasticsearch.hadoop.util.StringUtils;
+import org.elasticsearch.hadoop.util.TestUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.FixMethodOrder;
@@ -40,10 +41,12 @@ import static org.elasticsearch.hadoop.integration.hive.HiveSuite.server;
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class AbstractHiveSaveJsonTest {
 
+    private EsMajorVersion targetVersion;
 
     @Before
     public void before() throws Exception {
         HiveSuite.before();
+        targetVersion = TestUtils.getEsClusterInfo().getMajorVersion();
     }
 
     @After
@@ -69,7 +72,7 @@ public class AbstractHiveSaveJsonTest {
         String ddl =
                 "CREATE EXTERNAL TABLE jsonartistssave ("
                         + "json     STRING) "
-                        + tableProps("json-hive-artists/data");
+                        + tableProps(resource("json-hive-artists", "data"));
 
         // transfer data
         String insert =
@@ -97,7 +100,7 @@ public class AbstractHiveSaveJsonTest {
         String ddl =
                 "CREATE EXTERNAL TABLE jsonexternalserdetest ("
                         + "data     STRING) "
-                        + tableProps("json-hive-externalserde/data");
+                        + tableProps(resource("json-hive-externalserde", "data"));
 
         String insert =
                 "INSERT OVERWRITE TABLE jsonexternalserdetest "
@@ -119,7 +122,7 @@ public class AbstractHiveSaveJsonTest {
         String ddl =
                 "CREATE EXTERNAL TABLE jsonvarcharsave ("
                         + "json     VARCHAR(255))"
-                        + tableProps("json-hive-varcharsave/data");
+                        + tableProps(resource("json-hive-varcharsave", "data"));
 
         // transfer data
         String insert =
@@ -145,7 +148,7 @@ public class AbstractHiveSaveJsonTest {
         String ddl =
                 "CREATE EXTERNAL TABLE jsoncreatesave ("
                         + "json     STRING) "
-                        + tableProps("json-hive-createsave/data",
+                        + tableProps(resource("json-hive-createsave", "data"),
                                 "'" + ConfigurationOptions.ES_MAPPING_ID + "'='number'",
                                 "'" + ConfigurationOptions.ES_WRITE_OPERATION + "'='create'");
 
@@ -173,7 +176,7 @@ public class AbstractHiveSaveJsonTest {
         String ddl =
                 "CREATE EXTERNAL TABLE jsoncreatesaveduplicate ("
                         + "json     STRING) "
-                        + tableProps("json-hive-createsave/data",
+                        + tableProps(resource("json-hive-createsave", "data"),
                                 "'" + ConfigurationOptions.ES_MAPPING_ID + "'='number'",
                                 "'" + ConfigurationOptions.ES_WRITE_OPERATION + "'='create'");
 
@@ -204,7 +207,7 @@ public class AbstractHiveSaveJsonTest {
         String ddl =
                 "CREATE EXTERNAL TABLE jsonupdatesave ("
                         + "json     STRING) "
-                        + tableProps("json-hive-updatesave/data",
+                        + tableProps(resource("json-hive-updatesave", "data"),
                                 "'" + ConfigurationOptions.ES_MAPPING_ID + "'='number'",
                                 "'" + ConfigurationOptions.ES_WRITE_OPERATION + "'='upsert'");
 
@@ -236,7 +239,7 @@ public class AbstractHiveSaveJsonTest {
         String ddl =
                 "CREATE EXTERNAL TABLE jsonupdatewoupsertsave ("
                         + "json     STRING) "
-                        + tableProps("json-hive-updatewoupsertsave/data",
+                        + tableProps(resource("json-hive-updatewoupsertsave", "data"),
                                 "'" + ConfigurationOptions.ES_MAPPING_ID + "'='number'",
                                 "'" + ConfigurationOptions.ES_WRITE_OPERATION + "'='update'");
 
@@ -300,7 +303,7 @@ public class AbstractHiveSaveJsonTest {
         String ddl =
                 "CREATE EXTERNAL TABLE jsonpattern ("
                         + "json     STRING) "
-                        + tableProps("json-hive-pattern-{number}/data");
+                        + tableProps(resource("json-hive-pattern-{number}", "data"));
 
         String selectTest = "SELECT s.json FROM jsonsourcepattern s";
 
@@ -330,7 +333,7 @@ public class AbstractHiveSaveJsonTest {
         String ddl =
                 "CREATE EXTERNAL TABLE jsonpatternformat ("
                         + "json     STRING) "
-                        + tableProps("json-hive-pattern-format-{@timestamp|YYYY-MM-dd}/data");
+                        + tableProps(resource("json-hive-pattern-format-{@timestamp|YYYY-MM-dd}", "data"));
 
         String selectTest = "SELECT s.json FROM jsonsourcepatternformat s";
 
@@ -345,6 +348,14 @@ public class AbstractHiveSaveJsonTest {
         System.out.println(server.execute(load));
         System.out.println(server.execute(selectTest));
         System.out.println(server.execute(insert));
+    }
+
+    private String resource(String index, String type) {
+        if (targetVersion.onOrAfter(EsMajorVersion.V_8_X)) {
+            return index;
+        } else {
+            return index + "/" + type;
+        }
     }
 
     private String createTable(String tableName) {

--- a/hive/src/itest/java/org/elasticsearch/hadoop/integration/hive/AbstractHiveSaveJsonTest.java
+++ b/hive/src/itest/java/org/elasticsearch/hadoop/integration/hive/AbstractHiveSaveJsonTest.java
@@ -37,6 +37,7 @@ import org.junit.runners.MethodSorters;
 
 import static org.elasticsearch.hadoop.integration.hive.HiveSuite.isLocal;
 import static org.elasticsearch.hadoop.integration.hive.HiveSuite.server;
+import static org.elasticsearch.hadoop.util.TestUtils.resource;
 
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class AbstractHiveSaveJsonTest {
@@ -72,7 +73,7 @@ public class AbstractHiveSaveJsonTest {
         String ddl =
                 "CREATE EXTERNAL TABLE jsonartistssave ("
                         + "json     STRING) "
-                        + tableProps(resource("json-hive-artists", "data"));
+                        + tableProps(resource("json-hive-artists", "data", targetVersion));
 
         // transfer data
         String insert =
@@ -100,7 +101,7 @@ public class AbstractHiveSaveJsonTest {
         String ddl =
                 "CREATE EXTERNAL TABLE jsonexternalserdetest ("
                         + "data     STRING) "
-                        + tableProps(resource("json-hive-externalserde", "data"));
+                        + tableProps(resource("json-hive-externalserde", "data", targetVersion));
 
         String insert =
                 "INSERT OVERWRITE TABLE jsonexternalserdetest "
@@ -122,7 +123,7 @@ public class AbstractHiveSaveJsonTest {
         String ddl =
                 "CREATE EXTERNAL TABLE jsonvarcharsave ("
                         + "json     VARCHAR(255))"
-                        + tableProps(resource("json-hive-varcharsave", "data"));
+                        + tableProps(resource("json-hive-varcharsave", "data", targetVersion));
 
         // transfer data
         String insert =
@@ -148,7 +149,7 @@ public class AbstractHiveSaveJsonTest {
         String ddl =
                 "CREATE EXTERNAL TABLE jsoncreatesave ("
                         + "json     STRING) "
-                        + tableProps(resource("json-hive-createsave", "data"),
+                        + tableProps(resource("json-hive-createsave", "data", targetVersion),
                                 "'" + ConfigurationOptions.ES_MAPPING_ID + "'='number'",
                                 "'" + ConfigurationOptions.ES_WRITE_OPERATION + "'='create'");
 
@@ -176,7 +177,7 @@ public class AbstractHiveSaveJsonTest {
         String ddl =
                 "CREATE EXTERNAL TABLE jsoncreatesaveduplicate ("
                         + "json     STRING) "
-                        + tableProps(resource("json-hive-createsave", "data"),
+                        + tableProps(resource("json-hive-createsave", "data", targetVersion),
                                 "'" + ConfigurationOptions.ES_MAPPING_ID + "'='number'",
                                 "'" + ConfigurationOptions.ES_WRITE_OPERATION + "'='create'");
 
@@ -207,7 +208,7 @@ public class AbstractHiveSaveJsonTest {
         String ddl =
                 "CREATE EXTERNAL TABLE jsonupdatesave ("
                         + "json     STRING) "
-                        + tableProps(resource("json-hive-updatesave", "data"),
+                        + tableProps(resource("json-hive-updatesave", "data", targetVersion),
                                 "'" + ConfigurationOptions.ES_MAPPING_ID + "'='number'",
                                 "'" + ConfigurationOptions.ES_WRITE_OPERATION + "'='upsert'");
 
@@ -239,7 +240,7 @@ public class AbstractHiveSaveJsonTest {
         String ddl =
                 "CREATE EXTERNAL TABLE jsonupdatewoupsertsave ("
                         + "json     STRING) "
-                        + tableProps(resource("json-hive-updatewoupsertsave", "data"),
+                        + tableProps(resource("json-hive-updatewoupsertsave", "data", targetVersion),
                                 "'" + ConfigurationOptions.ES_MAPPING_ID + "'='number'",
                                 "'" + ConfigurationOptions.ES_WRITE_OPERATION + "'='update'");
 
@@ -303,7 +304,7 @@ public class AbstractHiveSaveJsonTest {
         String ddl =
                 "CREATE EXTERNAL TABLE jsonpattern ("
                         + "json     STRING) "
-                        + tableProps(resource("json-hive-pattern-{number}", "data"));
+                        + tableProps(resource("json-hive-pattern-{number}", "data", targetVersion));
 
         String selectTest = "SELECT s.json FROM jsonsourcepattern s";
 
@@ -333,7 +334,7 @@ public class AbstractHiveSaveJsonTest {
         String ddl =
                 "CREATE EXTERNAL TABLE jsonpatternformat ("
                         + "json     STRING) "
-                        + tableProps(resource("json-hive-pattern-format-{@timestamp|YYYY-MM-dd}", "data"));
+                        + tableProps(resource("json-hive-pattern-format-{@timestamp|YYYY-MM-dd}", "data", targetVersion));
 
         String selectTest = "SELECT s.json FROM jsonsourcepatternformat s";
 
@@ -348,14 +349,6 @@ public class AbstractHiveSaveJsonTest {
         System.out.println(server.execute(load));
         System.out.println(server.execute(selectTest));
         System.out.println(server.execute(insert));
-    }
-
-    private String resource(String index, String type) {
-        if (TestUtils.isTypelessVersion(targetVersion)) {
-            return index;
-        } else {
-            return index + "/" + type;
-        }
     }
 
     private String createTable(String tableName) {

--- a/hive/src/itest/java/org/elasticsearch/hadoop/integration/hive/AbstractHiveSaveJsonTest.java
+++ b/hive/src/itest/java/org/elasticsearch/hadoop/integration/hive/AbstractHiveSaveJsonTest.java
@@ -351,7 +351,7 @@ public class AbstractHiveSaveJsonTest {
     }
 
     private String resource(String index, String type) {
-        if (targetVersion.onOrAfter(EsMajorVersion.V_8_X)) {
+        if (TestUtils.isTypelessVersion(targetVersion)) {
             return index;
         } else {
             return index + "/" + type;

--- a/hive/src/itest/java/org/elasticsearch/hadoop/integration/hive/AbstractHiveSaveTest.java
+++ b/hive/src/itest/java/org/elasticsearch/hadoop/integration/hive/AbstractHiveSaveTest.java
@@ -695,10 +695,7 @@ public class AbstractHiveSaveTest {
         System.out.println(server.execute(selectTest));
         System.out.println(server.execute(insert));
 
-        String docEndpoint = resource("hive-fieldexclude", "data");
-        if (TestUtils.isTypelessVersion(targetVersion)) {
-            docEndpoint = docEndpoint + "/_doc";
-        }
+        String docEndpoint = docEndpoint("hive-fieldexclude", "data");
         String string = RestUtils.get(docEndpoint + "/1");
         assertThat(string, containsString("MALICE"));
 
@@ -711,6 +708,14 @@ public class AbstractHiveSaveTest {
     private String resource(String index, String type) {
         if (TestUtils.isTypelessVersion(targetVersion)) {
             return index;
+        } else {
+            return index + "/" + type;
+        }
+    }
+
+    private String docEndpoint(String index, String type) {
+        if (TestUtils.isTypelessVersion(targetVersion)) {
+            return index + "/_doc";
         } else {
             return index + "/" + type;
         }

--- a/hive/src/itest/java/org/elasticsearch/hadoop/integration/hive/AbstractHiveSaveTest.java
+++ b/hive/src/itest/java/org/elasticsearch/hadoop/integration/hive/AbstractHiveSaveTest.java
@@ -696,7 +696,7 @@ public class AbstractHiveSaveTest {
         System.out.println(server.execute(insert));
 
         String docEndpoint = resource("hive-fieldexclude", "data");
-        if (targetVersion.onOrAfter(EsMajorVersion.V_8_X)) {
+        if (TestUtils.isTypelessVersion(targetVersion)) {
             docEndpoint = docEndpoint + "/_doc";
         }
         String string = RestUtils.get(docEndpoint + "/1");
@@ -709,7 +709,7 @@ public class AbstractHiveSaveTest {
     }
 
     private String resource(String index, String type) {
-        if (targetVersion.onOrAfter(EsMajorVersion.V_8_X)) {
+        if (TestUtils.isTypelessVersion(targetVersion)) {
             return index;
         } else {
             return index + "/" + type;

--- a/hive/src/itest/java/org/elasticsearch/hadoop/integration/hive/AbstractHiveSaveTest.java
+++ b/hive/src/itest/java/org/elasticsearch/hadoop/integration/hive/AbstractHiveSaveTest.java
@@ -32,6 +32,8 @@ import org.junit.Test;
 import org.junit.runners.MethodSorters;
 
 import static org.elasticsearch.hadoop.util.EsMajorVersion.V_5_X;
+import static org.elasticsearch.hadoop.util.TestUtils.docEndpoint;
+import static org.elasticsearch.hadoop.util.TestUtils.resource;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 
@@ -71,7 +73,7 @@ public class AbstractHiveSaveTest {
                         + "id       BIGINT, "
                         + "name     STRING, "
                         + "links    STRUCT<url:STRING, picture:STRING>) "
-                        + tableProps(resource("hive-artists", "data"));
+                        + tableProps(resource("hive-artists", "data", targetVersion));
 
         String selectTest = "SELECT s.name, struct(s.url, s.picture) FROM source s";
 
@@ -102,7 +104,7 @@ public class AbstractHiveSaveTest {
                         + "id       BIGINT, "
                         + "name     STRING, "
                         + "ts       STRING) "
-                        + tableProps(resource("hive-savemeta", "data"), "'es.mapping.id' = 'id'", "'es.mapping.version' = '<\"5\">'");
+                        + tableProps(resource("hive-savemeta", "data", targetVersion), "'es.mapping.id' = 'id'", "'es.mapping.version' = '<\"5\">'");
 
         String selectTest = "SELECT s.name, s.ts FROM sourcewithmetadata s";
 
@@ -158,7 +160,7 @@ public class AbstractHiveSaveTest {
                         + "rid      INT, "
                         + "mapids   ARRAY<INT>, "
                         + "rdata    MAP<INT, STRING>) "
-                        + tableProps(resource("hive-compound", "data"));
+                        + tableProps(resource("hive-compound", "data", targetVersion));
 
         String selectTest = "SELECT rid, mapids, rdata FROM compoundsource";
 
@@ -197,7 +199,7 @@ public class AbstractHiveSaveTest {
                         + "dte     TIMESTAMP, "
                         + "name     STRING, "
                         + "links    STRUCT<url:STRING, picture:STRING>) "
-                        + tableProps(resource("hive-artiststimestamp", "data"));
+                        + tableProps(resource("hive-artiststimestamp", "data", targetVersion));
 
         String currentDate = "SELECT *, from_unixtime(unix_timestamp()) from timestampsource";
 
@@ -234,7 +236,7 @@ public class AbstractHiveSaveTest {
                         + "dTE     TIMESTAMP, "
                         + "Name     STRING, "
                         + "links    STRUCT<uRl:STRING, pICture:STRING>) "
-                        + tableProps(resource("hive-aliassave", "data"), "'es.mapping.names' = 'dTE:@timestamp, uRl:url_123'");
+                        + tableProps(resource("hive-aliassave", "data", targetVersion), "'es.mapping.names' = 'dTE:@timestamp, uRl:url_123'");
 
         // since the date format is different in Hive vs ISO8601/Joda, save only the date (which is the same) as a string
         // we do this since unix_timestamp() saves the date as a long (in seconds) and w/o mapping the date is not recognized as data
@@ -270,7 +272,7 @@ public class AbstractHiveSaveTest {
                         + "date     DATE, "
                         + "name     STRING, "
                         + "links    STRUCT<url:STRING, picture:STRING>) "
-                        + tableProps(resource("hive-datesave", "data"));
+                        + tableProps(resource("hive-datesave", "data", targetVersion));
 
         // this works
         String someDate = "SELECT cast('2013-10-21' as date) from datesource";
@@ -309,7 +311,7 @@ public class AbstractHiveSaveTest {
                         + "id       BIGINT, "
                         + "name     CHAR(20), "
                         + "links    STRUCT<url:STRING, picture:STRING>) "
-                        + tableProps(resource("hive-charsave", "data"));
+                        + tableProps(resource("hive-charsave", "data", targetVersion));
 
         // this does not
         String insert =
@@ -345,7 +347,7 @@ public class AbstractHiveSaveTest {
         String ddl =
                 "CREATE EXTERNAL TABLE externalserdetest ("
                         + "data     STRING)"
-                        + tableProps(resource("hive-externalserde", "data"));
+                        + tableProps(resource("hive-externalserde", "data", targetVersion));
 
         String insert =
                 "INSERT OVERWRITE TABLE externalserdetest "
@@ -377,7 +379,7 @@ public class AbstractHiveSaveTest {
                         + "id       BIGINT, "
                         + "name     VARCHAR(10), "
                         + "links    STRUCT<url:STRING, picture:STRING>) "
-                        + tableProps(resource("hive-varcharsave", "data"));
+                        + tableProps(resource("hive-varcharsave", "data", targetVersion));
 
         // transfer data
         String insert =
@@ -413,7 +415,7 @@ public class AbstractHiveSaveTest {
                         + "id       BIGINT, "
                         + "name     STRING, "
                         + "links    STRUCT<url:STRING, picture:STRING>) "
-                        + tableProps(resource("hive-createsave", "data"),
+                        + tableProps(resource("hive-createsave", "data", targetVersion),
                                 "'" + ConfigurationOptions.ES_MAPPING_ID + "'='id'",
                                 "'" + ConfigurationOptions.ES_WRITE_OPERATION + "'='create'");
 
@@ -454,7 +456,7 @@ public class AbstractHiveSaveTest {
                         + "id       BIGINT, "
                         + "name     STRING, "
                         + "links    STRUCT<url:STRING, picture:STRING>) "
-                        + tableProps(resource("hive-createsave", "data"),
+                        + tableProps(resource("hive-createsave", "data", targetVersion),
                                 "'" + ConfigurationOptions.ES_MAPPING_ID + "'='id'",
                                 "'" + ConfigurationOptions.ES_WRITE_OPERATION + "'='create'");
 
@@ -487,7 +489,7 @@ public class AbstractHiveSaveTest {
                         + "id       BIGINT, "
                         + "name     STRING, "
                         + "links    STRUCT<url:STRING, picture:STRING>) "
-                        + tableProps(resource("hive-updatesave", "data"),
+                        + tableProps(resource("hive-updatesave", "data", targetVersion),
                                 "'" + ConfigurationOptions.ES_MAPPING_ID + "'='id'",
                                 "'" + ConfigurationOptions.ES_WRITE_OPERATION + "'='upsert'");
 
@@ -528,7 +530,7 @@ public class AbstractHiveSaveTest {
                         + "id       BIGINT, "
                         + "name     STRING, "
                         + "links    STRUCT<url:STRING, picture:STRING>) "
-                        + tableProps(resource("hive-updatewoupsertsave", "data"),
+                        + tableProps(resource("hive-updatewoupsertsave", "data", targetVersion),
                                 "'" + ConfigurationOptions.ES_MAPPING_ID + "'='id'",
                                 "'" + ConfigurationOptions.ES_WRITE_OPERATION + "'='update'");
 
@@ -604,7 +606,7 @@ public class AbstractHiveSaveTest {
                         + "id       BIGINT, "
                         + "name     STRING, "
                         + "links    STRUCT<url:STRING, picture:STRING>) "
-                        + tableProps(resource("hive-pattern-{id}", "data"));
+                        + tableProps(resource("hive-pattern-{id}", "data", targetVersion));
 
         String selectTest = "SELECT s.name, struct(s.url, s.picture) FROM sourcepattern s";
 
@@ -644,7 +646,7 @@ public class AbstractHiveSaveTest {
                         + "name     STRING, "
                         + "ts       STRING, "
                         + "links    STRUCT<url:STRING, picture:STRING>) "
-                        + tableProps(resource("hive-pattern-format-{ts|YYYY-MM-dd}", "data"));
+                        + tableProps(resource("hive-pattern-format-{ts|YYYY-MM-dd}", "data", targetVersion));
 
         String selectTest = "SELECT s.name, s.ts, struct(s.url, s.picture) FROM sourcepatternformat s";
 
@@ -679,7 +681,7 @@ public class AbstractHiveSaveTest {
                 "CREATE EXTERNAL TABLE fieldexclude ("
                         + "id       BIGINT, "
                         + "name     STRING)"
-                        + tableProps(resource("hive-fieldexclude", "data"), "'es.mapping.id'='id'", "'es.mapping.exclude'='id'");
+                        + tableProps(resource("hive-fieldexclude", "data", targetVersion), "'es.mapping.id'='id'", "'es.mapping.exclude'='id'");
 
         String selectTest = "SELECT s.id, s.name FROM sourcefieldexclude s";
 
@@ -695,7 +697,7 @@ public class AbstractHiveSaveTest {
         System.out.println(server.execute(selectTest));
         System.out.println(server.execute(insert));
 
-        String docEndpoint = docEndpoint("hive-fieldexclude", "data");
+        String docEndpoint = docEndpoint("hive-fieldexclude", "data", targetVersion);
         String string = RestUtils.get(docEndpoint + "/1");
         assertThat(string, containsString("MALICE"));
 
@@ -703,22 +705,6 @@ public class AbstractHiveSaveTest {
         assertThat(string, containsString("Manson"));
 
         assertFalse(RestUtils.getMappings("hive-fieldexclude").getResolvedView().toString().contains("id="));
-    }
-
-    private String resource(String index, String type) {
-        if (TestUtils.isTypelessVersion(targetVersion)) {
-            return index;
-        } else {
-            return index + "/" + type;
-        }
-    }
-
-    private String docEndpoint(String index, String type) {
-        if (TestUtils.isTypelessVersion(targetVersion)) {
-            return index + "/_doc";
-        } else {
-            return index + "/" + type;
-        }
     }
 
     private String createTable(String tableName) {

--- a/hive/src/itest/java/org/elasticsearch/hadoop/integration/hive/AbstractHiveSaveTest.java
+++ b/hive/src/itest/java/org/elasticsearch/hadoop/integration/hive/AbstractHiveSaveTest.java
@@ -32,7 +32,6 @@ import org.junit.Test;
 import org.junit.runners.MethodSorters;
 
 import static org.elasticsearch.hadoop.util.EsMajorVersion.V_5_X;
-import static org.elasticsearch.hadoop.util.EsMajorVersion.V_6_X;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 
@@ -72,7 +71,7 @@ public class AbstractHiveSaveTest {
                         + "id       BIGINT, "
                         + "name     STRING, "
                         + "links    STRUCT<url:STRING, picture:STRING>) "
-                        + tableProps("hive-artists/data");
+                        + tableProps(resource("hive-artists", "data"));
 
         String selectTest = "SELECT s.name, struct(s.url, s.picture) FROM source s";
 
@@ -103,7 +102,7 @@ public class AbstractHiveSaveTest {
                         + "id       BIGINT, "
                         + "name     STRING, "
                         + "ts       STRING) "
-                        + tableProps("hive-savemeta/data", "'es.mapping.id' = 'id'", "'es.mapping.version' = '<\"5\">'");
+                        + tableProps(resource("hive-savemeta", "data"), "'es.mapping.id' = 'id'", "'es.mapping.version' = '<\"5\">'");
 
         String selectTest = "SELECT s.name, s.ts FROM sourcewithmetadata s";
 
@@ -159,7 +158,7 @@ public class AbstractHiveSaveTest {
                         + "rid      INT, "
                         + "mapids   ARRAY<INT>, "
                         + "rdata    MAP<INT, STRING>) "
-                        + tableProps("hive-compound/data");
+                        + tableProps(resource("hive-compound", "data"));
 
         String selectTest = "SELECT rid, mapids, rdata FROM compoundsource";
 
@@ -198,7 +197,7 @@ public class AbstractHiveSaveTest {
                         + "dte     TIMESTAMP, "
                         + "name     STRING, "
                         + "links    STRUCT<url:STRING, picture:STRING>) "
-                        + tableProps("hive-artiststimestamp/data");
+                        + tableProps(resource("hive-artiststimestamp", "data"));
 
         String currentDate = "SELECT *, from_unixtime(unix_timestamp()) from timestampsource";
 
@@ -235,7 +234,7 @@ public class AbstractHiveSaveTest {
                         + "dTE     TIMESTAMP, "
                         + "Name     STRING, "
                         + "links    STRUCT<uRl:STRING, pICture:STRING>) "
-                        + tableProps("hive-aliassave/data", "'es.mapping.names' = 'dTE:@timestamp, uRl:url_123'");
+                        + tableProps(resource("hive-aliassave", "data"), "'es.mapping.names' = 'dTE:@timestamp, uRl:url_123'");
 
         // since the date format is different in Hive vs ISO8601/Joda, save only the date (which is the same) as a string
         // we do this since unix_timestamp() saves the date as a long (in seconds) and w/o mapping the date is not recognized as data
@@ -271,7 +270,7 @@ public class AbstractHiveSaveTest {
                         + "date     DATE, "
                         + "name     STRING, "
                         + "links    STRUCT<url:STRING, picture:STRING>) "
-                        + tableProps("hive-datesave/data");
+                        + tableProps(resource("hive-datesave", "data"));
 
         // this works
         String someDate = "SELECT cast('2013-10-21' as date) from datesource";
@@ -310,7 +309,7 @@ public class AbstractHiveSaveTest {
                         + "id       BIGINT, "
                         + "name     CHAR(20), "
                         + "links    STRUCT<url:STRING, picture:STRING>) "
-                        + tableProps("hive-charsave/data");
+                        + tableProps(resource("hive-charsave", "data"));
 
         // this does not
         String insert =
@@ -346,7 +345,7 @@ public class AbstractHiveSaveTest {
         String ddl =
                 "CREATE EXTERNAL TABLE externalserdetest ("
                         + "data     STRING)"
-                        + tableProps("hive-externalserde/data");
+                        + tableProps(resource("hive-externalserde", "data"));
 
         String insert =
                 "INSERT OVERWRITE TABLE externalserdetest "
@@ -378,7 +377,7 @@ public class AbstractHiveSaveTest {
                         + "id       BIGINT, "
                         + "name     VARCHAR(10), "
                         + "links    STRUCT<url:STRING, picture:STRING>) "
-                        + tableProps("hive-varcharsave/data");
+                        + tableProps(resource("hive-varcharsave", "data"));
 
         // transfer data
         String insert =
@@ -414,7 +413,7 @@ public class AbstractHiveSaveTest {
                         + "id       BIGINT, "
                         + "name     STRING, "
                         + "links    STRUCT<url:STRING, picture:STRING>) "
-                        + tableProps("hive-createsave/data",
+                        + tableProps(resource("hive-createsave", "data"),
                                 "'" + ConfigurationOptions.ES_MAPPING_ID + "'='id'",
                                 "'" + ConfigurationOptions.ES_WRITE_OPERATION + "'='create'");
 
@@ -455,7 +454,7 @@ public class AbstractHiveSaveTest {
                         + "id       BIGINT, "
                         + "name     STRING, "
                         + "links    STRUCT<url:STRING, picture:STRING>) "
-                        + tableProps("hive-createsave/data",
+                        + tableProps(resource("hive-createsave", "data"),
                                 "'" + ConfigurationOptions.ES_MAPPING_ID + "'='id'",
                                 "'" + ConfigurationOptions.ES_WRITE_OPERATION + "'='create'");
 
@@ -488,7 +487,7 @@ public class AbstractHiveSaveTest {
                         + "id       BIGINT, "
                         + "name     STRING, "
                         + "links    STRUCT<url:STRING, picture:STRING>) "
-                        + tableProps("hive-updatesave/data",
+                        + tableProps(resource("hive-updatesave", "data"),
                                 "'" + ConfigurationOptions.ES_MAPPING_ID + "'='id'",
                                 "'" + ConfigurationOptions.ES_WRITE_OPERATION + "'='upsert'");
 
@@ -529,7 +528,7 @@ public class AbstractHiveSaveTest {
                         + "id       BIGINT, "
                         + "name     STRING, "
                         + "links    STRUCT<url:STRING, picture:STRING>) "
-                        + tableProps("hive-updatewoupsertsave/data",
+                        + tableProps(resource("hive-updatewoupsertsave", "data"),
                                 "'" + ConfigurationOptions.ES_MAPPING_ID + "'='id'",
                                 "'" + ConfigurationOptions.ES_WRITE_OPERATION + "'='update'");
 
@@ -605,7 +604,7 @@ public class AbstractHiveSaveTest {
                         + "id       BIGINT, "
                         + "name     STRING, "
                         + "links    STRUCT<url:STRING, picture:STRING>) "
-                        + tableProps("hive-pattern-{id}/data");
+                        + tableProps(resource("hive-pattern-{id}", "data"));
 
         String selectTest = "SELECT s.name, struct(s.url, s.picture) FROM sourcepattern s";
 
@@ -645,7 +644,7 @@ public class AbstractHiveSaveTest {
                         + "name     STRING, "
                         + "ts       STRING, "
                         + "links    STRUCT<url:STRING, picture:STRING>) "
-                        + tableProps("hive-pattern-format-{ts|YYYY-MM-dd}/data");
+                        + tableProps(resource("hive-pattern-format-{ts|YYYY-MM-dd}", "data"));
 
         String selectTest = "SELECT s.name, s.ts, struct(s.url, s.picture) FROM sourcepatternformat s";
 
@@ -680,7 +679,7 @@ public class AbstractHiveSaveTest {
                 "CREATE EXTERNAL TABLE fieldexclude ("
                         + "id       BIGINT, "
                         + "name     STRING)"
-                        + tableProps("hive-fieldexclude/data", "'es.mapping.id'='id'", "'es.mapping.exclude'='id'");
+                        + tableProps(resource("hive-fieldexclude", "data"), "'es.mapping.id'='id'", "'es.mapping.exclude'='id'");
 
         String selectTest = "SELECT s.id, s.name FROM sourcefieldexclude s";
 
@@ -696,13 +695,25 @@ public class AbstractHiveSaveTest {
         System.out.println(server.execute(selectTest));
         System.out.println(server.execute(insert));
 
-        String string = RestUtils.get("hive-fieldexclude/data/1");
+        String docEndpoint = resource("hive-fieldexclude", "data");
+        if (targetVersion.onOrAfter(EsMajorVersion.V_8_X)) {
+            docEndpoint = docEndpoint + "/_doc";
+        }
+        String string = RestUtils.get(docEndpoint + "/1");
         assertThat(string, containsString("MALICE"));
 
-        string = RestUtils.get("hive-fieldexclude/data/7");
+        string = RestUtils.get(docEndpoint + "/7");
         assertThat(string, containsString("Manson"));
 
         assertFalse(RestUtils.getMappings("hive-fieldexclude").getResolvedView().toString().contains("id="));
+    }
+
+    private String resource(String index, String type) {
+        if (targetVersion.onOrAfter(EsMajorVersion.V_8_X)) {
+            return index;
+        } else {
+            return index + "/" + type;
+        }
     }
 
     private String createTable(String tableName) {

--- a/hive/src/itest/java/org/elasticsearch/hadoop/integration/hive/AbstractHiveSearchJsonTest.java
+++ b/hive/src/itest/java/org/elasticsearch/hadoop/integration/hive/AbstractHiveSearchJsonTest.java
@@ -82,7 +82,7 @@ public class AbstractHiveSearchJsonTest {
     public void loadMultiNestedField() throws Exception {
         Assume.assumeTrue(testInstance == 0);
         String docEndpoint = resource("json-hive-nestedmap", "data");
-        if (targetVersion.onOrAfter(EsMajorVersion.V_8_X)) {
+        if (TestUtils.isTypelessVersion(targetVersion)) {
             docEndpoint = docEndpoint + "/_doc";
         }
 
@@ -123,7 +123,7 @@ public class AbstractHiveSearchJsonTest {
     public void loadSingleNestedField() throws Exception {
         Assume.assumeTrue(testInstance == 0);
         String docEndpoint = resource("json-hive-nestedmap", "data");
-        if (targetVersion.onOrAfter(EsMajorVersion.V_8_X)) {
+        if (TestUtils.isTypelessVersion(targetVersion)) {
             docEndpoint = docEndpoint + "/_doc";
         }
 
@@ -268,7 +268,7 @@ public class AbstractHiveSearchJsonTest {
     }
 
     private String resource(String index, String type) {
-        if (targetVersion.onOrAfter(EsMajorVersion.V_8_X)) {
+        if (TestUtils.isTypelessVersion(targetVersion)) {
             return index;
         } else {
             return index + "/" + type;

--- a/hive/src/itest/java/org/elasticsearch/hadoop/integration/hive/AbstractHiveSearchJsonTest.java
+++ b/hive/src/itest/java/org/elasticsearch/hadoop/integration/hive/AbstractHiveSearchJsonTest.java
@@ -39,6 +39,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
+import static org.elasticsearch.hadoop.util.TestUtils.resource;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -81,7 +82,7 @@ public class AbstractHiveSearchJsonTest {
     @Test
     public void loadMultiNestedField() throws Exception {
         Assume.assumeTrue(testInstance == 0);
-        String docEndpoint = resource("json-hive-nestedmap", "data");
+        String docEndpoint = resource("json-hive-nestedmap", "data", targetVersion);
         if (TestUtils.isTypelessVersion(targetVersion)) {
             docEndpoint = docEndpoint + "/_doc";
         }
@@ -95,13 +96,13 @@ public class AbstractHiveSearchJsonTest {
 
         String createList = "CREATE EXTERNAL TABLE jsonnestedmaplistload" + testInstance + "("
                 + "nested   ARRAY<INT>) "
-                + tableProps(resource("json-hive-nestedmap", "data"), "'es.mapping.names' = 'nested:data.map.key'");
+                + tableProps(resource("json-hive-nestedmap", "data", targetVersion), "'es.mapping.names' = 'nested:data.map.key'");
 
         String selectList = "SELECT * FROM jsonnestedmaplistload" + testInstance;
 
         String createMap = "CREATE EXTERNAL TABLE jsonnestedmapmapload" + testInstance + "("
                 + "nested   MAP<STRING,ARRAY<INT>>) "
-                + tableProps(resource("json-hive-nestedmap", "data"), "'es.mapping.names' = 'nested:data.map'");
+                + tableProps(resource("json-hive-nestedmap", "data", targetVersion), "'es.mapping.names' = 'nested:data.map'");
 
         String selectMap = "SELECT * FROM jsonnestedmapmapload" + testInstance;
 
@@ -122,7 +123,7 @@ public class AbstractHiveSearchJsonTest {
     @Test
     public void loadSingleNestedField() throws Exception {
         Assume.assumeTrue(testInstance == 0);
-        String docEndpoint = resource("json-hive-nestedmap", "data");
+        String docEndpoint = resource("json-hive-nestedmap", "data", targetVersion);
         if (TestUtils.isTypelessVersion(targetVersion)) {
             docEndpoint = docEndpoint + "/_doc";
         }
@@ -134,13 +135,13 @@ public class AbstractHiveSearchJsonTest {
 
         String createList = "CREATE EXTERNAL TABLE jsonnestedsinglemaplistload" + testInstance + "("
                 + "nested   ARRAY<INT>) "
-                + tableProps(resource("json-hive-nestedmap", "data"), "'es.mapping.names' = 'nested:data.single.key'");
+                + tableProps(resource("json-hive-nestedmap", "data", targetVersion), "'es.mapping.names' = 'nested:data.single.key'");
 
         String selectList = "SELECT * FROM jsonnestedsinglemaplistload" + testInstance;
 
         String createMap = "CREATE EXTERNAL TABLE jsonnestedsinglemapmapload" + testInstance + "("
                 + "nested   MAP<STRING,ARRAY<INT>>) "
-                + tableProps(resource("json-hive-nestedmap", "data"), "'es.mapping.names' = 'nested:data.single'");
+                + tableProps(resource("json-hive-nestedmap", "data", targetVersion), "'es.mapping.names' = 'nested:data.single'");
 
         String selectMap = "SELECT * FROM jsonnestedsinglemapmapload" + testInstance;
 
@@ -165,7 +166,7 @@ public class AbstractHiveSearchJsonTest {
                 + "name     STRING, "
                 + "url  STRING, "
                 + "picture  STRING) "
-                + tableProps(resource("json-hive-artists", "data"));
+                + tableProps(resource("json-hive-artists", "data", targetVersion));
 
         String select = "SELECT * FROM jsonartistsload" + testInstance;
 
@@ -184,7 +185,7 @@ public class AbstractHiveSearchJsonTest {
                 + "name     STRING, "
                 + "url  STRING, "
                 + "picture  STRING) "
-                + tableProps(resource("json-hive-artists", "data"));
+                + tableProps(resource("json-hive-artists", "data", targetVersion));
 
         String select = "SELECT count(*) FROM jsonartistscount" + testInstance;
 
@@ -201,7 +202,7 @@ public class AbstractHiveSearchJsonTest {
                 + "dTE     TIMESTAMP, "
                 + "Name     STRING, "
                 + "links    STRUCT<uRl:STRING, pICture:STRING>) "
-                + tableProps(resource("foobar", "missing"), "'es.index.read.missing.as.empty' = 'true'");
+                + tableProps(resource("foobar", "missing", targetVersion), "'es.index.read.missing.as.empty' = 'true'");
 
         String select = "SELECT * FROM jsonmissing" + testInstance;
 
@@ -218,7 +219,7 @@ public class AbstractHiveSearchJsonTest {
                 + "name     STRING, "
                 + "url  STRING, "
                 + "picture  STRING) "
-                + tableProps(resource("json-hive-varcharsave", "data"));
+                + tableProps(resource("json-hive-varcharsave", "data", targetVersion));
 
         String select = "SELECT * FROM jsonvarcharload" + testInstance;
 
@@ -255,24 +256,16 @@ public class AbstractHiveSearchJsonTest {
 
     @Test
     public void testDynamicPattern() throws Exception {
-        Assert.assertTrue(RestUtils.exists(resource("json-hive-pattern-7", "data")));
-        Assert.assertTrue(RestUtils.exists(resource("json-hive-pattern-10", "data")));
-        Assert.assertTrue(RestUtils.exists(resource("json-hive-pattern-3", "data")));
+        Assert.assertTrue(RestUtils.exists(resource("json-hive-pattern-7", "data", targetVersion)));
+        Assert.assertTrue(RestUtils.exists(resource("json-hive-pattern-10", "data", targetVersion)));
+        Assert.assertTrue(RestUtils.exists(resource("json-hive-pattern-3", "data", targetVersion)));
     }
 
     @Test
     public void testDynamicPatternFormat() throws Exception {
-        Assert.assertTrue(RestUtils.exists(resource("json-hive-pattern-format-2007-10-06", "data")));
-        Assert.assertTrue(RestUtils.exists(resource("json-hive-pattern-format-2001-10-06", "data")));
-        Assert.assertTrue(RestUtils.exists(resource("json-hive-pattern-format-2000-10-06", "data")));
-    }
-
-    private String resource(String index, String type) {
-        if (TestUtils.isTypelessVersion(targetVersion)) {
-            return index;
-        } else {
-            return index + "/" + type;
-        }
+        Assert.assertTrue(RestUtils.exists(resource("json-hive-pattern-format-2007-10-06", "data", targetVersion)));
+        Assert.assertTrue(RestUtils.exists(resource("json-hive-pattern-format-2001-10-06", "data", targetVersion)));
+        Assert.assertTrue(RestUtils.exists(resource("json-hive-pattern-format-2000-10-06", "data", targetVersion)));
     }
 
     private static boolean containsNoNull(List<String> str) {

--- a/hive/src/itest/java/org/elasticsearch/hadoop/integration/hive/AbstractHiveSearchJsonTest.java
+++ b/hive/src/itest/java/org/elasticsearch/hadoop/integration/hive/AbstractHiveSearchJsonTest.java
@@ -29,6 +29,7 @@ import org.elasticsearch.hadoop.mr.EsAssume;
 import org.elasticsearch.hadoop.mr.RestUtils;
 import org.elasticsearch.hadoop.util.EsMajorVersion;
 import org.elasticsearch.hadoop.util.StringUtils;
+import org.elasticsearch.hadoop.util.TestUtils;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Assume;
@@ -50,6 +51,7 @@ public class AbstractHiveSearchJsonTest {
 
     private static int testInstance = 0;
     private final boolean readMetadata;
+    private EsMajorVersion targetVersion;
 
     @Parameters
     public static Collection<Object[]> queries() {
@@ -67,6 +69,7 @@ public class AbstractHiveSearchJsonTest {
     public void before() throws Exception {
         provisionEsLib();
         RestUtils.refresh("json-hive*");
+        targetVersion = TestUtils.getEsClusterInfo().getMajorVersion();
     }
 
     @After
@@ -78,22 +81,27 @@ public class AbstractHiveSearchJsonTest {
     @Test
     public void loadMultiNestedField() throws Exception {
         Assume.assumeTrue(testInstance == 0);
+        String docEndpoint = resource("json-hive-nestedmap", "data");
+        if (targetVersion.onOrAfter(EsMajorVersion.V_8_X)) {
+            docEndpoint = docEndpoint + "/_doc";
+        }
+
         String data = "{ \"data\" : { \"map\" : { \"key\" : [ 10 20 ] } } }";
-        RestUtils.postData("json-hive-nestedmap/data", StringUtils.toUTF(data));
+        RestUtils.postData(docEndpoint, StringUtils.toUTF(data));
         data = "{ \"data\" : { \"different\" : \"structure\" } } }";
-        RestUtils.postData("json-hive-nestedmap/data", StringUtils.toUTF(data));
+        RestUtils.postData(docEndpoint, StringUtils.toUTF(data));
 
         RestUtils.refresh("json-hive*");
 
         String createList = "CREATE EXTERNAL TABLE jsonnestedmaplistload" + testInstance + "("
                 + "nested   ARRAY<INT>) "
-                + tableProps("json-hive-nestedmap/data", "'es.mapping.names' = 'nested:data.map.key'");
+                + tableProps(resource("json-hive-nestedmap", "data"), "'es.mapping.names' = 'nested:data.map.key'");
 
         String selectList = "SELECT * FROM jsonnestedmaplistload" + testInstance;
 
         String createMap = "CREATE EXTERNAL TABLE jsonnestedmapmapload" + testInstance + "("
                 + "nested   MAP<STRING,ARRAY<INT>>) "
-                + tableProps("json-hive-nestedmap/data", "'es.mapping.names' = 'nested:data.map'");
+                + tableProps(resource("json-hive-nestedmap", "data"), "'es.mapping.names' = 'nested:data.map'");
 
         String selectMap = "SELECT * FROM jsonnestedmapmapload" + testInstance;
 
@@ -114,20 +122,25 @@ public class AbstractHiveSearchJsonTest {
     @Test
     public void loadSingleNestedField() throws Exception {
         Assume.assumeTrue(testInstance == 0);
+        String docEndpoint = resource("json-hive-nestedmap", "data");
+        if (targetVersion.onOrAfter(EsMajorVersion.V_8_X)) {
+            docEndpoint = docEndpoint + "/_doc";
+        }
+
         String data = "{ \"data\" : { \"single\" : { \"key\" : [ 10 ] } } }";
-        RestUtils.postData("json-hive-nestedmap/data", StringUtils.toUTF(data));
+        RestUtils.postData(docEndpoint, StringUtils.toUTF(data));
 
         RestUtils.refresh("json-hive*");
 
         String createList = "CREATE EXTERNAL TABLE jsonnestedsinglemaplistload" + testInstance + "("
                 + "nested   ARRAY<INT>) "
-                + tableProps("json-hive-nestedmap/data", "'es.mapping.names' = 'nested:data.single.key'");
+                + tableProps(resource("json-hive-nestedmap", "data"), "'es.mapping.names' = 'nested:data.single.key'");
 
         String selectList = "SELECT * FROM jsonnestedsinglemaplistload" + testInstance;
 
         String createMap = "CREATE EXTERNAL TABLE jsonnestedsinglemapmapload" + testInstance + "("
                 + "nested   MAP<STRING,ARRAY<INT>>) "
-                + tableProps("json-hive-nestedmap/data", "'es.mapping.names' = 'nested:data.single'");
+                + tableProps(resource("json-hive-nestedmap", "data"), "'es.mapping.names' = 'nested:data.single'");
 
         String selectMap = "SELECT * FROM jsonnestedsinglemapmapload" + testInstance;
 
@@ -152,7 +165,7 @@ public class AbstractHiveSearchJsonTest {
                 + "name     STRING, "
                 + "url  STRING, "
                 + "picture  STRING) "
-                + tableProps("json-hive-artists/data");
+                + tableProps(resource("json-hive-artists", "data"));
 
         String select = "SELECT * FROM jsonartistsload" + testInstance;
 
@@ -171,7 +184,7 @@ public class AbstractHiveSearchJsonTest {
                 + "name     STRING, "
                 + "url  STRING, "
                 + "picture  STRING) "
-                + tableProps("json-hive-artists/data");
+                + tableProps(resource("json-hive-artists", "data"));
 
         String select = "SELECT count(*) FROM jsonartistscount" + testInstance;
 
@@ -188,7 +201,7 @@ public class AbstractHiveSearchJsonTest {
                 + "dTE     TIMESTAMP, "
                 + "Name     STRING, "
                 + "links    STRUCT<uRl:STRING, pICture:STRING>) "
-                + tableProps("foobar/missing", "'es.index.read.missing.as.empty' = 'true'");
+                + tableProps(resource("foobar", "missing"), "'es.index.read.missing.as.empty' = 'true'");
 
         String select = "SELECT * FROM jsonmissing" + testInstance;
 
@@ -205,7 +218,7 @@ public class AbstractHiveSearchJsonTest {
                 + "name     STRING, "
                 + "url  STRING, "
                 + "picture  STRING) "
-                + tableProps("json-hive-varcharsave/data");
+                + tableProps(resource("json-hive-varcharsave", "data"));
 
         String select = "SELECT * FROM jsonvarcharload" + testInstance;
 
@@ -242,16 +255,24 @@ public class AbstractHiveSearchJsonTest {
 
     @Test
     public void testDynamicPattern() throws Exception {
-        Assert.assertTrue(RestUtils.exists("json-hive-pattern-7/data"));
-        Assert.assertTrue(RestUtils.exists("json-hive-pattern-10/data"));
-        Assert.assertTrue(RestUtils.exists("json-hive-pattern-3/data"));
+        Assert.assertTrue(RestUtils.exists(resource("json-hive-pattern-7", "data")));
+        Assert.assertTrue(RestUtils.exists(resource("json-hive-pattern-10", "data")));
+        Assert.assertTrue(RestUtils.exists(resource("json-hive-pattern-3", "data")));
     }
 
     @Test
     public void testDynamicPatternFormat() throws Exception {
-        Assert.assertTrue(RestUtils.exists("json-hive-pattern-format-2007-10-06/data"));
-        Assert.assertTrue(RestUtils.exists("json-hive-pattern-format-2001-10-06/data"));
-        Assert.assertTrue(RestUtils.exists("json-hive-pattern-format-2000-10-06/data"));
+        Assert.assertTrue(RestUtils.exists(resource("json-hive-pattern-format-2007-10-06", "data")));
+        Assert.assertTrue(RestUtils.exists(resource("json-hive-pattern-format-2001-10-06", "data")));
+        Assert.assertTrue(RestUtils.exists(resource("json-hive-pattern-format-2000-10-06", "data")));
+    }
+
+    private String resource(String index, String type) {
+        if (targetVersion.onOrAfter(EsMajorVersion.V_8_X)) {
+            return index;
+        } else {
+            return index + "/" + type;
+        }
     }
 
     private static boolean containsNoNull(List<String> str) {

--- a/hive/src/itest/java/org/elasticsearch/hadoop/integration/hive/AbstractHiveSearchTest.java
+++ b/hive/src/itest/java/org/elasticsearch/hadoop/integration/hive/AbstractHiveSearchTest.java
@@ -42,6 +42,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
+import static org.elasticsearch.hadoop.util.TestUtils.resource;
 import static org.junit.Assert.*;
 
 import static org.elasticsearch.hadoop.integration.hive.HiveSuite.*;
@@ -87,7 +88,7 @@ public class AbstractHiveSearchTest {
                 + "id         BIGINT, "
                 + "name     STRING, "
                 + "links     STRUCT<url:STRING, picture:STRING>) "
-                + tableProps(resource("hive-artists", "data"));
+                + tableProps(resource("hive-artists", "data", targetVersion));
 
         String select = "SELECT * FROM artistsload" + testInstance;
 
@@ -107,7 +108,7 @@ public class AbstractHiveSearchTest {
                 + "name     STRING, "
                 + "links     STRUCT<url:STRING, picture:STRING>, "
                 + "meta     MAP<STRING, STRING>) "
-                + tableProps(resource("hive-artists", "data"), "'es.read.metadata.field'='meta'");
+                + tableProps(resource("hive-artists", "data", targetVersion), "'es.read.metadata.field'='meta'");
 
         String select = "SELECT meta FROM artistsload" + testInstance;
 
@@ -124,7 +125,7 @@ public class AbstractHiveSearchTest {
                 + "id       BIGINT, "
                 + "name     STRING, "
                 + "links    STRUCT<url:STRING, picture:STRING>) "
-                + tableProps(resource("hive-artists", "data"));
+                + tableProps(resource("hive-artists", "data", targetVersion));
 
         String select = "SELECT count(*) FROM artistscount" + testInstance;
 
@@ -141,7 +142,7 @@ public class AbstractHiveSearchTest {
                 + "rid      BIGINT, "
                 + "mapids   ARRAY<BIGINT>, "
                 + "rdata    MAP<STRING, STRING>) "
-                + tableProps(resource("hive-compound", "data"));
+                + tableProps(resource("hive-compound", "data", targetVersion));
 
         String select = "SELECT * FROM compoundarray" + testInstance;
 
@@ -160,7 +161,7 @@ public class AbstractHiveSearchTest {
                 + "date     TIMESTAMP, "
                 + "name     STRING, "
                 + "links    STRUCT<url:STRING, picture:STRING>) "
-                + tableProps(resource("hive-artiststimestamp", "data"));
+                + tableProps(resource("hive-artiststimestamp", "data", targetVersion));
 
         String select = "SELECT date FROM timestampload" + testInstance;
         String select2 = "SELECT unix_timestamp(), date FROM timestampload" + testInstance;
@@ -187,7 +188,7 @@ public class AbstractHiveSearchTest {
                 + "date     DATE, "
                 + "name     STRING, "
                 + "links    STRUCT<url:STRING, picture:STRING>) "
-                + tableProps(resource("hive-datesave", "data"));
+                + tableProps(resource("hive-datesave", "data", targetVersion));
 
         String select = "SELECT date FROM dateload" + testInstance;
         String select2 = "SELECT unix_timestamp(), date FROM dateload" + testInstance;
@@ -205,7 +206,7 @@ public class AbstractHiveSearchTest {
                 + "id       BIGINT, "
                 + "name     STRING, "
                 + "links    STRUCT<url:STRING, picture:STRING>) "
-                + tableProps(resource("hive-artists", "data"));
+                + tableProps(resource("hive-artists", "data", targetVersion));
 
         long currentTimeMillis = System.currentTimeMillis();
 
@@ -223,7 +224,7 @@ public class AbstractHiveSearchTest {
                 + "dTE     TIMESTAMP, "
                 + "Name     STRING, "
                 + "links    STRUCT<uRl:STRING, pICture:STRING>) "
-                + tableProps(resource("hive-aliassave", "data"), "'es.mapping.names' = 'dTE:@timestamp, uRl:url_123'");
+                + tableProps(resource("hive-aliassave", "data", targetVersion), "'es.mapping.names' = 'dTE:@timestamp, uRl:url_123'");
 
         String select = "SELECT * FROM aliasload" + testInstance;
 
@@ -242,7 +243,7 @@ public class AbstractHiveSearchTest {
                 + "dTE     TIMESTAMP, "
                 + "Name     STRING, "
                 + "links    STRUCT<uRl:STRING, pICture:STRING>) "
-                + tableProps(resource("foobar", "missing"), "'es.index.read.missing.as.empty' = 'true'");
+                + tableProps(resource("foobar", "missing", targetVersion), "'es.index.read.missing.as.empty' = 'true'");
 
         String select = "SELECT * FROM missing" + testInstance;
 
@@ -258,7 +259,7 @@ public class AbstractHiveSearchTest {
                 + "id         BIGINT, "
                 + "name     STRING, "
                 + "links     STRUCT<url:STRING, picture:STRING>) "
-                + tableProps(resource("hive-artists", "data"), "'es.read.source.filter' = 'name,links'");
+                + tableProps(resource("hive-artists", "data", targetVersion), "'es.read.source.filter' = 'name,links'");
 
         String select = "SELECT * FROM collisiontest" + testInstance;
 
@@ -274,7 +275,7 @@ public class AbstractHiveSearchTest {
                 + "id       BIGINT, "
                 + "name     STRING, "
                 + "links    STRUCT<url:STRING, picture:STRING>) "
-                + tableProps(resource("hive-varcharsave", "data"));
+                + tableProps(resource("hive-varcharsave", "data", targetVersion));
 
         String select = "SELECT * FROM varcharload" + testInstance;
 
@@ -294,7 +295,7 @@ public class AbstractHiveSearchTest {
                 + "id       BIGINT, "
                 + "name     STRING, "
                 + "links    STRUCT<url:STRING, picture:STRING>) "
-                + tableProps(resource("hive-charsave", "data"));
+                + tableProps(resource("hive-charsave", "data", targetVersion));
 
         // this does not
         String select = "SELECT * FROM charload" + testInstance;
@@ -335,14 +336,14 @@ public class AbstractHiveSearchTest {
                 + "id       BIGINT, "
                 + "name     STRING, "
                 + "links    STRUCT<url:STRING, picture:STRING>) "
-                + tableProps(resource("hive-rwwrite", "data"));
+                + tableProps(resource("hive-rwwrite", "data", targetVersion));
 
 
         String read = "CREATE EXTERNAL TABLE rwread" + testInstance + " ("
                 + "id       BIGINT, "
                 + "name     STRING, "
                 + "links    STRUCT<url:STRING, picture:STRING>) "
-                + tableProps(resource("hive-artists", "data"));
+                + tableProps(resource("hive-artists", "data", targetVersion));
 
         String selectInsert = "INSERT OVERWRITE TABLE rwwrite" + testInstance + " SELECT * FROM rwread" + testInstance;
         String select = "SELECT * FROM rwwrite" + testInstance;
@@ -366,13 +367,13 @@ public class AbstractHiveSearchTest {
                 + "id       BIGINT, "
                 + "name     STRING, "
                 + "links    STRUCT<url:STRING, picture:STRING>) "
-                + tableProps(resource("hive-artists", "data"));
+                + tableProps(resource("hive-artists", "data", targetVersion));
 
         String right = "CREATE EXTERNAL TABLE right" + testInstance + "("
                 + "id       BIGINT, "
                 + "name     STRING, "
                 + "links    STRUCT<url:STRING, picture:STRING>) "
-                + tableProps(resource("hive-artists", "data"));
+                + tableProps(resource("hive-artists", "data", targetVersion));
 
         String select = "SELECT * FROM left" + testInstance + " l JOIN right" + testInstance + " r ON l.id = r.id";
         //String select = "SELECT * FROM left" + testInstance + " l JOIN source r ON l.id = r.id";
@@ -396,13 +397,13 @@ public class AbstractHiveSearchTest {
                 + "id       BIGINT, "
                 + "name     STRING, "
                 + "links    STRUCT<url:STRING, picture:STRING>) "
-                + tableProps(resource("hive-artists", "data"));
+                + tableProps(resource("hive-artists", "data", targetVersion));
 
         String unionB = "CREATE EXTERNAL TABLE unionb" + testInstance + " ("
                 + "id       BIGINT, "
                 + "name     STRING, "
                 + "links    STRUCT<url:STRING, picture:STRING>) "
-                + tableProps(resource("hive-varcharsave", "data"));
+                + tableProps(resource("hive-varcharsave", "data", targetVersion));
 
         //create two external table
         server.execute(unionA);
@@ -431,24 +432,16 @@ public class AbstractHiveSearchTest {
 
     @Test
     public void testDynamicPattern() throws Exception {
-        Assert.assertTrue(RestUtils.exists(resource("hive-pattern-7", "data")));
-        Assert.assertTrue(RestUtils.exists(resource("hive-pattern-10", "data")));
-        Assert.assertTrue(RestUtils.exists(resource("hive-pattern-15", "data")));
+        Assert.assertTrue(RestUtils.exists(resource("hive-pattern-7", "data", targetVersion)));
+        Assert.assertTrue(RestUtils.exists(resource("hive-pattern-10", "data", targetVersion)));
+        Assert.assertTrue(RestUtils.exists(resource("hive-pattern-15", "data", targetVersion)));
     }
 
     @Test
     public void testDynamicPatternFormat() throws Exception {
-        Assert.assertTrue(RestUtils.exists(resource("hive-pattern-format-2007-10-06", "data")));
-        Assert.assertTrue(RestUtils.exists(resource("hive-pattern-format-2011-10-06", "data")));
-        Assert.assertTrue(RestUtils.exists(resource("hive-pattern-format-2001-10-06", "data")));
-    }
-
-    private String resource(String index, String type) {
-        if (TestUtils.isTypelessVersion(targetVersion)) {
-            return index;
-        } else {
-            return index + "/" + type;
-        }
+        Assert.assertTrue(RestUtils.exists(resource("hive-pattern-format-2007-10-06", "data", targetVersion)));
+        Assert.assertTrue(RestUtils.exists(resource("hive-pattern-format-2011-10-06", "data", targetVersion)));
+        Assert.assertTrue(RestUtils.exists(resource("hive-pattern-format-2001-10-06", "data", targetVersion)));
     }
 
     private static boolean containsNoNull(List<String> str) {

--- a/hive/src/itest/java/org/elasticsearch/hadoop/integration/hive/AbstractHiveSearchTest.java
+++ b/hive/src/itest/java/org/elasticsearch/hadoop/integration/hive/AbstractHiveSearchTest.java
@@ -444,7 +444,7 @@ public class AbstractHiveSearchTest {
     }
 
     private String resource(String index, String type) {
-        if (targetVersion.onOrAfter(EsMajorVersion.V_8_X)) {
+        if (TestUtils.isTypelessVersion(targetVersion)) {
             return index;
         } else {
             return index + "/" + type;

--- a/mr/src/itest/java/org/elasticsearch/hadoop/integration/mr/AbstractExtraMRTests.java
+++ b/mr/src/itest/java/org/elasticsearch/hadoop/integration/mr/AbstractExtraMRTests.java
@@ -164,7 +164,7 @@ public class AbstractExtraMRTests {
         String targetB = resource(targetPrefix + "b", "type");
         String docEndpointA = targetA;
         String docEndpointB = targetB;
-        if (targetVersion.onOrAfter(EsMajorVersion.V_8_X)) {
+        if (TestUtils.isTypelessVersion(targetVersion)) {
             docEndpointA = docEndpointA + "/_doc";
             docEndpointB = docEndpointB + "/_doc";
         }
@@ -188,7 +188,7 @@ public class AbstractExtraMRTests {
     }
 
     private String resource(String index, String type) {
-        if (targetVersion.onOrAfter(EsMajorVersion.V_8_X)) {
+        if (TestUtils.isTypelessVersion(targetVersion)) {
             return index;
         } else {
             return index + "/" + type;

--- a/mr/src/itest/java/org/elasticsearch/hadoop/integration/mr/AbstractMRNewApiSaveTest.java
+++ b/mr/src/itest/java/org/elasticsearch/hadoop/integration/mr/AbstractMRNewApiSaveTest.java
@@ -56,6 +56,7 @@ import org.junit.runners.MethodSorters;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
+import static org.elasticsearch.hadoop.util.TestUtils.resource;
 import static org.junit.Assert.assertFalse;
 
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
@@ -138,7 +139,7 @@ public class AbstractMRNewApiSaveTest {
     @Test
     public void testBasicMultiSave() throws Exception {
         Configuration conf = createConf();
-        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mrnewapi-multi-save", "data"));
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mrnewapi-multi-save", "data", clusterInfo.getMajorVersion()));
 
         MultiOutputFormat.addOutputFormat(conf, EsOutputFormat.class);
         MultiOutputFormat.addOutputFormat(conf, PrintStreamOutputFormat.class);
@@ -155,7 +156,7 @@ public class AbstractMRNewApiSaveTest {
     @Test
     public void testBasicSave() throws Exception {
         Configuration conf = createConf();
-        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mrnewapi-save", "data"));
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mrnewapi-save", "data", clusterInfo.getMajorVersion()));
 
         runJob(conf);
     }
@@ -163,7 +164,7 @@ public class AbstractMRNewApiSaveTest {
     @Test
     public void testSaveWithId() throws Exception {
         Configuration conf = createConf();
-        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mrnewapi-savewithid", "data"));
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mrnewapi-savewithid", "data", clusterInfo.getMajorVersion()));
         conf.set(ConfigurationOptions.ES_MAPPING_ID, "number");
 
         runJob(conf);
@@ -174,7 +175,7 @@ public class AbstractMRNewApiSaveTest {
         Configuration conf = createConf();
         conf.set(ConfigurationOptions.ES_WRITE_OPERATION, "create");
         conf.set(ConfigurationOptions.ES_MAPPING_ID, "number");
-        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mrnewapi-createwithid", "data"));
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mrnewapi-createwithid", "data", clusterInfo.getMajorVersion()));
 
         runJob(conf);
     }
@@ -184,7 +185,7 @@ public class AbstractMRNewApiSaveTest {
         Configuration conf = createConf();
         conf.set(ConfigurationOptions.ES_WRITE_OPERATION, "create");
         conf.set(ConfigurationOptions.ES_MAPPING_ID, "number");
-        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mrnewapi-createwithid", "data"));
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mrnewapi-createwithid", "data", clusterInfo.getMajorVersion()));
 
         assertFalse("job should have failed", runJob(conf));
     }
@@ -201,7 +202,7 @@ public class AbstractMRNewApiSaveTest {
         client.put("/_ingest/pipeline/" + prefix + "-pipeline", StringUtils.toUTF(pipeline));
         client.close();
 
-        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mrnewapi-ingested", "data"));
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mrnewapi-ingested", "data", clusterInfo.getMajorVersion()));
         conf.set(ConfigurationOptions.ES_INGEST_PIPELINE, "mrnewapi-pipeline");
         conf.set(ConfigurationOptions.ES_NODES_INGEST_ONLY, "true");
 
@@ -212,7 +213,7 @@ public class AbstractMRNewApiSaveTest {
     public void testUpdateWithoutId() throws Exception {
         Configuration conf = createConf();
         conf.set(ConfigurationOptions.ES_WRITE_OPERATION, "update");
-        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mrnewapi-update", "data"));
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mrnewapi-update", "data", clusterInfo.getMajorVersion()));
 
         runJob(conf);
     }
@@ -222,7 +223,7 @@ public class AbstractMRNewApiSaveTest {
         Configuration conf = createConf();
         conf.set(ConfigurationOptions.ES_WRITE_OPERATION, "upsert");
         conf.set(ConfigurationOptions.ES_MAPPING_ID, "number");
-        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mrnewapi-update", "data"));
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mrnewapi-update", "data", clusterInfo.getMajorVersion()));
 
         runJob(conf);
     }
@@ -232,7 +233,7 @@ public class AbstractMRNewApiSaveTest {
         Configuration conf = createConf();
         conf.set(ConfigurationOptions.ES_WRITE_OPERATION, "update");
         conf.set(ConfigurationOptions.ES_MAPPING_ID, "number");
-        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mrnewapi-updatewoupsert", "data"));
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mrnewapi-updatewoupsert", "data", clusterInfo.getMajorVersion()));
 
         assertFalse("job should have failed", runJob(conf));
     }
@@ -241,7 +242,7 @@ public class AbstractMRNewApiSaveTest {
     public void testUpdateOnlyScript() throws Exception {
         Configuration conf = createConf();
         // use an existing id to allow the update to succeed
-        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mrnewapi-createwithid", "data"));
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mrnewapi-createwithid", "data", clusterInfo.getMajorVersion()));
         conf.set(ConfigurationOptions.ES_WRITE_OPERATION, "update");
         conf.set(ConfigurationOptions.ES_MAPPING_ID, "number");
 
@@ -262,7 +263,7 @@ public class AbstractMRNewApiSaveTest {
     @Test
     public void testUpdateOnlyParamScript() throws Exception {
         Configuration conf = createConf();
-        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mrnewapi-createwithid", "data"));
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mrnewapi-createwithid", "data", clusterInfo.getMajorVersion()));
         conf.set(ConfigurationOptions.ES_INDEX_AUTO_CREATE, "yes");
 
         conf.set(ConfigurationOptions.ES_WRITE_OPERATION, "update");
@@ -283,7 +284,7 @@ public class AbstractMRNewApiSaveTest {
     @Test
     public void testUpdateOnlyParamJsonScript() throws Exception {
         Configuration conf = createConf();
-        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mrnewapi-createwithid", "data"));
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mrnewapi-createwithid", "data", clusterInfo.getMajorVersion()));
         conf.set(ConfigurationOptions.ES_INDEX_AUTO_CREATE, "yes");
 
         conf.set(ConfigurationOptions.ES_WRITE_OPERATION, "update");
@@ -304,7 +305,7 @@ public class AbstractMRNewApiSaveTest {
     @Test
     public void testUpsertScript() throws Exception {
         Configuration conf = createConf();
-        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mrnewapi-upsert-script", "data"));
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mrnewapi-upsert-script", "data", clusterInfo.getMajorVersion()));
         conf.set(ConfigurationOptions.ES_INDEX_AUTO_CREATE, "yes");
         conf.set(ConfigurationOptions.ES_WRITE_OPERATION, "upsert");
         conf.set(ConfigurationOptions.ES_MAPPING_ID, "number");
@@ -316,7 +317,7 @@ public class AbstractMRNewApiSaveTest {
     @Test
     public void testUpsertParamScript() throws Exception {
         Configuration conf = createConf();
-        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mrnewapi-upsert-script-param", "data"));
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mrnewapi-upsert-script-param", "data", clusterInfo.getMajorVersion()));
         conf.set(ConfigurationOptions.ES_INDEX_AUTO_CREATE, "yes");
         conf.set(ConfigurationOptions.ES_WRITE_OPERATION, "upsert");
         conf.set(ConfigurationOptions.ES_MAPPING_ID, "number");
@@ -336,7 +337,7 @@ public class AbstractMRNewApiSaveTest {
     @Test
     public void testUpsertParamJsonScript() throws Exception {
         Configuration conf = createConf();
-        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mrnewapi-upsert-script-param", "data"));
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mrnewapi-upsert-script-param", "data", clusterInfo.getMajorVersion()));
         conf.set(ConfigurationOptions.ES_INDEX_AUTO_CREATE, "yes");
         conf.set(ConfigurationOptions.ES_WRITE_OPERATION, "upsert");
         conf.set(ConfigurationOptions.ES_MAPPING_ID, "number");
@@ -356,7 +357,7 @@ public class AbstractMRNewApiSaveTest {
     @Test(expected = EsHadoopIllegalArgumentException.class)
     public void testIndexAutoCreateDisabled() throws Exception {
         Configuration conf = createConf();
-        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mrnewapi-non-existing", "data"));
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mrnewapi-non-existing", "data", clusterInfo.getMajorVersion()));
         conf.set(ConfigurationOptions.ES_INDEX_AUTO_CREATE, "no");
 
         runJob(conf);
@@ -388,7 +389,7 @@ public class AbstractMRNewApiSaveTest {
     @Test
     public void testIndexPattern() throws Exception {
         Configuration conf = createConf();
-        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mrnewapi-pattern-{tag}", "data"));
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mrnewapi-pattern-{tag}", "data", clusterInfo.getMajorVersion()));
         conf.set(ConfigurationOptions.ES_INDEX_AUTO_CREATE, "yes");
 
         runJob(conf);
@@ -397,18 +398,10 @@ public class AbstractMRNewApiSaveTest {
     @Test
     public void testIndexPatternWithFormatting() throws Exception {
         Configuration conf = createConf();
-        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mrnewapi-pattern-format-{@timestamp|YYYY-MM-dd}", "data"));
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mrnewapi-pattern-format-{@timestamp|YYYY-MM-dd}", "data", clusterInfo.getMajorVersion()));
         conf.set(ConfigurationOptions.ES_INDEX_AUTO_CREATE, "yes");
 
         runJob(conf);
-    }
-
-    private String resource(String index, String type) {
-        if (TestUtils.isTypelessVersion(clusterInfo.getMajorVersion())) {
-            return index;
-        } else {
-            return index + "/" + type;
-        }
     }
 
     private Configuration createConf() throws IOException {

--- a/mr/src/itest/java/org/elasticsearch/hadoop/integration/mr/AbstractMRNewApiSaveTest.java
+++ b/mr/src/itest/java/org/elasticsearch/hadoop/integration/mr/AbstractMRNewApiSaveTest.java
@@ -404,7 +404,7 @@ public class AbstractMRNewApiSaveTest {
     }
 
     private String resource(String index, String type) {
-        if (clusterInfo.getMajorVersion().onOrAfter(EsMajorVersion.V_8_X)) {
+        if (TestUtils.isTypelessVersion(clusterInfo.getMajorVersion())) {
             return index;
         } else {
             return index + "/" + type;

--- a/mr/src/itest/java/org/elasticsearch/hadoop/integration/mr/AbstractMRNewApiSaveTest.java
+++ b/mr/src/itest/java/org/elasticsearch/hadoop/integration/mr/AbstractMRNewApiSaveTest.java
@@ -138,7 +138,7 @@ public class AbstractMRNewApiSaveTest {
     @Test
     public void testBasicMultiSave() throws Exception {
         Configuration conf = createConf();
-        conf.set(ConfigurationOptions.ES_RESOURCE, "mrnewapi-multi-save/data");
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mrnewapi-multi-save", "data"));
 
         MultiOutputFormat.addOutputFormat(conf, EsOutputFormat.class);
         MultiOutputFormat.addOutputFormat(conf, PrintStreamOutputFormat.class);
@@ -155,7 +155,7 @@ public class AbstractMRNewApiSaveTest {
     @Test
     public void testBasicSave() throws Exception {
         Configuration conf = createConf();
-        conf.set(ConfigurationOptions.ES_RESOURCE, "mrnewapi-save/data");
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mrnewapi-save", "data"));
 
         runJob(conf);
     }
@@ -163,7 +163,7 @@ public class AbstractMRNewApiSaveTest {
     @Test
     public void testSaveWithId() throws Exception {
         Configuration conf = createConf();
-        conf.set(ConfigurationOptions.ES_RESOURCE, "mrnewapi-savewithid/data");
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mrnewapi-savewithid", "data"));
         conf.set(ConfigurationOptions.ES_MAPPING_ID, "number");
 
         runJob(conf);
@@ -174,7 +174,7 @@ public class AbstractMRNewApiSaveTest {
         Configuration conf = createConf();
         conf.set(ConfigurationOptions.ES_WRITE_OPERATION, "create");
         conf.set(ConfigurationOptions.ES_MAPPING_ID, "number");
-        conf.set(ConfigurationOptions.ES_RESOURCE, "mrnewapi-createwithid/data");
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mrnewapi-createwithid", "data"));
 
         runJob(conf);
     }
@@ -184,7 +184,7 @@ public class AbstractMRNewApiSaveTest {
         Configuration conf = createConf();
         conf.set(ConfigurationOptions.ES_WRITE_OPERATION, "create");
         conf.set(ConfigurationOptions.ES_MAPPING_ID, "number");
-        conf.set(ConfigurationOptions.ES_RESOURCE, "mrnewapi-createwithid/data");
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mrnewapi-createwithid", "data"));
 
         assertFalse("job should have failed", runJob(conf));
     }
@@ -201,7 +201,7 @@ public class AbstractMRNewApiSaveTest {
         client.put("/_ingest/pipeline/" + prefix + "-pipeline", StringUtils.toUTF(pipeline));
         client.close();
 
-        conf.set(ConfigurationOptions.ES_RESOURCE, "mrnewapi-ingested/data");
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mrnewapi-ingested", "data"));
         conf.set(ConfigurationOptions.ES_INGEST_PIPELINE, "mrnewapi-pipeline");
         conf.set(ConfigurationOptions.ES_NODES_INGEST_ONLY, "true");
 
@@ -212,7 +212,7 @@ public class AbstractMRNewApiSaveTest {
     public void testUpdateWithoutId() throws Exception {
         Configuration conf = createConf();
         conf.set(ConfigurationOptions.ES_WRITE_OPERATION, "update");
-        conf.set(ConfigurationOptions.ES_RESOURCE, "mrnewapi-update/data");
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mrnewapi-update", "data"));
 
         runJob(conf);
     }
@@ -222,7 +222,7 @@ public class AbstractMRNewApiSaveTest {
         Configuration conf = createConf();
         conf.set(ConfigurationOptions.ES_WRITE_OPERATION, "upsert");
         conf.set(ConfigurationOptions.ES_MAPPING_ID, "number");
-        conf.set(ConfigurationOptions.ES_RESOURCE, "mrnewapi-update/data");
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mrnewapi-update", "data"));
 
         runJob(conf);
     }
@@ -232,7 +232,7 @@ public class AbstractMRNewApiSaveTest {
         Configuration conf = createConf();
         conf.set(ConfigurationOptions.ES_WRITE_OPERATION, "update");
         conf.set(ConfigurationOptions.ES_MAPPING_ID, "number");
-        conf.set(ConfigurationOptions.ES_RESOURCE, "mrnewapi-updatewoupsert/data");
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mrnewapi-updatewoupsert", "data"));
 
         assertFalse("job should have failed", runJob(conf));
     }
@@ -241,7 +241,7 @@ public class AbstractMRNewApiSaveTest {
     public void testUpdateOnlyScript() throws Exception {
         Configuration conf = createConf();
         // use an existing id to allow the update to succeed
-        conf.set(ConfigurationOptions.ES_RESOURCE, "mrnewapi-createwithid/data");
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mrnewapi-createwithid", "data"));
         conf.set(ConfigurationOptions.ES_WRITE_OPERATION, "update");
         conf.set(ConfigurationOptions.ES_MAPPING_ID, "number");
 
@@ -262,7 +262,7 @@ public class AbstractMRNewApiSaveTest {
     @Test
     public void testUpdateOnlyParamScript() throws Exception {
         Configuration conf = createConf();
-        conf.set(ConfigurationOptions.ES_RESOURCE, "mrnewapi-createwithid/data");
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mrnewapi-createwithid", "data"));
         conf.set(ConfigurationOptions.ES_INDEX_AUTO_CREATE, "yes");
 
         conf.set(ConfigurationOptions.ES_WRITE_OPERATION, "update");
@@ -283,7 +283,7 @@ public class AbstractMRNewApiSaveTest {
     @Test
     public void testUpdateOnlyParamJsonScript() throws Exception {
         Configuration conf = createConf();
-        conf.set(ConfigurationOptions.ES_RESOURCE, "mrnewapi-createwithid/data");
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mrnewapi-createwithid", "data"));
         conf.set(ConfigurationOptions.ES_INDEX_AUTO_CREATE, "yes");
 
         conf.set(ConfigurationOptions.ES_WRITE_OPERATION, "update");
@@ -304,7 +304,7 @@ public class AbstractMRNewApiSaveTest {
     @Test
     public void testUpsertScript() throws Exception {
         Configuration conf = createConf();
-        conf.set(ConfigurationOptions.ES_RESOURCE, "mrnewapi-upsert-script/data");
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mrnewapi-upsert-script", "data"));
         conf.set(ConfigurationOptions.ES_INDEX_AUTO_CREATE, "yes");
         conf.set(ConfigurationOptions.ES_WRITE_OPERATION, "upsert");
         conf.set(ConfigurationOptions.ES_MAPPING_ID, "number");
@@ -316,7 +316,7 @@ public class AbstractMRNewApiSaveTest {
     @Test
     public void testUpsertParamScript() throws Exception {
         Configuration conf = createConf();
-        conf.set(ConfigurationOptions.ES_RESOURCE, "mrnewapi-upsert-script-param/data");
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mrnewapi-upsert-script-param", "data"));
         conf.set(ConfigurationOptions.ES_INDEX_AUTO_CREATE, "yes");
         conf.set(ConfigurationOptions.ES_WRITE_OPERATION, "upsert");
         conf.set(ConfigurationOptions.ES_MAPPING_ID, "number");
@@ -336,7 +336,7 @@ public class AbstractMRNewApiSaveTest {
     @Test
     public void testUpsertParamJsonScript() throws Exception {
         Configuration conf = createConf();
-        conf.set(ConfigurationOptions.ES_RESOURCE, "mrnewapi-upsert-script-param/data");
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mrnewapi-upsert-script-param", "data"));
         conf.set(ConfigurationOptions.ES_INDEX_AUTO_CREATE, "yes");
         conf.set(ConfigurationOptions.ES_WRITE_OPERATION, "upsert");
         conf.set(ConfigurationOptions.ES_MAPPING_ID, "number");
@@ -356,7 +356,7 @@ public class AbstractMRNewApiSaveTest {
     @Test(expected = EsHadoopIllegalArgumentException.class)
     public void testIndexAutoCreateDisabled() throws Exception {
         Configuration conf = createConf();
-        conf.set(ConfigurationOptions.ES_RESOURCE, "mrnewapi-non-existing/data");
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mrnewapi-non-existing", "data"));
         conf.set(ConfigurationOptions.ES_INDEX_AUTO_CREATE, "no");
 
         runJob(conf);
@@ -388,7 +388,7 @@ public class AbstractMRNewApiSaveTest {
     @Test
     public void testIndexPattern() throws Exception {
         Configuration conf = createConf();
-        conf.set(ConfigurationOptions.ES_RESOURCE, "mrnewapi-pattern-{tag}/data");
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mrnewapi-pattern-{tag}", "data"));
         conf.set(ConfigurationOptions.ES_INDEX_AUTO_CREATE, "yes");
 
         runJob(conf);
@@ -397,10 +397,18 @@ public class AbstractMRNewApiSaveTest {
     @Test
     public void testIndexPatternWithFormatting() throws Exception {
         Configuration conf = createConf();
-        conf.set(ConfigurationOptions.ES_RESOURCE, "mrnewapi-pattern-format-{@timestamp|YYYY-MM-dd}/data");
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mrnewapi-pattern-format-{@timestamp|YYYY-MM-dd}", "data"));
         conf.set(ConfigurationOptions.ES_INDEX_AUTO_CREATE, "yes");
 
         runJob(conf);
+    }
+
+    private String resource(String index, String type) {
+        if (clusterInfo.getMajorVersion().onOrAfter(EsMajorVersion.V_8_X)) {
+            return index;
+        } else {
+            return index + "/" + type;
+        }
     }
 
     private Configuration createConf() throws IOException {

--- a/mr/src/itest/java/org/elasticsearch/hadoop/integration/mr/AbstractMRNewApiSearchTest.java
+++ b/mr/src/itest/java/org/elasticsearch/hadoop/integration/mr/AbstractMRNewApiSearchTest.java
@@ -35,8 +35,10 @@ import org.elasticsearch.hadoop.mr.EsInputFormat;
 import org.elasticsearch.hadoop.mr.HadoopCfgUtils;
 import org.elasticsearch.hadoop.mr.LinkedMapWritable;
 import org.elasticsearch.hadoop.mr.RestUtils;
+import org.elasticsearch.hadoop.util.ClusterInfo;
 import org.elasticsearch.hadoop.util.EsMajorVersion;
 import org.elasticsearch.hadoop.util.TestSettings;
+import org.elasticsearch.hadoop.util.TestUtils;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -57,12 +59,14 @@ public class AbstractMRNewApiSearchTest {
     private final Random random = new Random();
     private final boolean readMetadata;
     private final boolean readAsJson;
+    private final ClusterInfo clusterInfo;
 
     public AbstractMRNewApiSearchTest(String indexPrefix, String query, boolean readMetadata, boolean readAsJson) {
         this.indexPrefix = indexPrefix;
         this.query = query;
         this.readMetadata = readMetadata;
         this.readAsJson = readAsJson;
+        this.clusterInfo = TestUtils.getEsClusterInfo();
     }
 
     @Before
@@ -73,7 +77,7 @@ public class AbstractMRNewApiSearchTest {
     @Test
     public void testBasicSearch() throws Exception {
         Configuration conf = createConf();
-        conf.set(ConfigurationOptions.ES_RESOURCE, indexPrefix + "mrnewapi-save/data");
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource(indexPrefix + "mrnewapi-save", "data"));
 
         new Job(conf).waitForCompletion(true);
     }
@@ -81,7 +85,7 @@ public class AbstractMRNewApiSearchTest {
     @Test
     public void testBasicWildSearch() throws Exception {
         Configuration conf = createConf();
-        conf.set(ConfigurationOptions.ES_RESOURCE, indexPrefix + "mrnew*-save/data");
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource(indexPrefix + "mrnew*-save", "data"));
 
         new Job(conf).waitForCompletion(true);
     }
@@ -89,7 +93,7 @@ public class AbstractMRNewApiSearchTest {
     @Test
     public void testSearchWithId() throws Exception {
         Configuration conf = createConf();
-        conf.set(ConfigurationOptions.ES_RESOURCE, indexPrefix + "mrnewapi-savewithid/data");
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource(indexPrefix + "mrnewapi-savewithid", "data"));
 
         new Job(conf).waitForCompletion(true);
     }
@@ -98,7 +102,7 @@ public class AbstractMRNewApiSearchTest {
     public void testSearchNonExistingIndex() throws Exception {
         Configuration conf = createConf();
         conf.setBoolean(ConfigurationOptions.ES_INDEX_READ_MISSING_AS_EMPTY, true);
-        conf.set(ConfigurationOptions.ES_RESOURCE, indexPrefix + "foobar/save");
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource(indexPrefix + "foobar", "save"));
 
         new Job(conf).waitForCompletion(true);
     }
@@ -106,7 +110,7 @@ public class AbstractMRNewApiSearchTest {
     @Test
     public void testSearchCreated() throws Exception {
         Configuration conf = createConf();
-        conf.set(ConfigurationOptions.ES_RESOURCE, indexPrefix + "mrnewapi-createwithid/data");
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource(indexPrefix + "mrnewapi-createwithid", "data"));
 
         new Job(conf).waitForCompletion(true);
     }
@@ -114,16 +118,7 @@ public class AbstractMRNewApiSearchTest {
     @Test
     public void testSearchUpdated() throws Exception {
         Configuration conf = createConf();
-        conf.set(ConfigurationOptions.ES_RESOURCE, indexPrefix + "mrnewapi-update/data");
-
-        new Job(conf).waitForCompletion(true);
-    }
-
-    @Test(expected = EsHadoopIllegalArgumentException.class)
-    public void testSearchUpdatedWithoutUpsertMeaningNonExistingIndex() throws Exception {
-        Configuration conf = createConf();
-        conf.setBoolean(ConfigurationOptions.ES_INDEX_READ_MISSING_AS_EMPTY, false);
-        conf.set(ConfigurationOptions.ES_RESOURCE, indexPrefix + "mrnewapi-updatewoupsert/data");
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource(indexPrefix + "mrnewapi-update", "data"));
 
         new Job(conf).waitForCompletion(true);
     }
@@ -143,18 +138,25 @@ public class AbstractMRNewApiSearchTest {
 
     @Test
     public void testDynamicPattern() throws Exception {
-        Assert.assertTrue(RestUtils.exists("mrnewapi-pattern-1/data"));
-        Assert.assertTrue(RestUtils.exists("mrnewapi-pattern-5/data"));
-        Assert.assertTrue(RestUtils.exists("mrnewapi-pattern-9/data"));
+        Assert.assertTrue(RestUtils.exists(resource("mrnewapi-pattern-1", "data")));
+        Assert.assertTrue(RestUtils.exists(resource("mrnewapi-pattern-5", "data")));
+        Assert.assertTrue(RestUtils.exists(resource("mrnewapi-pattern-9", "data")));
     }
 
     @Test
     public void testDynamicPatternWithFormat() throws Exception {
-        Assert.assertTrue(RestUtils.exists("mrnewapi-pattern-format-2001-10-06/data"));
-        Assert.assertTrue(RestUtils.exists("mrnewapi-pattern-format-2005-10-06/data"));
-        Assert.assertTrue(RestUtils.exists("mrnewapi-pattern-format-2017-10-06/data"));
+        Assert.assertTrue(RestUtils.exists(resource("mrnewapi-pattern-format-2001-10-06", "data")));
+        Assert.assertTrue(RestUtils.exists(resource("mrnewapi-pattern-format-2005-10-06", "data")));
+        Assert.assertTrue(RestUtils.exists(resource("mrnewapi-pattern-format-2017-10-06", "data")));
     }
 
+    private String resource(String index, String type) {
+        if (clusterInfo.getMajorVersion().onOrAfter(EsMajorVersion.V_8_X)) {
+            return index;
+        } else {
+            return index + "/" + type;
+        }
+    }
 
     private Configuration createConf() throws IOException {
         Configuration conf = HdpBootstrap.hadoopConfig();

--- a/mr/src/itest/java/org/elasticsearch/hadoop/integration/mr/AbstractMRNewApiSearchTest.java
+++ b/mr/src/itest/java/org/elasticsearch/hadoop/integration/mr/AbstractMRNewApiSearchTest.java
@@ -26,7 +26,6 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.MapWritable;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.mapreduce.Job;
-import org.elasticsearch.hadoop.EsHadoopIllegalArgumentException;
 import org.elasticsearch.hadoop.HdpBootstrap;
 import org.elasticsearch.hadoop.QueryTestParams;
 import org.elasticsearch.hadoop.cfg.ConfigurationOptions;
@@ -45,6 +44,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
+
+import static org.elasticsearch.hadoop.util.TestUtils.resource;
 
 @RunWith(Parameterized.class)
 public class AbstractMRNewApiSearchTest {
@@ -77,7 +78,7 @@ public class AbstractMRNewApiSearchTest {
     @Test
     public void testBasicSearch() throws Exception {
         Configuration conf = createConf();
-        conf.set(ConfigurationOptions.ES_RESOURCE, resource(indexPrefix + "mrnewapi-save", "data"));
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource(indexPrefix + "mrnewapi-save", "data", clusterInfo.getMajorVersion()));
 
         new Job(conf).waitForCompletion(true);
     }
@@ -85,7 +86,7 @@ public class AbstractMRNewApiSearchTest {
     @Test
     public void testBasicWildSearch() throws Exception {
         Configuration conf = createConf();
-        conf.set(ConfigurationOptions.ES_RESOURCE, resource(indexPrefix + "mrnew*-save", "data"));
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource(indexPrefix + "mrnew*-save", "data", clusterInfo.getMajorVersion()));
 
         new Job(conf).waitForCompletion(true);
     }
@@ -93,7 +94,7 @@ public class AbstractMRNewApiSearchTest {
     @Test
     public void testSearchWithId() throws Exception {
         Configuration conf = createConf();
-        conf.set(ConfigurationOptions.ES_RESOURCE, resource(indexPrefix + "mrnewapi-savewithid", "data"));
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource(indexPrefix + "mrnewapi-savewithid", "data", clusterInfo.getMajorVersion()));
 
         new Job(conf).waitForCompletion(true);
     }
@@ -102,7 +103,7 @@ public class AbstractMRNewApiSearchTest {
     public void testSearchNonExistingIndex() throws Exception {
         Configuration conf = createConf();
         conf.setBoolean(ConfigurationOptions.ES_INDEX_READ_MISSING_AS_EMPTY, true);
-        conf.set(ConfigurationOptions.ES_RESOURCE, resource(indexPrefix + "foobar", "save"));
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource(indexPrefix + "foobar", "save", clusterInfo.getMajorVersion()));
 
         new Job(conf).waitForCompletion(true);
     }
@@ -110,7 +111,7 @@ public class AbstractMRNewApiSearchTest {
     @Test
     public void testSearchCreated() throws Exception {
         Configuration conf = createConf();
-        conf.set(ConfigurationOptions.ES_RESOURCE, resource(indexPrefix + "mrnewapi-createwithid", "data"));
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource(indexPrefix + "mrnewapi-createwithid", "data", clusterInfo.getMajorVersion()));
 
         new Job(conf).waitForCompletion(true);
     }
@@ -118,7 +119,7 @@ public class AbstractMRNewApiSearchTest {
     @Test
     public void testSearchUpdated() throws Exception {
         Configuration conf = createConf();
-        conf.set(ConfigurationOptions.ES_RESOURCE, resource(indexPrefix + "mrnewapi-update", "data"));
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource(indexPrefix + "mrnewapi-update", "data", clusterInfo.getMajorVersion()));
 
         new Job(conf).waitForCompletion(true);
     }
@@ -138,24 +139,16 @@ public class AbstractMRNewApiSearchTest {
 
     @Test
     public void testDynamicPattern() throws Exception {
-        Assert.assertTrue(RestUtils.exists(resource("mrnewapi-pattern-1", "data")));
-        Assert.assertTrue(RestUtils.exists(resource("mrnewapi-pattern-5", "data")));
-        Assert.assertTrue(RestUtils.exists(resource("mrnewapi-pattern-9", "data")));
+        Assert.assertTrue(RestUtils.exists(resource("mrnewapi-pattern-1", "data", clusterInfo.getMajorVersion())));
+        Assert.assertTrue(RestUtils.exists(resource("mrnewapi-pattern-5", "data", clusterInfo.getMajorVersion())));
+        Assert.assertTrue(RestUtils.exists(resource("mrnewapi-pattern-9", "data", clusterInfo.getMajorVersion())));
     }
 
     @Test
     public void testDynamicPatternWithFormat() throws Exception {
-        Assert.assertTrue(RestUtils.exists(resource("mrnewapi-pattern-format-2001-10-06", "data")));
-        Assert.assertTrue(RestUtils.exists(resource("mrnewapi-pattern-format-2005-10-06", "data")));
-        Assert.assertTrue(RestUtils.exists(resource("mrnewapi-pattern-format-2017-10-06", "data")));
-    }
-
-    private String resource(String index, String type) {
-        if (TestUtils.isTypelessVersion(clusterInfo.getMajorVersion())) {
-            return index;
-        } else {
-            return index + "/" + type;
-        }
+        Assert.assertTrue(RestUtils.exists(resource("mrnewapi-pattern-format-2001-10-06", "data", clusterInfo.getMajorVersion())));
+        Assert.assertTrue(RestUtils.exists(resource("mrnewapi-pattern-format-2005-10-06", "data", clusterInfo.getMajorVersion())));
+        Assert.assertTrue(RestUtils.exists(resource("mrnewapi-pattern-format-2017-10-06", "data", clusterInfo.getMajorVersion())));
     }
 
     private Configuration createConf() throws IOException {

--- a/mr/src/itest/java/org/elasticsearch/hadoop/integration/mr/AbstractMRNewApiSearchTest.java
+++ b/mr/src/itest/java/org/elasticsearch/hadoop/integration/mr/AbstractMRNewApiSearchTest.java
@@ -151,7 +151,7 @@ public class AbstractMRNewApiSearchTest {
     }
 
     private String resource(String index, String type) {
-        if (clusterInfo.getMajorVersion().onOrAfter(EsMajorVersion.V_8_X)) {
+        if (TestUtils.isTypelessVersion(clusterInfo.getMajorVersion())) {
             return index;
         } else {
             return index + "/" + type;

--- a/mr/src/itest/java/org/elasticsearch/hadoop/integration/mr/AbstractMROldApiSaveTest.java
+++ b/mr/src/itest/java/org/elasticsearch/hadoop/integration/mr/AbstractMROldApiSaveTest.java
@@ -608,7 +608,7 @@ public class AbstractMROldApiSaveTest {
     }
 
     private String resource(String index, String type) {
-        if (clusterInfo.getMajorVersion().onOrAfter(EsMajorVersion.V_8_X)) {
+        if (TestUtils.isTypelessVersion(clusterInfo.getMajorVersion())) {
             return index;
         } else {
             return index + "/" + type;
@@ -616,7 +616,7 @@ public class AbstractMROldApiSaveTest {
     }
 
     private String docEndpoint(String index, String type) {
-        if (clusterInfo.getMajorVersion().onOrAfter(EsMajorVersion.V_8_X)) {
+        if (TestUtils.isTypelessVersion(clusterInfo.getMajorVersion())) {
             return index + "/_doc";
         } else {
             return index + "/" + type;

--- a/mr/src/itest/java/org/elasticsearch/hadoop/integration/mr/AbstractMROldApiSaveTest.java
+++ b/mr/src/itest/java/org/elasticsearch/hadoop/integration/mr/AbstractMROldApiSaveTest.java
@@ -64,6 +64,8 @@ import org.junit.runners.MethodSorters;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
+import static org.elasticsearch.hadoop.util.TestUtils.docEndpoint;
+import static org.elasticsearch.hadoop.util.TestUtils.resource;
 import static org.junit.Assume.assumeFalse;
 
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
@@ -162,7 +164,7 @@ public class AbstractMROldApiSaveTest {
     @Test
     public void testBasicMultiSave() throws Exception {
         JobConf conf = createJobConf();
-        conf.set(ConfigurationOptions.ES_RESOURCE, resource("oldapi-multi-save", "data"));
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource("oldapi-multi-save", "data", clusterInfo.getMajorVersion()));
 
         MultiOutputFormat.addOutputFormat(conf, EsOutputFormat.class);
         MultiOutputFormat.addOutputFormat(conf, PrintStreamOutputFormat.class);
@@ -183,7 +185,7 @@ public class AbstractMROldApiSaveTest {
 
         // use only when dealing with constant input
         assumeFalse(conf.get(ConfigurationOptions.ES_INPUT_JSON).equals("true"));
-        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mroldapi-constant", "data"));
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mroldapi-constant", "data", clusterInfo.getMajorVersion()));
         conf.setMapperClass(ConstantMapper.class);
 
         runJob(conf);
@@ -192,7 +194,7 @@ public class AbstractMROldApiSaveTest {
     @Test
     public void testBasicIndex() throws Exception {
         JobConf conf = createJobConf();
-        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mroldapi-save", "data"));
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mroldapi-save", "data", clusterInfo.getMajorVersion()));
 
         runJob(conf);
     }
@@ -201,7 +203,7 @@ public class AbstractMROldApiSaveTest {
     public void testBasicIndexWithId() throws Exception {
         JobConf conf = createJobConf();
         conf.set(ConfigurationOptions.ES_MAPPING_ID, "number");
-        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mroldapi-savewithid", "data"));
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mroldapi-savewithid", "data", clusterInfo.getMajorVersion()));
 
         runJob(conf);
     }
@@ -210,7 +212,7 @@ public class AbstractMROldApiSaveTest {
     public void testBasicIndexWithExtractedRouting() throws Exception {
         String index = indexPrefix + "mroldapi-savewithdynamicrouting";
         String type = "data";
-        String target = resource(index, type);
+        String target = resource(index, type, clusterInfo.getMajorVersion());
 
         JobConf conf = createJobConf();
         conf.set(ConfigurationOptions.ES_MAPPING_ROUTING, "number");
@@ -232,7 +234,7 @@ public class AbstractMROldApiSaveTest {
     public void testBasicIndexWithConstantRouting() throws Exception {
         String index = indexPrefix + "mroldapi-savewithconstantrouting";
         String type = "data";
-        String target = resource(index, type);
+        String target = resource(index, type, clusterInfo.getMajorVersion());
 
         JobConf conf = createJobConf();
         conf.set(ConfigurationOptions.ES_MAPPING_ROUTING, "<foobar/>");
@@ -254,7 +256,7 @@ public class AbstractMROldApiSaveTest {
         JobConf conf = createJobConf();
         conf.set(ConfigurationOptions.ES_WRITE_OPERATION, "create");
         conf.set(ConfigurationOptions.ES_MAPPING_ID, "number");
-        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mroldapi-createwithid", "data"));
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mroldapi-createwithid", "data", clusterInfo.getMajorVersion()));
 
         runJob(conf);
     }
@@ -276,7 +278,7 @@ public class AbstractMROldApiSaveTest {
         client.put("/_ingest/pipeline/" + prefix + "-pipeline", StringUtils.toUTF(pipeline));
         client.close();
 
-        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mroldapi-ingested", "data"));
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mroldapi-ingested", "data", clusterInfo.getMajorVersion()));
         conf.set(ConfigurationOptions.ES_INGEST_PIPELINE, "mroldapi-pipeline");
         conf.set(ConfigurationOptions.ES_NODES_INGEST_ONLY, "true");
 
@@ -288,7 +290,7 @@ public class AbstractMROldApiSaveTest {
     public void testUpdateWithoutId() throws Exception {
         JobConf conf = createJobConf();
         conf.set(ConfigurationOptions.ES_WRITE_OPERATION, "upsert");
-        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mroldapi-update", "data"));
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mroldapi-update", "data", clusterInfo.getMajorVersion()));
 
         runJob(conf);
     }
@@ -298,7 +300,7 @@ public class AbstractMROldApiSaveTest {
         JobConf conf = createJobConf();
         conf.set(ConfigurationOptions.ES_WRITE_OPERATION, "upsert");
         conf.set(ConfigurationOptions.ES_MAPPING_ID, "number");
-        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mroldapi-update", "data"));
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mroldapi-update", "data", clusterInfo.getMajorVersion()));
 
         runJob(conf);
     }
@@ -308,7 +310,7 @@ public class AbstractMROldApiSaveTest {
         JobConf conf = createJobConf();
         conf.set(ConfigurationOptions.ES_WRITE_OPERATION, "update");
         conf.set(ConfigurationOptions.ES_MAPPING_ID, "number");
-        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mroldapi-updatewoupsert", "data"));
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mroldapi-updatewoupsert", "data", clusterInfo.getMajorVersion()));
 
         runJob(conf);
     }
@@ -317,7 +319,7 @@ public class AbstractMROldApiSaveTest {
     public void testUpdateOnlyScript() throws Exception {
         JobConf conf = createJobConf();
         // use an existing id to allow the update to succeed
-        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mroldapi-createwithid", "data"));
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mroldapi-createwithid", "data", clusterInfo.getMajorVersion()));
         conf.set(ConfigurationOptions.ES_WRITE_OPERATION, "update");
         conf.set(ConfigurationOptions.ES_MAPPING_ID, "number");
 
@@ -338,7 +340,7 @@ public class AbstractMROldApiSaveTest {
     @Test
     public void testUpdateOnlyParamScript() throws Exception {
         JobConf conf = createJobConf();
-        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mroldapi-createwithid", "data"));
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mroldapi-createwithid", "data", clusterInfo.getMajorVersion()));
         conf.set(ConfigurationOptions.ES_INDEX_AUTO_CREATE, "yes");
 
         conf.set(ConfigurationOptions.ES_WRITE_OPERATION, "update");
@@ -359,7 +361,7 @@ public class AbstractMROldApiSaveTest {
     @Test
     public void testUpdateOnlyParamJsonScript() throws Exception {
         JobConf conf = createJobConf();
-        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mroldapi-createwithid", "data"));
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mroldapi-createwithid", "data", clusterInfo.getMajorVersion()));
         conf.set(ConfigurationOptions.ES_INDEX_AUTO_CREATE, "yes");
 
         conf.set(ConfigurationOptions.ES_WRITE_OPERATION, "update");
@@ -380,7 +382,7 @@ public class AbstractMROldApiSaveTest {
     @Test
     public void testUpdateOnlyParamJsonScriptWithArray() throws Exception {
         JobConf conf = createJobConf();
-        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mroldapi-createwithid", "data"));
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mroldapi-createwithid", "data", clusterInfo.getMajorVersion()));
         conf.set(ConfigurationOptions.ES_INDEX_AUTO_CREATE, "yes");
 
         conf.set(ConfigurationOptions.ES_WRITE_OPERATION, "update");
@@ -413,13 +415,13 @@ public class AbstractMROldApiSaveTest {
     @Test
     public void testUpdateOnlyParamJsonScriptWithArrayOnArrayField() throws Exception {
         String docWithArray = "{ \"counter\" : 1 , \"tags\" : [\"an array\", \"with multiple values\"], \"more_tags\" : [ \"I am tag\"], \"even_more_tags\" : \"I am a tag too\" } ";
-        String docEndpoint = docEndpoint(indexPrefix + "mroldapi-createwitharray", "data");
+        String docEndpoint = docEndpoint(indexPrefix + "mroldapi-createwitharray", "data", clusterInfo.getMajorVersion());
         RestUtils.postData(docEndpoint + "/1", docWithArray.getBytes());
         RestUtils.refresh(indexPrefix + "mroldapi-createwitharray");
         RestUtils.waitForYellow(indexPrefix + "mroldapi-createwitharray");
 
         JobConf conf = createJobConf();
-        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mroldapi-createwitharray", "data"));
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mroldapi-createwitharray", "data", clusterInfo.getMajorVersion()));
         conf.set(ConfigurationOptions.ES_INDEX_AUTO_CREATE, "yes");
 
         conf.set(ConfigurationOptions.ES_WRITE_OPERATION, "update");
@@ -441,7 +443,7 @@ public class AbstractMROldApiSaveTest {
     @Test
     public void testUpsertScript() throws Exception {
         JobConf conf = createJobConf();
-        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mroldapi-upsert-script", "data"));
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mroldapi-upsert-script", "data", clusterInfo.getMajorVersion()));
         conf.set(ConfigurationOptions.ES_INDEX_AUTO_CREATE, "yes");
         conf.set(ConfigurationOptions.ES_WRITE_OPERATION, "upsert");
         conf.set(ConfigurationOptions.ES_MAPPING_ID, "number");
@@ -453,7 +455,7 @@ public class AbstractMROldApiSaveTest {
     @Test
     public void testUpsertParamScript() throws Exception {
         JobConf conf = createJobConf();
-        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mroldapi-upsert-script-param", "data"));
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mroldapi-upsert-script-param", "data", clusterInfo.getMajorVersion()));
         conf.set(ConfigurationOptions.ES_INDEX_AUTO_CREATE, "yes");
         conf.set(ConfigurationOptions.ES_WRITE_OPERATION, "upsert");
         conf.set(ConfigurationOptions.ES_MAPPING_ID, "number");
@@ -467,7 +469,7 @@ public class AbstractMROldApiSaveTest {
     @Test
     public void testUpsertParamJsonScript() throws Exception {
         JobConf conf = createJobConf();
-        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mroldapi-upsert-script-json-param", "data"));
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mroldapi-upsert-script-json-param", "data", clusterInfo.getMajorVersion()));
         conf.set(ConfigurationOptions.ES_INDEX_AUTO_CREATE, "yes");
         conf.set(ConfigurationOptions.ES_WRITE_OPERATION, "upsert");
         conf.set(ConfigurationOptions.ES_MAPPING_ID, "number");
@@ -481,13 +483,13 @@ public class AbstractMROldApiSaveTest {
     @Test
     public void testUpsertOnlyParamScriptWithArrayOnArrayField() throws Exception {
         String docWithArray = "{ \"counter\" : 1 , \"tags\" : [\"an array\", \"with multiple values\"], \"more_tags\" : [ \"I am tag\"], \"even_more_tags\" : \"I am a tag too\" } ";
-        String docEndpoint = docEndpoint(indexPrefix + "mroldapi-createwitharrayupsert", "data");
+        String docEndpoint = docEndpoint(indexPrefix + "mroldapi-createwitharrayupsert", "data", clusterInfo.getMajorVersion());
         RestUtils.postData(docEndpoint + "/1", docWithArray.getBytes());
         RestUtils.refresh(indexPrefix + "mroldapi-createwitharrayupsert");
         RestUtils.waitForYellow(indexPrefix + "mroldapi-createwitharrayupsert");
 
         JobConf conf = createJobConf();
-        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mroldapi-createwitharrayupsert", "data"));
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mroldapi-createwitharrayupsert", "data", clusterInfo.getMajorVersion()));
         conf.set(ConfigurationOptions.ES_INDEX_AUTO_CREATE, "yes");
 
         conf.set(ConfigurationOptions.ES_WRITE_OPERATION, "upsert");
@@ -509,7 +511,7 @@ public class AbstractMROldApiSaveTest {
     @Test(expected = EsHadoopIllegalArgumentException.class)
     public void testIndexAutoCreateDisabled() throws Exception {
         JobConf conf = createJobConf();
-        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mroldapi-non-existing", "data"));
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mroldapi-non-existing", "data", clusterInfo.getMajorVersion()));
         conf.set(ConfigurationOptions.ES_INDEX_AUTO_CREATE, "no");
 
         runJob(conf);
@@ -518,7 +520,7 @@ public class AbstractMROldApiSaveTest {
     @Test
     public void testIndexWithVersionMappingImpliesVersionTypeExternal() throws Exception {
         JobConf conf = createJobConf();
-        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mroldapi-external-version-implied", "data"));
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mroldapi-external-version-implied", "data", clusterInfo.getMajorVersion()));
         // an id must be provided if version type or value are set
         conf.set(ConfigurationOptions.ES_MAPPING_ID, "number");
         conf.set(ConfigurationOptions.ES_MAPPING_VERSION, "number");
@@ -562,7 +564,7 @@ public class AbstractMROldApiSaveTest {
     @Test
     public void testIndexPattern() throws Exception {
         JobConf conf = createJobConf();
-        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mroldapi-pattern-{tag}", "data"));
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mroldapi-pattern-{tag}", "data", clusterInfo.getMajorVersion()));
         conf.set(ConfigurationOptions.ES_INDEX_AUTO_CREATE, "yes");
 
         runJob(conf);
@@ -571,7 +573,7 @@ public class AbstractMROldApiSaveTest {
     @Test
     public void testIndexPatternWithFormatting() throws Exception {
         JobConf conf = createJobConf();
-        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mroldapi-pattern-format-{@timestamp|YYYY-MM-dd}", "data"));
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mroldapi-pattern-format-{@timestamp|YYYY-MM-dd}", "data", clusterInfo.getMajorVersion()));
         conf.set(ConfigurationOptions.ES_INDEX_AUTO_CREATE, "yes");
 
         runJob(conf);
@@ -580,7 +582,7 @@ public class AbstractMROldApiSaveTest {
     @Test
     public void testIndexPatternWithFormattingAndId() throws Exception {
         JobConf conf = createJobConf();
-        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mroldapi-pattern-format-{@timestamp|YYYY-MM-dd}-with-id", "data"));
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mroldapi-pattern-format-{@timestamp|YYYY-MM-dd}-with-id", "data", clusterInfo.getMajorVersion()));
         conf.set(ConfigurationOptions.ES_MAPPING_ID, "number");
 
         runJob(conf);
@@ -589,7 +591,7 @@ public class AbstractMROldApiSaveTest {
     @Test
     public void testIndexWithEscapedJson() throws Exception {
         JobConf conf = createJobConf();
-        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mroldapi-simple-escaped-fields", "data"));
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mroldapi-simple-escaped-fields", "data", clusterInfo.getMajorVersion()));
         conf.set(ConfigurationOptions.ES_INDEX_AUTO_CREATE, "yes");
 
         runJob(conf);
@@ -599,28 +601,12 @@ public class AbstractMROldApiSaveTest {
     //@Test
     public void testNested() throws Exception {
         JobConf conf = createJobConf();
-        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mroldapi-nested", "data"));
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mroldapi-nested", "data", clusterInfo.getMajorVersion()));
         conf.set(ConfigurationOptions.ES_INDEX_AUTO_CREATE, "no");
 
         RestUtils.putMapping(indexPrefix + "mroldapi-nested", "data", "org/elasticsearch/hadoop/integration/mr-nested.json");
 
         runJob(conf);
-    }
-
-    private String resource(String index, String type) {
-        if (TestUtils.isTypelessVersion(clusterInfo.getMajorVersion())) {
-            return index;
-        } else {
-            return index + "/" + type;
-        }
-    }
-
-    private String docEndpoint(String index, String type) {
-        if (TestUtils.isTypelessVersion(clusterInfo.getMajorVersion())) {
-            return index + "/_doc";
-        } else {
-            return index + "/" + type;
-        }
     }
 
     private JobConf createJobConf() {

--- a/mr/src/itest/java/org/elasticsearch/hadoop/integration/mr/AbstractMROldApiSaveTest.java
+++ b/mr/src/itest/java/org/elasticsearch/hadoop/integration/mr/AbstractMROldApiSaveTest.java
@@ -162,7 +162,7 @@ public class AbstractMROldApiSaveTest {
     @Test
     public void testBasicMultiSave() throws Exception {
         JobConf conf = createJobConf();
-        conf.set(ConfigurationOptions.ES_RESOURCE, "oldapi-multi-save/data");
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource("oldapi-multi-save", "data"));
 
         MultiOutputFormat.addOutputFormat(conf, EsOutputFormat.class);
         MultiOutputFormat.addOutputFormat(conf, PrintStreamOutputFormat.class);
@@ -183,7 +183,7 @@ public class AbstractMROldApiSaveTest {
 
         // use only when dealing with constant input
         assumeFalse(conf.get(ConfigurationOptions.ES_INPUT_JSON).equals("true"));
-        conf.set(ConfigurationOptions.ES_RESOURCE, "mroldapi-constant/data");
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mroldapi-constant", "data"));
         conf.setMapperClass(ConstantMapper.class);
 
         runJob(conf);
@@ -192,7 +192,7 @@ public class AbstractMROldApiSaveTest {
     @Test
     public void testBasicIndex() throws Exception {
         JobConf conf = createJobConf();
-        conf.set(ConfigurationOptions.ES_RESOURCE, "mroldapi-save/data");
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mroldapi-save", "data"));
 
         runJob(conf);
     }
@@ -201,7 +201,7 @@ public class AbstractMROldApiSaveTest {
     public void testBasicIndexWithId() throws Exception {
         JobConf conf = createJobConf();
         conf.set(ConfigurationOptions.ES_MAPPING_ID, "number");
-        conf.set(ConfigurationOptions.ES_RESOURCE, "mroldapi-savewithid/data");
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mroldapi-savewithid", "data"));
 
         runJob(conf);
     }
@@ -210,7 +210,7 @@ public class AbstractMROldApiSaveTest {
     public void testBasicIndexWithExtractedRouting() throws Exception {
         String index = indexPrefix + "mroldapi-savewithdynamicrouting";
         String type = "data";
-        String target = index + "/" + type;
+        String target = resource(index, type);
 
         JobConf conf = createJobConf();
         conf.set(ConfigurationOptions.ES_MAPPING_ROUTING, "number");
@@ -232,7 +232,7 @@ public class AbstractMROldApiSaveTest {
     public void testBasicIndexWithConstantRouting() throws Exception {
         String index = indexPrefix + "mroldapi-savewithconstantrouting";
         String type = "data";
-        String target = index + "/" + type;
+        String target = resource(index, type);
 
         JobConf conf = createJobConf();
         conf.set(ConfigurationOptions.ES_MAPPING_ROUTING, "<foobar/>");
@@ -254,7 +254,7 @@ public class AbstractMROldApiSaveTest {
         JobConf conf = createJobConf();
         conf.set(ConfigurationOptions.ES_WRITE_OPERATION, "create");
         conf.set(ConfigurationOptions.ES_MAPPING_ID, "number");
-        conf.set(ConfigurationOptions.ES_RESOURCE, "mroldapi-createwithid/data");
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mroldapi-createwithid", "data"));
 
         runJob(conf);
     }
@@ -276,7 +276,7 @@ public class AbstractMROldApiSaveTest {
         client.put("/_ingest/pipeline/" + prefix + "-pipeline", StringUtils.toUTF(pipeline));
         client.close();
 
-        conf.set(ConfigurationOptions.ES_RESOURCE, "mroldapi-ingested/data");
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mroldapi-ingested", "data"));
         conf.set(ConfigurationOptions.ES_INGEST_PIPELINE, "mroldapi-pipeline");
         conf.set(ConfigurationOptions.ES_NODES_INGEST_ONLY, "true");
 
@@ -288,7 +288,7 @@ public class AbstractMROldApiSaveTest {
     public void testUpdateWithoutId() throws Exception {
         JobConf conf = createJobConf();
         conf.set(ConfigurationOptions.ES_WRITE_OPERATION, "upsert");
-        conf.set(ConfigurationOptions.ES_RESOURCE, "mroldapi-update/data");
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mroldapi-update", "data"));
 
         runJob(conf);
     }
@@ -298,7 +298,7 @@ public class AbstractMROldApiSaveTest {
         JobConf conf = createJobConf();
         conf.set(ConfigurationOptions.ES_WRITE_OPERATION, "upsert");
         conf.set(ConfigurationOptions.ES_MAPPING_ID, "number");
-        conf.set(ConfigurationOptions.ES_RESOURCE, "mroldapi-update/data");
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mroldapi-update", "data"));
 
         runJob(conf);
     }
@@ -308,7 +308,7 @@ public class AbstractMROldApiSaveTest {
         JobConf conf = createJobConf();
         conf.set(ConfigurationOptions.ES_WRITE_OPERATION, "update");
         conf.set(ConfigurationOptions.ES_MAPPING_ID, "number");
-        conf.set(ConfigurationOptions.ES_RESOURCE, "mroldapi-updatewoupsert/data");
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mroldapi-updatewoupsert", "data"));
 
         runJob(conf);
     }
@@ -317,7 +317,7 @@ public class AbstractMROldApiSaveTest {
     public void testUpdateOnlyScript() throws Exception {
         JobConf conf = createJobConf();
         // use an existing id to allow the update to succeed
-        conf.set(ConfigurationOptions.ES_RESOURCE, "mroldapi-createwithid/data");
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mroldapi-createwithid", "data"));
         conf.set(ConfigurationOptions.ES_WRITE_OPERATION, "update");
         conf.set(ConfigurationOptions.ES_MAPPING_ID, "number");
 
@@ -338,7 +338,7 @@ public class AbstractMROldApiSaveTest {
     @Test
     public void testUpdateOnlyParamScript() throws Exception {
         JobConf conf = createJobConf();
-        conf.set(ConfigurationOptions.ES_RESOURCE, "mroldapi-createwithid/data");
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mroldapi-createwithid", "data"));
         conf.set(ConfigurationOptions.ES_INDEX_AUTO_CREATE, "yes");
 
         conf.set(ConfigurationOptions.ES_WRITE_OPERATION, "update");
@@ -359,7 +359,7 @@ public class AbstractMROldApiSaveTest {
     @Test
     public void testUpdateOnlyParamJsonScript() throws Exception {
         JobConf conf = createJobConf();
-        conf.set(ConfigurationOptions.ES_RESOURCE, "mroldapi-createwithid/data");
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mroldapi-createwithid", "data"));
         conf.set(ConfigurationOptions.ES_INDEX_AUTO_CREATE, "yes");
 
         conf.set(ConfigurationOptions.ES_WRITE_OPERATION, "update");
@@ -380,7 +380,7 @@ public class AbstractMROldApiSaveTest {
     @Test
     public void testUpdateOnlyParamJsonScriptWithArray() throws Exception {
         JobConf conf = createJobConf();
-        conf.set(ConfigurationOptions.ES_RESOURCE, "mroldapi-createwithid/data");
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mroldapi-createwithid", "data"));
         conf.set(ConfigurationOptions.ES_INDEX_AUTO_CREATE, "yes");
 
         conf.set(ConfigurationOptions.ES_WRITE_OPERATION, "update");
@@ -413,13 +413,13 @@ public class AbstractMROldApiSaveTest {
     @Test
     public void testUpdateOnlyParamJsonScriptWithArrayOnArrayField() throws Exception {
         String docWithArray = "{ \"counter\" : 1 , \"tags\" : [\"an array\", \"with multiple values\"], \"more_tags\" : [ \"I am tag\"], \"even_more_tags\" : \"I am a tag too\" } ";
-        String index = indexPrefix + "mroldapi-createwitharray/data";
-        RestUtils.postData(index + "/1", docWithArray.getBytes());
+        String docEndpoint = docEndpoint(indexPrefix + "mroldapi-createwitharray", "data");
+        RestUtils.postData(docEndpoint + "/1", docWithArray.getBytes());
         RestUtils.refresh(indexPrefix + "mroldapi-createwitharray");
         RestUtils.waitForYellow(indexPrefix + "mroldapi-createwitharray");
 
         JobConf conf = createJobConf();
-        conf.set(ConfigurationOptions.ES_RESOURCE, "mroldapi-createwitharray/data");
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mroldapi-createwitharray", "data"));
         conf.set(ConfigurationOptions.ES_INDEX_AUTO_CREATE, "yes");
 
         conf.set(ConfigurationOptions.ES_WRITE_OPERATION, "update");
@@ -441,7 +441,7 @@ public class AbstractMROldApiSaveTest {
     @Test
     public void testUpsertScript() throws Exception {
         JobConf conf = createJobConf();
-        conf.set(ConfigurationOptions.ES_RESOURCE, "mroldapi-upsert-script/data");
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mroldapi-upsert-script", "data"));
         conf.set(ConfigurationOptions.ES_INDEX_AUTO_CREATE, "yes");
         conf.set(ConfigurationOptions.ES_WRITE_OPERATION, "upsert");
         conf.set(ConfigurationOptions.ES_MAPPING_ID, "number");
@@ -453,7 +453,7 @@ public class AbstractMROldApiSaveTest {
     @Test
     public void testUpsertParamScript() throws Exception {
         JobConf conf = createJobConf();
-        conf.set(ConfigurationOptions.ES_RESOURCE, "mroldapi-upsert-script-param/data");
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mroldapi-upsert-script-param", "data"));
         conf.set(ConfigurationOptions.ES_INDEX_AUTO_CREATE, "yes");
         conf.set(ConfigurationOptions.ES_WRITE_OPERATION, "upsert");
         conf.set(ConfigurationOptions.ES_MAPPING_ID, "number");
@@ -467,7 +467,7 @@ public class AbstractMROldApiSaveTest {
     @Test
     public void testUpsertParamJsonScript() throws Exception {
         JobConf conf = createJobConf();
-        conf.set(ConfigurationOptions.ES_RESOURCE, "mroldapi-upsert-script-json-param/data");
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mroldapi-upsert-script-json-param", "data"));
         conf.set(ConfigurationOptions.ES_INDEX_AUTO_CREATE, "yes");
         conf.set(ConfigurationOptions.ES_WRITE_OPERATION, "upsert");
         conf.set(ConfigurationOptions.ES_MAPPING_ID, "number");
@@ -481,13 +481,13 @@ public class AbstractMROldApiSaveTest {
     @Test
     public void testUpsertOnlyParamScriptWithArrayOnArrayField() throws Exception {
         String docWithArray = "{ \"counter\" : 1 , \"tags\" : [\"an array\", \"with multiple values\"], \"more_tags\" : [ \"I am tag\"], \"even_more_tags\" : \"I am a tag too\" } ";
-        String index = indexPrefix + "mroldapi-createwitharrayupsert/data";
-        RestUtils.postData(index + "/1", docWithArray.getBytes());
+        String docEndpoint = docEndpoint(indexPrefix + "mroldapi-createwitharrayupsert", "data");
+        RestUtils.postData(docEndpoint + "/1", docWithArray.getBytes());
         RestUtils.refresh(indexPrefix + "mroldapi-createwitharrayupsert");
         RestUtils.waitForYellow(indexPrefix + "mroldapi-createwitharrayupsert");
 
         JobConf conf = createJobConf();
-        conf.set(ConfigurationOptions.ES_RESOURCE, "mroldapi-createwitharrayupsert/data");
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mroldapi-createwitharrayupsert", "data"));
         conf.set(ConfigurationOptions.ES_INDEX_AUTO_CREATE, "yes");
 
         conf.set(ConfigurationOptions.ES_WRITE_OPERATION, "upsert");
@@ -509,7 +509,7 @@ public class AbstractMROldApiSaveTest {
     @Test(expected = EsHadoopIllegalArgumentException.class)
     public void testIndexAutoCreateDisabled() throws Exception {
         JobConf conf = createJobConf();
-        conf.set(ConfigurationOptions.ES_RESOURCE, "mroldapi-non-existing/data");
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mroldapi-non-existing", "data"));
         conf.set(ConfigurationOptions.ES_INDEX_AUTO_CREATE, "no");
 
         runJob(conf);
@@ -518,7 +518,7 @@ public class AbstractMROldApiSaveTest {
     @Test
     public void testIndexWithVersionMappingImpliesVersionTypeExternal() throws Exception {
         JobConf conf = createJobConf();
-        conf.set(ConfigurationOptions.ES_RESOURCE, "mroldapi-external-version-implied/data");
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mroldapi-external-version-implied", "data"));
         // an id must be provided if version type or value are set
         conf.set(ConfigurationOptions.ES_MAPPING_ID, "number");
         conf.set(ConfigurationOptions.ES_MAPPING_VERSION, "number");
@@ -562,7 +562,7 @@ public class AbstractMROldApiSaveTest {
     @Test
     public void testIndexPattern() throws Exception {
         JobConf conf = createJobConf();
-        conf.set(ConfigurationOptions.ES_RESOURCE, "mroldapi-pattern-{tag}/data");
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mroldapi-pattern-{tag}", "data"));
         conf.set(ConfigurationOptions.ES_INDEX_AUTO_CREATE, "yes");
 
         runJob(conf);
@@ -571,7 +571,7 @@ public class AbstractMROldApiSaveTest {
     @Test
     public void testIndexPatternWithFormatting() throws Exception {
         JobConf conf = createJobConf();
-        conf.set(ConfigurationOptions.ES_RESOURCE, "mroldapi-pattern-format-{@timestamp|YYYY-MM-dd}/data");
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mroldapi-pattern-format-{@timestamp|YYYY-MM-dd}", "data"));
         conf.set(ConfigurationOptions.ES_INDEX_AUTO_CREATE, "yes");
 
         runJob(conf);
@@ -580,7 +580,7 @@ public class AbstractMROldApiSaveTest {
     @Test
     public void testIndexPatternWithFormattingAndId() throws Exception {
         JobConf conf = createJobConf();
-        conf.set(ConfigurationOptions.ES_RESOURCE, "mroldapi-pattern-format-{@timestamp|YYYY-MM-dd}-with-id/data");
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mroldapi-pattern-format-{@timestamp|YYYY-MM-dd}-with-id", "data"));
         conf.set(ConfigurationOptions.ES_MAPPING_ID, "number");
 
         runJob(conf);
@@ -589,7 +589,7 @@ public class AbstractMROldApiSaveTest {
     @Test
     public void testIndexWithEscapedJson() throws Exception {
         JobConf conf = createJobConf();
-        conf.set(ConfigurationOptions.ES_RESOURCE, "mroldapi-simple-escaped-fields/data");
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mroldapi-simple-escaped-fields", "data"));
         conf.set(ConfigurationOptions.ES_INDEX_AUTO_CREATE, "yes");
 
         runJob(conf);
@@ -599,12 +599,28 @@ public class AbstractMROldApiSaveTest {
     //@Test
     public void testNested() throws Exception {
         JobConf conf = createJobConf();
-        conf.set(ConfigurationOptions.ES_RESOURCE, "mroldapi-nested/data");
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource("mroldapi-nested", "data"));
         conf.set(ConfigurationOptions.ES_INDEX_AUTO_CREATE, "no");
 
         RestUtils.putMapping(indexPrefix + "mroldapi-nested", "data", "org/elasticsearch/hadoop/integration/mr-nested.json");
 
         runJob(conf);
+    }
+
+    private String resource(String index, String type) {
+        if (clusterInfo.getMajorVersion().onOrAfter(EsMajorVersion.V_8_X)) {
+            return index;
+        } else {
+            return index + "/" + type;
+        }
+    }
+
+    private String docEndpoint(String index, String type) {
+        if (clusterInfo.getMajorVersion().onOrAfter(EsMajorVersion.V_8_X)) {
+            return index + "/_doc";
+        } else {
+            return index + "/" + type;
+        }
     }
 
     private JobConf createJobConf() {

--- a/mr/src/itest/java/org/elasticsearch/hadoop/integration/mr/AbstractMROldApiSearchTest.java
+++ b/mr/src/itest/java/org/elasticsearch/hadoop/integration/mr/AbstractMROldApiSearchTest.java
@@ -28,7 +28,6 @@ import org.apache.hadoop.io.Text;
 import org.apache.hadoop.mapred.FileInputFormat;
 import org.apache.hadoop.mapred.JobClient;
 import org.apache.hadoop.mapred.JobConf;
-import org.elasticsearch.hadoop.EsHadoopIllegalArgumentException;
 import org.elasticsearch.hadoop.HdpBootstrap;
 import org.elasticsearch.hadoop.QueryTestParams;
 import org.elasticsearch.hadoop.cfg.ConfigurationOptions;
@@ -43,12 +42,13 @@ import org.elasticsearch.hadoop.util.TestSettings;
 import org.elasticsearch.hadoop.util.TestUtils;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
+import static org.elasticsearch.hadoop.util.TestUtils.docEndpoint;
+import static org.elasticsearch.hadoop.util.TestUtils.resource;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThat;
@@ -85,7 +85,7 @@ public class AbstractMROldApiSearchTest {
     @Test
     public void testBasicReadWithConstantRouting() throws Exception {
         String type = "data";
-        String target = resource(indexPrefix + "mroldapi-savewithconstantrouting", type);
+        String target = resource(indexPrefix + "mroldapi-savewithconstantrouting", type, clusterInfo.getMajorVersion());
 
         JobConf conf = createJobConf();
         conf.set(ConfigurationOptions.ES_MAPPING_ROUTING, "<foobar/>");
@@ -97,7 +97,7 @@ public class AbstractMROldApiSearchTest {
     @Test
     public void testBasicSearch() throws Exception {
         JobConf conf = createJobConf();
-        conf.set(ConfigurationOptions.ES_RESOURCE, resource(indexPrefix + "mroldapi-save", "data"));
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource(indexPrefix + "mroldapi-save", "data", clusterInfo.getMajorVersion()));
 
         JobClient.runJob(conf);
     }
@@ -106,7 +106,7 @@ public class AbstractMROldApiSearchTest {
     @Test
     public void testBasicSearchWithWildCard() throws Exception {
         JobConf conf = createJobConf();
-        conf.set(ConfigurationOptions.ES_RESOURCE, resource(indexPrefix + "mrold*-save", "data"));
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource(indexPrefix + "mrold*-save", "data", clusterInfo.getMajorVersion()));
 
         JobClient.runJob(conf);
     }
@@ -114,7 +114,7 @@ public class AbstractMROldApiSearchTest {
     @Test
     public void testSearchWithId() throws Exception {
         JobConf conf = createJobConf();
-        conf.set(ConfigurationOptions.ES_RESOURCE, resource(indexPrefix + "mroldapi-savewithid", "data"));
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource(indexPrefix + "mroldapi-savewithid", "data", clusterInfo.getMajorVersion()));
 
         JobClient.runJob(conf);
     }
@@ -123,7 +123,7 @@ public class AbstractMROldApiSearchTest {
     public void testSearchNonExistingIndex() throws Exception {
         JobConf conf = createJobConf();
         conf.setBoolean(ConfigurationOptions.ES_INDEX_READ_MISSING_AS_EMPTY, true);
-        conf.set(ConfigurationOptions.ES_RESOURCE, resource("foobar", "save"));
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource("foobar", "save", clusterInfo.getMajorVersion()));
 
         JobClient.runJob(conf);
     }
@@ -131,7 +131,7 @@ public class AbstractMROldApiSearchTest {
     @Test
     public void testSearchCreated() throws Exception {
         JobConf conf = createJobConf();
-        conf.set(ConfigurationOptions.ES_RESOURCE, resource(indexPrefix + "mroldapi-createwithid", "data"));
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource(indexPrefix + "mroldapi-createwithid", "data", clusterInfo.getMajorVersion()));
 
         JobClient.runJob(conf);
     }
@@ -139,7 +139,7 @@ public class AbstractMROldApiSearchTest {
     @Test
     public void testSearchUpdated() throws Exception {
         JobConf conf = createJobConf();
-        conf.set(ConfigurationOptions.ES_RESOURCE, resource(indexPrefix + "mroldapi-update", "data"));
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource(indexPrefix + "mroldapi-update", "data", clusterInfo.getMajorVersion()));
 
         JobClient.runJob(conf);
     }
@@ -159,21 +159,21 @@ public class AbstractMROldApiSearchTest {
 
     @Test
     public void testDynamicPattern() throws Exception {
-        Assert.assertTrue(RestUtils.exists(resource("mroldapi-pattern-1", "data")));
-        Assert.assertTrue(RestUtils.exists(resource("mroldapi-pattern-5", "data")));
-        Assert.assertTrue(RestUtils.exists(resource("mroldapi-pattern-9", "data")));
+        Assert.assertTrue(RestUtils.exists(resource("mroldapi-pattern-1", "data", clusterInfo.getMajorVersion())));
+        Assert.assertTrue(RestUtils.exists(resource("mroldapi-pattern-5", "data", clusterInfo.getMajorVersion())));
+        Assert.assertTrue(RestUtils.exists(resource("mroldapi-pattern-9", "data", clusterInfo.getMajorVersion())));
     }
 
     @Test
     public void testDynamicPatternWithFormat() throws Exception {
-        Assert.assertTrue(RestUtils.exists(resource("mroldapi-pattern-format-2001-10-06", "data")));
-        Assert.assertTrue(RestUtils.exists(resource("mroldapi-pattern-format-2005-10-06", "data")));
-        Assert.assertTrue(RestUtils.exists(resource("mroldapi-pattern-format-2017-10-06", "data")));
+        Assert.assertTrue(RestUtils.exists(resource("mroldapi-pattern-format-2001-10-06", "data", clusterInfo.getMajorVersion())));
+        Assert.assertTrue(RestUtils.exists(resource("mroldapi-pattern-format-2005-10-06", "data", clusterInfo.getMajorVersion())));
+        Assert.assertTrue(RestUtils.exists(resource("mroldapi-pattern-format-2017-10-06", "data", clusterInfo.getMajorVersion())));
     }
 
     @Test
     public void testUpsertOnlyParamScriptWithArrayOnArrayField() throws Exception {
-        String target = docEndpoint("mroldapi-createwitharrayupsert", "data") + "/1";
+        String target = docEndpoint("mroldapi-createwitharrayupsert", "data", clusterInfo.getMajorVersion()) + "/1";
         Assert.assertTrue(RestUtils.exists(target));
         String result = RestUtils.get(target);
         assertThat(result, not(containsString("ArrayWritable@")));
@@ -182,28 +182,11 @@ public class AbstractMROldApiSearchTest {
     //@Test
     public void testNested() throws Exception {
         JobConf conf = createJobConf();
-        conf.set(ConfigurationOptions.ES_RESOURCE, resource(indexPrefix + "mroldapi-nested", "data"));
+        conf.set(ConfigurationOptions.ES_RESOURCE, resource(indexPrefix + "mroldapi-nested", "data", clusterInfo.getMajorVersion()));
         conf.set(ConfigurationOptions.ES_INDEX_AUTO_CREATE, "no");
 
         //conf.set(Stream.class.getName(), "OUT");
         JobClient.runJob(conf);
-    }
-
-
-    private String resource(String index, String type) {
-        if (TestUtils.isTypelessVersion(clusterInfo.getMajorVersion())) {
-            return index;
-        } else {
-            return index + "/" + type;
-        }
-    }
-
-    private String docEndpoint(String index, String type) {
-        if (TestUtils.isTypelessVersion(clusterInfo.getMajorVersion())) {
-            return index + "/_doc";
-        } else {
-            return index + "/" + type;
-        }
     }
 
     private JobConf createJobConf() throws IOException {

--- a/mr/src/itest/java/org/elasticsearch/hadoop/integration/mr/AbstractMROldApiSearchTest.java
+++ b/mr/src/itest/java/org/elasticsearch/hadoop/integration/mr/AbstractMROldApiSearchTest.java
@@ -191,7 +191,7 @@ public class AbstractMROldApiSearchTest {
 
 
     private String resource(String index, String type) {
-        if (clusterInfo.getMajorVersion().onOrAfter(EsMajorVersion.V_8_X)) {
+        if (TestUtils.isTypelessVersion(clusterInfo.getMajorVersion())) {
             return index;
         } else {
             return index + "/" + type;
@@ -199,7 +199,7 @@ public class AbstractMROldApiSearchTest {
     }
 
     private String docEndpoint(String index, String type) {
-        if (clusterInfo.getMajorVersion().onOrAfter(EsMajorVersion.V_8_X)) {
+        if (TestUtils.isTypelessVersion(clusterInfo.getMajorVersion())) {
             return index + "/_doc";
         } else {
             return index + "/" + type;

--- a/mr/src/test/java/org/elasticsearch/hadoop/util/TestUtils.java
+++ b/mr/src/test/java/org/elasticsearch/hadoop/util/TestUtils.java
@@ -58,6 +58,22 @@ public class TestUtils {
         }
     }
 
+    public static String resource(String index, String type, EsMajorVersion testVersion) {
+        if (TestUtils.isTypelessVersion(testVersion)) {
+            return index;
+        } else {
+            return index + "/" + type;
+        }
+    }
+
+    public static String docEndpoint(String index, String type, EsMajorVersion testVersion) {
+        if (TestUtils.isTypelessVersion(testVersion)) {
+            return index + "/_doc";
+        } else {
+            return index + "/" + type;
+        }
+    }
+
     public static boolean isTypelessVersion(EsMajorVersion version) {
         // Types have been deprecated in 7.0.0, and will be removed at a later date
         return version.onOrAfter(EsMajorVersion.V_7_X);

--- a/mr/src/test/java/org/elasticsearch/hadoop/util/TestUtils.java
+++ b/mr/src/test/java/org/elasticsearch/hadoop/util/TestUtils.java
@@ -50,7 +50,17 @@ public class TestUtils {
     }
 
     public static ClusterInfo getEsClusterInfo() {
-        return new RestClient(new TestSettings()).mainInfo();
+        RestClient client = new RestClient(new TestSettings());
+        try {
+            return client.mainInfo();
+        } finally {
+            client.close();
+        }
+    }
+
+    public static boolean isTypelessVersion(EsMajorVersion version) {
+        // Types have been deprecated in 7.0.0, and will be removed at a later date
+        return version.onOrAfter(EsMajorVersion.V_7_X);
     }
 
     public static boolean isWindows() {

--- a/pig/src/itest/java/org/elasticsearch/hadoop/integration/pig/AbstractPigExtraTests.java
+++ b/pig/src/itest/java/org/elasticsearch/hadoop/integration/pig/AbstractPigExtraTests.java
@@ -24,6 +24,8 @@ import org.elasticsearch.hadoop.util.EsMajorVersion;
 import org.elasticsearch.hadoop.util.TestUtils;
 import org.junit.Test;
 
+import static org.elasticsearch.hadoop.util.TestUtils.docEndpoint;
+import static org.elasticsearch.hadoop.util.TestUtils.resource;
 import static org.junit.Assert.*;
 
 import static org.hamcrest.CoreMatchers.*;
@@ -39,12 +41,12 @@ public class AbstractPigExtraTests extends AbstractPigTests {
                 "REGISTER "+ Provisioner.ESHADOOP_TESTING_JAR + ";" +
                 "PARENT = LOAD 'src/itest/resources/parent.txt' using PigStorage('|') as (parent_name: chararray, parent_value: chararray);" +
                 "CHILD = LOAD 'src/itest/resources/child.txt' using PigStorage('|') as (child_name: chararray, parent_name: chararray, child_value: long);" +
-                "STORE PARENT into '"+resource("pig-test-parent", "data")+"' using org.elasticsearch.hadoop.pig.EsStorage();" +
-                "STORE CHILD into '"+resource("pig-test-child", "data")+"' using org.elasticsearch.hadoop.pig.EsStorage();";
+                "STORE PARENT into '"+ resource("pig-test-parent", "data", VERSION)+"' using org.elasticsearch.hadoop.pig.EsStorage();" +
+                "STORE CHILD into '"+resource("pig-test-child", "data", VERSION)+"' using org.elasticsearch.hadoop.pig.EsStorage();";
        String script2 =
                 "REGISTER "+ Provisioner.ESHADOOP_TESTING_JAR + ";" +
-                "ES_PARENT = LOAD '"+resource("pig-test-parent", "data")+"' using org.elasticsearch.hadoop.pig.EsStorage() as (parent_name: chararray, parent_value: chararray);" +
-                "ES_CHILD = LOAD '"+resource("pig-test-child", "data")+"' using org.elasticsearch.hadoop.pig.EsStorage() as (child_name: chararray, parent_name: chararray, child_value: long);" +
+                "ES_PARENT = LOAD '"+resource("pig-test-parent", "data", VERSION)+"' using org.elasticsearch.hadoop.pig.EsStorage() as (parent_name: chararray, parent_value: chararray);" +
+                "ES_CHILD = LOAD '"+resource("pig-test-child", "data", VERSION)+"' using org.elasticsearch.hadoop.pig.EsStorage() as (child_name: chararray, parent_name: chararray, child_value: long);" +
                 "CO_GROUP = COGROUP ES_PARENT by parent_name, ES_CHILD by parent_name;" +
                 "PARENT_CHILD = JOIN ES_PARENT by parent_name, ES_CHILD by parent_name;" +
                 "STORE PARENT_CHILD INTO 'tmp-pig/testjoin-join';" +
@@ -75,7 +77,7 @@ public class AbstractPigExtraTests extends AbstractPigTests {
                 "data = LOAD 'src/itest/resources/group-sample.txt' using PigStorage(',') as (no:long,name:chararray,age:long);" +
                 "data_limit = LIMIT data 1;" +
                 "data_final = FOREACH data_limit GENERATE TRIM(name) as details, no as number;" +
-                "STORE data_final into '"+resource("pig-test-temp_schema", "data")+"' using org.elasticsearch.hadoop.pig.EsStorage('es.mapping.id=details');";
+                "STORE data_final into '"+resource("pig-test-temp_schema", "data", VERSION)+"' using org.elasticsearch.hadoop.pig.EsStorage('es.mapping.id=details');";
         pig.executeScript(script);
     }
 
@@ -90,20 +92,20 @@ public class AbstractPigExtraTests extends AbstractPigTests {
                 "data = GROUP data by $0;" +
                 "data = FOREACH data GENERATE $1 as details;" +
                 "DUMP data;" +
-                "STORE data into '"+resource("pig-test-group-data-2", "data")+"' using org.elasticsearch.hadoop.pig.EsStorage();";
+                "STORE data into '"+resource("pig-test-group-data-2", "data", VERSION)+"' using org.elasticsearch.hadoop.pig.EsStorage();";
         pig.executeScript(script);
     }
 
     @Test
     public void testIterate() throws Exception {
         RestUtils.touch("pig-test-iterate");
-        RestUtils.postData(docEndpoint("pig-test-iterate", "data"), "{\"message\" : \"Hello World\",\"message_date\" : \"2014-05-25\"}".getBytes());
-        RestUtils.postData(docEndpoint("pig-test-iterate", "data"), "{\"message\" : \"Goodbye World\",\"message_date\" : \"2014-05-25\"}".getBytes());
+        RestUtils.postData(docEndpoint("pig-test-iterate", "data", VERSION), "{\"message\" : \"Hello World\",\"message_date\" : \"2014-05-25\"}".getBytes());
+        RestUtils.postData(docEndpoint("pig-test-iterate", "data", VERSION), "{\"message\" : \"Goodbye World\",\"message_date\" : \"2014-05-25\"}".getBytes());
         RestUtils.refresh("pig-test-iterate");
 
         String script =
                 "REGISTER "+ Provisioner.ESHADOOP_TESTING_JAR + ";" +
-                "data = LOAD '"+resource("pig-test-iterate", "data")+"' using org.elasticsearch.hadoop.pig.EsStorage() as (message:chararray,message_date:chararray);" +
+                "data = LOAD '"+resource("pig-test-iterate", "data", VERSION)+"' using org.elasticsearch.hadoop.pig.EsStorage() as (message:chararray,message_date:chararray);" +
                 "data = FOREACH data GENERATE message_date as date, message as message;" +
                 "STORE data INTO 'tmp-pig/pig-iterate';";
         pig.executeScript(script);
@@ -124,27 +126,10 @@ public class AbstractPigExtraTests extends AbstractPigTests {
                 "answers = LOAD 'src/itest/resources/tuple.txt' using PigStorage(',') as (id:int, parentId:int, score:int);" +
                 "grouped = GROUP answers by id;" +
                 "ILLUSTRATE grouped;" +
-                "STORE grouped into '"+resource("pig-test-tuple-structure", "data")+"' using org.elasticsearch.hadoop.pig.EsStorage('es.mapping.pig.tuple.use.field.names = true');";
+                "STORE grouped into '"+resource("pig-test-tuple-structure", "data", VERSION)+"' using org.elasticsearch.hadoop.pig.EsStorage('es.mapping.pig.tuple.use.field.names = true');";
         pig.executeScript(script);
 
         String string = RestUtils.get("pig-test-tuple-structure/_search");
         assertThat(string, containsString("parentId"));
-    }
-
-
-    private String resource(String index, String type) {
-        if (TestUtils.isTypelessVersion(VERSION)) {
-            return index;
-        } else {
-            return index + "/" + type;
-        }
-    }
-
-    private String docEndpoint(String index, String type) {
-        if (TestUtils.isTypelessVersion(VERSION)) {
-            return index + "/_doc";
-        } else {
-            return index + "/" + type;
-        }
     }
 }

--- a/pig/src/itest/java/org/elasticsearch/hadoop/integration/pig/AbstractPigExtraTests.java
+++ b/pig/src/itest/java/org/elasticsearch/hadoop/integration/pig/AbstractPigExtraTests.java
@@ -133,7 +133,7 @@ public class AbstractPigExtraTests extends AbstractPigTests {
 
 
     private String resource(String index, String type) {
-        if (VERSION.onOrAfter(EsMajorVersion.V_8_X)) {
+        if (TestUtils.isTypelessVersion(VERSION)) {
             return index;
         } else {
             return index + "/" + type;
@@ -141,7 +141,7 @@ public class AbstractPigExtraTests extends AbstractPigTests {
     }
 
     private String docEndpoint(String index, String type) {
-        if (VERSION.onOrAfter(EsMajorVersion.V_8_X)) {
+        if (TestUtils.isTypelessVersion(VERSION)) {
             return index + "/_doc";
         } else {
             return index + "/" + type;

--- a/pig/src/itest/java/org/elasticsearch/hadoop/integration/pig/AbstractPigExtraTests.java
+++ b/pig/src/itest/java/org/elasticsearch/hadoop/integration/pig/AbstractPigExtraTests.java
@@ -20,6 +20,8 @@ package org.elasticsearch.hadoop.integration.pig;
 
 import org.elasticsearch.hadoop.Provisioner;
 import org.elasticsearch.hadoop.mr.RestUtils;
+import org.elasticsearch.hadoop.util.EsMajorVersion;
+import org.elasticsearch.hadoop.util.TestUtils;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
@@ -29,18 +31,20 @@ import static org.hamcrest.CoreMatchers.*;
 
 public class AbstractPigExtraTests extends AbstractPigTests {
 
+    private EsMajorVersion VERSION = TestUtils.getEsClusterInfo().getMajorVersion();
+
     @Test
     public void testJoin() throws Exception {
         String script =
                 "REGISTER "+ Provisioner.ESHADOOP_TESTING_JAR + ";" +
                 "PARENT = LOAD 'src/itest/resources/parent.txt' using PigStorage('|') as (parent_name: chararray, parent_value: chararray);" +
                 "CHILD = LOAD 'src/itest/resources/child.txt' using PigStorage('|') as (child_name: chararray, parent_name: chararray, child_value: long);" +
-                "STORE PARENT into 'pig-test-parent/data' using org.elasticsearch.hadoop.pig.EsStorage();" +
-                "STORE CHILD into 'pig-test-child/data' using org.elasticsearch.hadoop.pig.EsStorage();";
+                "STORE PARENT into '"+resource("pig-test-parent", "data")+"' using org.elasticsearch.hadoop.pig.EsStorage();" +
+                "STORE CHILD into '"+resource("pig-test-child", "data")+"' using org.elasticsearch.hadoop.pig.EsStorage();";
        String script2 =
                 "REGISTER "+ Provisioner.ESHADOOP_TESTING_JAR + ";" +
-                "ES_PARENT = LOAD 'pig-test-parent/data' using org.elasticsearch.hadoop.pig.EsStorage() as (parent_name: chararray, parent_value: chararray);" +
-                "ES_CHILD = LOAD 'pig-test-child/data' using org.elasticsearch.hadoop.pig.EsStorage() as (child_name: chararray, parent_name: chararray, child_value: long);" +
+                "ES_PARENT = LOAD '"+resource("pig-test-parent", "data")+"' using org.elasticsearch.hadoop.pig.EsStorage() as (parent_name: chararray, parent_value: chararray);" +
+                "ES_CHILD = LOAD '"+resource("pig-test-child", "data")+"' using org.elasticsearch.hadoop.pig.EsStorage() as (child_name: chararray, parent_name: chararray, child_value: long);" +
                 "CO_GROUP = COGROUP ES_PARENT by parent_name, ES_CHILD by parent_name;" +
                 "PARENT_CHILD = JOIN ES_PARENT by parent_name, ES_CHILD by parent_name;" +
                 "STORE PARENT_CHILD INTO 'tmp-pig/testjoin-join';" +
@@ -71,7 +75,7 @@ public class AbstractPigExtraTests extends AbstractPigTests {
                 "data = LOAD 'src/itest/resources/group-sample.txt' using PigStorage(',') as (no:long,name:chararray,age:long);" +
                 "data_limit = LIMIT data 1;" +
                 "data_final = FOREACH data_limit GENERATE TRIM(name) as details, no as number;" +
-                "STORE data_final into 'pig-test-temp_schema/data' using org.elasticsearch.hadoop.pig.EsStorage('es.mapping.id=details');";
+                "STORE data_final into '"+resource("pig-test-temp_schema", "data")+"' using org.elasticsearch.hadoop.pig.EsStorage('es.mapping.id=details');";
         pig.executeScript(script);
     }
 
@@ -86,20 +90,20 @@ public class AbstractPigExtraTests extends AbstractPigTests {
                 "data = GROUP data by $0;" +
                 "data = FOREACH data GENERATE $1 as details;" +
                 "DUMP data;" +
-                "STORE data into 'pig-test-group-data-2/data' using org.elasticsearch.hadoop.pig.EsStorage();";
+                "STORE data into '"+resource("pig-test-group-data-2", "data")+"' using org.elasticsearch.hadoop.pig.EsStorage();";
         pig.executeScript(script);
     }
 
     @Test
     public void testIterate() throws Exception {
         RestUtils.touch("pig-test-iterate");
-        RestUtils.postData("pig-test-iterate/data", "{\"message\" : \"Hello World\",\"message_date\" : \"2014-05-25\"}".getBytes());
-        RestUtils.postData("pig-test-iterate/data", "{\"message\" : \"Goodbye World\",\"message_date\" : \"2014-05-25\"}".getBytes());
+        RestUtils.postData(docEndpoint("pig-test-iterate", "data"), "{\"message\" : \"Hello World\",\"message_date\" : \"2014-05-25\"}".getBytes());
+        RestUtils.postData(docEndpoint("pig-test-iterate", "data"), "{\"message\" : \"Goodbye World\",\"message_date\" : \"2014-05-25\"}".getBytes());
         RestUtils.refresh("pig-test-iterate");
 
         String script =
                 "REGISTER "+ Provisioner.ESHADOOP_TESTING_JAR + ";" +
-                "data = LOAD 'pig-test-iterate/data' using org.elasticsearch.hadoop.pig.EsStorage() as (message:chararray,message_date:chararray);" +
+                "data = LOAD '"+resource("pig-test-iterate", "data")+"' using org.elasticsearch.hadoop.pig.EsStorage() as (message:chararray,message_date:chararray);" +
                 "data = FOREACH data GENERATE message_date as date, message as message;" +
                 "STORE data INTO 'tmp-pig/pig-iterate';";
         pig.executeScript(script);
@@ -120,10 +124,27 @@ public class AbstractPigExtraTests extends AbstractPigTests {
                 "answers = LOAD 'src/itest/resources/tuple.txt' using PigStorage(',') as (id:int, parentId:int, score:int);" +
                 "grouped = GROUP answers by id;" +
                 "ILLUSTRATE grouped;" +
-                "STORE grouped into 'pig-test-tuple-structure/data' using org.elasticsearch.hadoop.pig.EsStorage('es.mapping.pig.tuple.use.field.names = true');";
+                "STORE grouped into '"+resource("pig-test-tuple-structure", "data")+"' using org.elasticsearch.hadoop.pig.EsStorage('es.mapping.pig.tuple.use.field.names = true');";
         pig.executeScript(script);
 
-        String string = RestUtils.get("pig-test-tuple-structure/data/_search?");
+        String string = RestUtils.get("pig-test-tuple-structure/_search");
         assertThat(string, containsString("parentId"));
+    }
+
+
+    private String resource(String index, String type) {
+        if (VERSION.onOrAfter(EsMajorVersion.V_8_X)) {
+            return index;
+        } else {
+            return index + "/" + type;
+        }
+    }
+
+    private String docEndpoint(String index, String type) {
+        if (VERSION.onOrAfter(EsMajorVersion.V_8_X)) {
+            return index + "/_doc";
+        } else {
+            return index + "/" + type;
+        }
     }
 }

--- a/pig/src/itest/java/org/elasticsearch/hadoop/integration/pig/AbstractPigReadAsJsonTest.java
+++ b/pig/src/itest/java/org/elasticsearch/hadoop/integration/pig/AbstractPigReadAsJsonTest.java
@@ -88,7 +88,7 @@ public class AbstractPigReadAsJsonTest extends AbstractPigTests {
         String results = getResults("" + tmpPig() + "/testtuple");
 
         String metaType = "data";
-        if (testVersion.onOrAfter(EsMajorVersion.V_8_X)) {
+        if (TestUtils.isTypelessVersion(testVersion)) {
             metaType = "_doc";
         }
 
@@ -133,7 +133,7 @@ public class AbstractPigReadAsJsonTest extends AbstractPigTests {
         String results = getResults("" + tmpPig() + "/testtupleschema");
 
         String metaType = "data";
-        if (testVersion.onOrAfter(EsMajorVersion.V_8_X)) {
+        if (TestUtils.isTypelessVersion(testVersion)) {
             metaType = "_doc";
         }
 
@@ -177,7 +177,7 @@ public class AbstractPigReadAsJsonTest extends AbstractPigTests {
         String results = getResults("" + tmpPig() + "/testfieldalias");
 
         String metaType = "data";
-        if (testVersion.onOrAfter(EsMajorVersion.V_8_X)) {
+        if (TestUtils.isTypelessVersion(testVersion)) {
             metaType = "_doc";
         }
 
@@ -287,7 +287,7 @@ public class AbstractPigReadAsJsonTest extends AbstractPigTests {
 
 
     private String resource(String index, String type) {
-        if (testVersion.onOrAfter(EsMajorVersion.V_8_X)) {
+        if (TestUtils.isTypelessVersion(testVersion)) {
             return index;
         } else {
             return index + "/" + type;
@@ -295,7 +295,7 @@ public class AbstractPigReadAsJsonTest extends AbstractPigTests {
     }
 
     private String docEndpoint(String index, String type) {
-        if (testVersion.onOrAfter(EsMajorVersion.V_8_X)) {
+        if (TestUtils.isTypelessVersion(testVersion)) {
             return index + "/_doc";
         } else {
             return index + "/" + type;

--- a/pig/src/itest/java/org/elasticsearch/hadoop/integration/pig/AbstractPigReadAsJsonTest.java
+++ b/pig/src/itest/java/org/elasticsearch/hadoop/integration/pig/AbstractPigReadAsJsonTest.java
@@ -36,6 +36,7 @@ import org.junit.runners.Parameterized.Parameters;
 import java.util.Collection;
 import java.util.List;
 
+import static org.elasticsearch.hadoop.util.TestUtils.resource;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.stringContainsInOrder;
 import static org.junit.Assert.assertThat;
@@ -79,7 +80,7 @@ public class AbstractPigReadAsJsonTest extends AbstractPigTests {
     @Test
     public void testTuple() throws Exception {
         String script = scriptHead +
-                "A = LOAD '"+resource("json-pig-tupleartists", "data")+"' USING EsStorage();" +
+                "A = LOAD '"+resource("json-pig-tupleartists", "data", testVersion)+"' USING EsStorage();" +
                 "X = LIMIT A 3;" +
                 //"DESCRIBE A;";
                 "STORE A INTO '" + tmpPig() + "/testtuple';";
@@ -124,7 +125,7 @@ public class AbstractPigReadAsJsonTest extends AbstractPigTests {
     @Test
     public void testTupleWithSchema() throws Exception {
         String script = scriptHead +
-                "A = LOAD '"+resource("json-pig-tupleartists", "data")+"' USING EsStorage() AS (name:chararray);" +
+                "A = LOAD '"+resource("json-pig-tupleartists", "data", testVersion)+"' USING EsStorage() AS (name:chararray);" +
                 "B = ORDER A BY name DESC;" +
                 "X = LIMIT B 3;" +
                 "STORE B INTO '" + tmpPig() + "/testtupleschema';";
@@ -169,7 +170,7 @@ public class AbstractPigReadAsJsonTest extends AbstractPigTests {
     @Test
     public void testFieldAlias() throws Exception {
         String script = scriptHead
-                      + "A = LOAD '"+resource("json-pig-fieldalias", "data")+"' USING EsStorage();"
+                      + "A = LOAD '"+resource("json-pig-fieldalias", "data", testVersion)+"' USING EsStorage();"
                       + "X = LIMIT A 3;"
                       + "STORE A INTO '" + tmpPig() + "/testfieldalias';";
         pig.executeScript(script);
@@ -213,7 +214,7 @@ public class AbstractPigReadAsJsonTest extends AbstractPigTests {
     @Test
     public void testMissingIndex() throws Exception {
         String script = scriptHead
-                      + "A = LOAD '"+resource("foo", "bar")+"' USING EsStorage();"
+                      + "A = LOAD '"+resource("foo", "bar", testVersion)+"' USING EsStorage();"
                       + "X = LIMIT A 3;"
                       + "STORE A INTO '" + tmpPig() + "/testmissingindex';";
         pig.executeScript(script);
@@ -273,33 +274,16 @@ public class AbstractPigReadAsJsonTest extends AbstractPigTests {
 
     @Test
     public void testDynamicPattern() throws Exception {
-        Assert.assertTrue(RestUtils.exists(resource("json-pig-pattern-1", "data")));
-        Assert.assertTrue(RestUtils.exists(resource("json-pig-pattern-5", "data")));
-        Assert.assertTrue(RestUtils.exists(resource("json-pig-pattern-9", "data")));
+        Assert.assertTrue(RestUtils.exists(resource("json-pig-pattern-1", "data", testVersion)));
+        Assert.assertTrue(RestUtils.exists(resource("json-pig-pattern-5", "data", testVersion)));
+        Assert.assertTrue(RestUtils.exists(resource("json-pig-pattern-9", "data", testVersion)));
     }
 
     @Test
     public void testDynamicPatternFormat() throws Exception {
-        Assert.assertTrue(RestUtils.exists(resource("json-pig-pattern-format-2001-10-06", "data")));
-        Assert.assertTrue(RestUtils.exists(resource("json-pig-pattern-format-2005-10-06", "data")));
-        Assert.assertTrue(RestUtils.exists(resource("json-pig-pattern-format-2017-10-06", "data")));
-    }
-
-
-    private String resource(String index, String type) {
-        if (TestUtils.isTypelessVersion(testVersion)) {
-            return index;
-        } else {
-            return index + "/" + type;
-        }
-    }
-
-    private String docEndpoint(String index, String type) {
-        if (TestUtils.isTypelessVersion(testVersion)) {
-            return index + "/_doc";
-        } else {
-            return index + "/" + type;
-        }
+        Assert.assertTrue(RestUtils.exists(resource("json-pig-pattern-format-2001-10-06", "data", testVersion)));
+        Assert.assertTrue(RestUtils.exists(resource("json-pig-pattern-format-2005-10-06", "data", testVersion)));
+        Assert.assertTrue(RestUtils.exists(resource("json-pig-pattern-format-2017-10-06", "data", testVersion)));
     }
 
     private static String tmpPig() {

--- a/pig/src/itest/java/org/elasticsearch/hadoop/integration/pig/AbstractPigReadAsJsonTest.java
+++ b/pig/src/itest/java/org/elasticsearch/hadoop/integration/pig/AbstractPigReadAsJsonTest.java
@@ -79,7 +79,7 @@ public class AbstractPigReadAsJsonTest extends AbstractPigTests {
     @Test
     public void testTuple() throws Exception {
         String script = scriptHead +
-                "A = LOAD 'json-pig-tupleartists/data' USING EsStorage();" +
+                "A = LOAD '"+resource("json-pig-tupleartists", "data")+"' USING EsStorage();" +
                 "X = LIMIT A 3;" +
                 //"DESCRIBE A;";
                 "STORE A INTO '" + tmpPig() + "/testtuple';";
@@ -87,11 +87,16 @@ public class AbstractPigReadAsJsonTest extends AbstractPigTests {
 
         String results = getResults("" + tmpPig() + "/testtuple");
 
+        String metaType = "data";
+        if (testVersion.onOrAfter(EsMajorVersion.V_8_X)) {
+            metaType = "_doc";
+        }
+
         List<String> doc1 = Lists.newArrayList(
                 "{\"number\":\"12\",\"name\":\"Behemoth\",\"url\":\"http://www.last.fm/music/Behemoth\",\"picture\":\"http://userserve-ak.last.fm/serve/252/54196161.jpg\",\"@timestamp\":\"2001-10-06T19:20:25.000Z\",\"list\":[\"quick\", \"brown\", \"fox\"]"
         );
         if (readMetadata) {
-            doc1.add(",\"_metadata\":{\"_index\":\"json-pig-tupleartists\",\"_type\":\"data\",\"_id\":\"");
+            doc1.add(",\"_metadata\":{\"_index\":\"json-pig-tupleartists\",\"_type\":\""+metaType+"\",\"_id\":\"");
             doc1.add("\",\"_score\":");
         }
 
@@ -99,7 +104,7 @@ public class AbstractPigReadAsJsonTest extends AbstractPigTests {
                 "{\"number\":\"918\",\"name\":\"Megadeth\",\"url\":\"http://www.last.fm/music/Megadeth\",\"picture\":\"http://userserve-ak.last.fm/serve/252/8129787.jpg\",\"@timestamp\":\"2017-10-06T19:20:25.000Z\",\"list\":[\"quick\", \"brown\", \"fox\"]"
         );
         if (readMetadata) {
-            doc2.add(",\"_metadata\":{\"_index\":\"json-pig-tupleartists\",\"_type\":\"data\",\"_id\":\"");
+            doc2.add(",\"_metadata\":{\"_index\":\"json-pig-tupleartists\",\"_type\":\""+metaType+"\",\"_id\":\"");
             doc2.add("\",\"_score\":");
         }
 
@@ -107,7 +112,7 @@ public class AbstractPigReadAsJsonTest extends AbstractPigTests {
                 "{\"number\":\"982\",\"name\":\"Foo Fighters\",\"url\":\"http://www.last.fm/music/Foo+Fighters\",\"picture\":\"http://userserve-ak.last.fm/serve/252/59495563.jpg\",\"@timestamp\":\"2017-10-06T19:20:25.000Z\",\"list\":[\"quick\", \"brown\", \"fox\"]"
         );
         if (readMetadata) {
-            doc3.add(",\"_metadata\":{\"_index\":\"json-pig-tupleartists\",\"_type\":\"data\",\"_id\":\"");
+            doc3.add(",\"_metadata\":{\"_index\":\"json-pig-tupleartists\",\"_type\":\""+metaType+"\",\"_id\":\"");
             doc3.add("\",\"_score\":");
         }
 
@@ -119,7 +124,7 @@ public class AbstractPigReadAsJsonTest extends AbstractPigTests {
     @Test
     public void testTupleWithSchema() throws Exception {
         String script = scriptHead +
-                "A = LOAD 'json-pig-tupleartists/data' USING EsStorage() AS (name:chararray);" +
+                "A = LOAD '"+resource("json-pig-tupleartists", "data")+"' USING EsStorage() AS (name:chararray);" +
                 "B = ORDER A BY name DESC;" +
                 "X = LIMIT B 3;" +
                 "STORE B INTO '" + tmpPig() + "/testtupleschema';";
@@ -127,11 +132,16 @@ public class AbstractPigReadAsJsonTest extends AbstractPigTests {
 
         String results = getResults("" + tmpPig() + "/testtupleschema");
 
+        String metaType = "data";
+        if (testVersion.onOrAfter(EsMajorVersion.V_8_X)) {
+            metaType = "_doc";
+        }
+
         List<String> doc1 = Lists.newArrayList(
                 "{\"number\":\"999\",\"name\":\"Thompson Twins\",\"url\":\"http://www.last.fm/music/Thompson+Twins\",\"picture\":\"http://userserve-ak.last.fm/serve/252/6943589.jpg\",\"@timestamp\":\"2017-10-06T19:20:25.000Z\",\"list\":[\"quick\", \"brown\", \"fox\"]"
         );
         if (readMetadata) {
-            doc1.add(",\"_metadata\":{\"_index\":\"json-pig-tupleartists\",\"_type\":\"data\",\"_id\":\"");
+            doc1.add(",\"_metadata\":{\"_index\":\"json-pig-tupleartists\",\"_type\":\""+metaType+"\",\"_id\":\"");
             doc1.add("\",\"_score\":");
         }
 
@@ -139,7 +149,7 @@ public class AbstractPigReadAsJsonTest extends AbstractPigTests {
                 "{\"number\":\"12\",\"name\":\"Behemoth\",\"url\":\"http://www.last.fm/music/Behemoth\",\"picture\":\"http://userserve-ak.last.fm/serve/252/54196161.jpg\",\"@timestamp\":\"2001-10-06T19:20:25.000Z\",\"list\":[\"quick\", \"brown\", \"fox\"]"
         );
         if (readMetadata) {
-            doc2.add(",\"_metadata\":{\"_index\":\"json-pig-tupleartists\",\"_type\":\"data\",\"_id\":\"");
+            doc2.add(",\"_metadata\":{\"_index\":\"json-pig-tupleartists\",\"_type\":\""+metaType+"\",\"_id\":\"");
             doc2.add("\",\"_score\":");
         }
 
@@ -147,7 +157,7 @@ public class AbstractPigReadAsJsonTest extends AbstractPigTests {
                 "{\"number\":\"230\",\"name\":\"Green Day\",\"url\":\"http://www.last.fm/music/Green+Day\",\"picture\":\"http://userserve-ak.last.fm/serve/252/15291249.jpg\",\"@timestamp\":\"2005-10-06T19:20:25.000Z\",\"list\":[\"quick\", \"brown\", \"fox\"]"
         );
         if (readMetadata) {
-            doc3.add(",\"_metadata\":{\"_index\":\"json-pig-tupleartists\",\"_type\":\"data\",\"_id\":\"");
+            doc3.add(",\"_metadata\":{\"_index\":\"json-pig-tupleartists\",\"_type\":\""+metaType+"\",\"_id\":\"");
             doc3.add("\",\"_score\":");
         }
 
@@ -159,18 +169,23 @@ public class AbstractPigReadAsJsonTest extends AbstractPigTests {
     @Test
     public void testFieldAlias() throws Exception {
         String script = scriptHead
-                      + "A = LOAD 'json-pig-fieldalias/data' USING EsStorage();"
+                      + "A = LOAD '"+resource("json-pig-fieldalias", "data")+"' USING EsStorage();"
                       + "X = LIMIT A 3;"
                       + "STORE A INTO '" + tmpPig() + "/testfieldalias';";
         pig.executeScript(script);
 
         String results = getResults("" + tmpPig() + "/testfieldalias");
 
+        String metaType = "data";
+        if (testVersion.onOrAfter(EsMajorVersion.V_8_X)) {
+            metaType = "_doc";
+        }
+
         List<String> doc1 = Lists.newArrayList(
                 "{\"number\":\"12\",\"name\":\"Behemoth\",\"url\":\"http://www.last.fm/music/Behemoth\",\"picture\":\"http://userserve-ak.last.fm/serve/252/54196161.jpg\",\"@timestamp\":\"2001-10-06T19:20:25.000Z\",\"list\":[\"quick\", \"brown\", \"fox\"]"
         );
         if (readMetadata) {
-            doc1.add(",\"_metadata\":{\"_index\":\"json-pig-fieldalias\",\"_type\":\"data\",\"_id\":\"");
+            doc1.add(",\"_metadata\":{\"_index\":\"json-pig-fieldalias\",\"_type\":\""+metaType+"\",\"_id\":\"");
             doc1.add("\",\"_score\":");
         }
 
@@ -178,7 +193,7 @@ public class AbstractPigReadAsJsonTest extends AbstractPigTests {
                 "{\"number\":\"918\",\"name\":\"Megadeth\",\"url\":\"http://www.last.fm/music/Megadeth\",\"picture\":\"http://userserve-ak.last.fm/serve/252/8129787.jpg\",\"@timestamp\":\"2017-10-06T19:20:25.000Z\",\"list\":[\"quick\", \"brown\", \"fox\"]"
         );
         if (readMetadata) {
-            doc2.add(",\"_metadata\":{\"_index\":\"json-pig-fieldalias\",\"_type\":\"data\",\"_id\":\"");
+            doc2.add(",\"_metadata\":{\"_index\":\"json-pig-fieldalias\",\"_type\":\""+metaType+"\",\"_id\":\"");
             doc2.add("\",\"_score\":");
         }
 
@@ -186,7 +201,7 @@ public class AbstractPigReadAsJsonTest extends AbstractPigTests {
                 "{\"number\":\"982\",\"name\":\"Foo Fighters\",\"url\":\"http://www.last.fm/music/Foo+Fighters\",\"picture\":\"http://userserve-ak.last.fm/serve/252/59495563.jpg\",\"@timestamp\":\"2017-10-06T19:20:25.000Z\",\"list\":[\"quick\", \"brown\", \"fox\"]"
         );
         if (readMetadata) {
-            doc3.add(",\"_metadata\":{\"_index\":\"json-pig-fieldalias\",\"_type\":\"data\",\"_id\":\"");
+            doc3.add(",\"_metadata\":{\"_index\":\"json-pig-fieldalias\",\"_type\":\""+metaType+"\",\"_id\":\"");
             doc3.add("\",\"_score\":");
         }
 
@@ -198,7 +213,7 @@ public class AbstractPigReadAsJsonTest extends AbstractPigTests {
     @Test
     public void testMissingIndex() throws Exception {
         String script = scriptHead
-                      + "A = LOAD 'foo/bar' USING EsStorage();"
+                      + "A = LOAD '"+resource("foo", "bar")+"' USING EsStorage();"
                       + "X = LIMIT A 3;"
                       + "STORE A INTO '" + tmpPig() + "/testmissingindex';";
         pig.executeScript(script);
@@ -258,16 +273,33 @@ public class AbstractPigReadAsJsonTest extends AbstractPigTests {
 
     @Test
     public void testDynamicPattern() throws Exception {
-        Assert.assertTrue(RestUtils.exists("json-pig-pattern-1/data"));
-        Assert.assertTrue(RestUtils.exists("json-pig-pattern-5/data"));
-        Assert.assertTrue(RestUtils.exists("json-pig-pattern-9/data"));
+        Assert.assertTrue(RestUtils.exists(resource("json-pig-pattern-1", "data")));
+        Assert.assertTrue(RestUtils.exists(resource("json-pig-pattern-5", "data")));
+        Assert.assertTrue(RestUtils.exists(resource("json-pig-pattern-9", "data")));
     }
 
     @Test
     public void testDynamicPatternFormat() throws Exception {
-        Assert.assertTrue(RestUtils.exists("json-pig-pattern-format-2001-10-06/data"));
-        Assert.assertTrue(RestUtils.exists("json-pig-pattern-format-2005-10-06/data"));
-        Assert.assertTrue(RestUtils.exists("json-pig-pattern-format-2017-10-06/data"));
+        Assert.assertTrue(RestUtils.exists(resource("json-pig-pattern-format-2001-10-06", "data")));
+        Assert.assertTrue(RestUtils.exists(resource("json-pig-pattern-format-2005-10-06", "data")));
+        Assert.assertTrue(RestUtils.exists(resource("json-pig-pattern-format-2017-10-06", "data")));
+    }
+
+
+    private String resource(String index, String type) {
+        if (testVersion.onOrAfter(EsMajorVersion.V_8_X)) {
+            return index;
+        } else {
+            return index + "/" + type;
+        }
+    }
+
+    private String docEndpoint(String index, String type) {
+        if (testVersion.onOrAfter(EsMajorVersion.V_8_X)) {
+            return index + "/_doc";
+        } else {
+            return index + "/" + type;
+        }
     }
 
     private static String tmpPig() {

--- a/pig/src/itest/java/org/elasticsearch/hadoop/integration/pig/AbstractPigSaveJsonTest.java
+++ b/pig/src/itest/java/org/elasticsearch/hadoop/integration/pig/AbstractPigSaveJsonTest.java
@@ -26,6 +26,7 @@ import org.elasticsearch.hadoop.mr.RestUtils;
 import org.elasticsearch.hadoop.rest.RestClient;
 import org.elasticsearch.hadoop.util.EsMajorVersion;
 import org.elasticsearch.hadoop.util.TestSettings;
+import org.elasticsearch.hadoop.util.TestUtils;
 import org.junit.BeforeClass;
 import org.junit.FixMethodOrder;
 import org.junit.Test;
@@ -34,6 +35,8 @@ import org.junit.runners.MethodSorters;
 
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class AbstractPigSaveJsonTest extends AbstractPigTests {
+
+    private final EsMajorVersion VERSION = TestUtils.getEsClusterInfo().getMajorVersion();
 
     @BeforeClass
     public static void startup() throws Exception {
@@ -54,7 +57,7 @@ public class AbstractPigSaveJsonTest extends AbstractPigTests {
                 "REGISTER "+ Provisioner.ESHADOOP_TESTING_JAR + ";" +
                 loadSource() +
                 //"ILLUSTRATE A;" +
-                "STORE A INTO 'json-pig-tupleartists/data' USING org.elasticsearch.hadoop.pig.EsStorage('es.input.json=true');";
+                "STORE A INTO '"+resource("json-pig-tupleartists", "data")+"' USING org.elasticsearch.hadoop.pig.EsStorage('es.input.json=true');";
         //"es_total = LOAD 'radio/artists/_count?q=me*' USING org.elasticsearch.hadoop.pig.EsStorage();" +
         pig.executeScript(script);
     }
@@ -64,7 +67,7 @@ public class AbstractPigSaveJsonTest extends AbstractPigTests {
         String script =
                 "REGISTER "+ Provisioner.ESHADOOP_TESTING_JAR + ";" +
                 loadSource() +
-                "STORE A INTO 'json-pig-fieldalias/data' USING org.elasticsearch.hadoop.pig.EsStorage('es.input.json=true','es.mapping.names=data:@json');";
+                "STORE A INTO '"+resource("json-pig-fieldalias", "data")+"' USING org.elasticsearch.hadoop.pig.EsStorage('es.input.json=true','es.mapping.names=data:@json');";
 
         pig.executeScript(script);
     }
@@ -74,7 +77,7 @@ public class AbstractPigSaveJsonTest extends AbstractPigTests {
         String script =
                 "REGISTER "+ Provisioner.ESHADOOP_TESTING_JAR + ";" +
                 loadSource() +
-                "STORE A INTO 'json-pig-createwithid/data' USING org.elasticsearch.hadoop.pig.EsStorage('"
+                "STORE A INTO '"+resource("json-pig-createwithid", "data")+"' USING org.elasticsearch.hadoop.pig.EsStorage('"
                                 + ConfigurationOptions.ES_WRITE_OPERATION + "=create','"
                                 + ConfigurationOptions.ES_MAPPING_ID + "=number',"
                                 + "'es.input.json=true');";
@@ -91,7 +94,7 @@ public class AbstractPigSaveJsonTest extends AbstractPigTests {
         String script =
                 "REGISTER "+ Provisioner.ESHADOOP_TESTING_JAR + ";" +
                 loadSource() +
-                "STORE A INTO 'json-pig-updatewoid/data' USING org.elasticsearch.hadoop.pig.EsStorage('"
+                "STORE A INTO '"+resource("json-pig-updatewoid", "data")+"' USING org.elasticsearch.hadoop.pig.EsStorage('"
                                 + ConfigurationOptions.ES_WRITE_OPERATION + "=update',"
                                 + "'es.input.json=true');";
         pig.executeScript(script);
@@ -102,7 +105,7 @@ public class AbstractPigSaveJsonTest extends AbstractPigTests {
         String script =
                 "REGISTER "+ Provisioner.ESHADOOP_TESTING_JAR + ";" +
                 loadSource() +
-                "STORE A INTO 'json-pig-update/data' USING org.elasticsearch.hadoop.pig.EsStorage('"
+                "STORE A INTO '"+resource("json-pig-update", "data")+"' USING org.elasticsearch.hadoop.pig.EsStorage('"
                                 + ConfigurationOptions.ES_WRITE_OPERATION + "=upsert','"
                                 + ConfigurationOptions.ES_MAPPING_ID + "=number',"
                                 + "'es.input.json=true');";
@@ -114,7 +117,7 @@ public class AbstractPigSaveJsonTest extends AbstractPigTests {
         String script =
                 "REGISTER "+ Provisioner.ESHADOOP_TESTING_JAR + ";" +
                 loadSource() +
-                "STORE A INTO 'json-pig-updatewoupsert/data' USING org.elasticsearch.hadoop.pig.EsStorage('"
+                "STORE A INTO '"+resource("json-pig-updatewoupsert", "data")+"' USING org.elasticsearch.hadoop.pig.EsStorage('"
                                 + ConfigurationOptions.ES_WRITE_OPERATION + "=update','"
                                 + ConfigurationOptions.ES_MAPPING_ID + "=number',"
                                 + "'es.input.json=true');";
@@ -142,7 +145,7 @@ public class AbstractPigSaveJsonTest extends AbstractPigTests {
         String script =
                 "REGISTER "+ Provisioner.ESHADOOP_TESTING_JAR + ";" +
                 loadSource() +
-                "STORE A INTO 'json-pig-pattern-{tag}/data' USING org.elasticsearch.hadoop.pig.EsStorage('es.input.json=true');";
+                "STORE A INTO '"+resource("json-pig-pattern-{tag}", "data")+"' USING org.elasticsearch.hadoop.pig.EsStorage('es.input.json=true');";
 
         pig.executeScript(script);
     }
@@ -152,9 +155,25 @@ public class AbstractPigSaveJsonTest extends AbstractPigTests {
         String script =
                 "REGISTER "+ Provisioner.ESHADOOP_TESTING_JAR + ";" +
                 loadSource() +
-                "STORE A INTO 'json-pig-pattern-format-{@timestamp|YYYY-MM-dd}/data' USING org.elasticsearch.hadoop.pig.EsStorage('es.input.json=true');";
+                "STORE A INTO '"+resource("json-pig-pattern-format-{@timestamp|YYYY-MM-dd}", "data")+"' USING org.elasticsearch.hadoop.pig.EsStorage('es.input.json=true');";
 
         pig.executeScript(script);
+    }
+
+    private String resource(String index, String type) {
+        if (VERSION.onOrAfter(EsMajorVersion.V_8_X)) {
+            return index;
+        } else {
+            return index + "/" + type;
+        }
+    }
+
+    private String docEndpoint(String index, String type) {
+        if (VERSION.onOrAfter(EsMajorVersion.V_8_X)) {
+            return index + "/_doc";
+        } else {
+            return index + "/" + type;
+        }
     }
 
     private String loadSource() {

--- a/pig/src/itest/java/org/elasticsearch/hadoop/integration/pig/AbstractPigSaveJsonTest.java
+++ b/pig/src/itest/java/org/elasticsearch/hadoop/integration/pig/AbstractPigSaveJsonTest.java
@@ -161,7 +161,7 @@ public class AbstractPigSaveJsonTest extends AbstractPigTests {
     }
 
     private String resource(String index, String type) {
-        if (VERSION.onOrAfter(EsMajorVersion.V_8_X)) {
+        if (TestUtils.isTypelessVersion(VERSION)) {
             return index;
         } else {
             return index + "/" + type;
@@ -169,7 +169,7 @@ public class AbstractPigSaveJsonTest extends AbstractPigTests {
     }
 
     private String docEndpoint(String index, String type) {
-        if (VERSION.onOrAfter(EsMajorVersion.V_8_X)) {
+        if (TestUtils.isTypelessVersion(VERSION)) {
             return index + "/_doc";
         } else {
             return index + "/" + type;

--- a/pig/src/itest/java/org/elasticsearch/hadoop/integration/pig/AbstractPigSaveJsonTest.java
+++ b/pig/src/itest/java/org/elasticsearch/hadoop/integration/pig/AbstractPigSaveJsonTest.java
@@ -32,6 +32,8 @@ import org.junit.FixMethodOrder;
 import org.junit.Test;
 import org.junit.runners.MethodSorters;
 
+import static org.elasticsearch.hadoop.util.TestUtils.resource;
+
 
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class AbstractPigSaveJsonTest extends AbstractPigTests {
@@ -57,7 +59,7 @@ public class AbstractPigSaveJsonTest extends AbstractPigTests {
                 "REGISTER "+ Provisioner.ESHADOOP_TESTING_JAR + ";" +
                 loadSource() +
                 //"ILLUSTRATE A;" +
-                "STORE A INTO '"+resource("json-pig-tupleartists", "data")+"' USING org.elasticsearch.hadoop.pig.EsStorage('es.input.json=true');";
+                "STORE A INTO '"+resource("json-pig-tupleartists", "data", VERSION)+"' USING org.elasticsearch.hadoop.pig.EsStorage('es.input.json=true');";
         //"es_total = LOAD 'radio/artists/_count?q=me*' USING org.elasticsearch.hadoop.pig.EsStorage();" +
         pig.executeScript(script);
     }
@@ -67,7 +69,7 @@ public class AbstractPigSaveJsonTest extends AbstractPigTests {
         String script =
                 "REGISTER "+ Provisioner.ESHADOOP_TESTING_JAR + ";" +
                 loadSource() +
-                "STORE A INTO '"+resource("json-pig-fieldalias", "data")+"' USING org.elasticsearch.hadoop.pig.EsStorage('es.input.json=true','es.mapping.names=data:@json');";
+                "STORE A INTO '"+resource("json-pig-fieldalias", "data", VERSION)+"' USING org.elasticsearch.hadoop.pig.EsStorage('es.input.json=true','es.mapping.names=data:@json');";
 
         pig.executeScript(script);
     }
@@ -77,7 +79,7 @@ public class AbstractPigSaveJsonTest extends AbstractPigTests {
         String script =
                 "REGISTER "+ Provisioner.ESHADOOP_TESTING_JAR + ";" +
                 loadSource() +
-                "STORE A INTO '"+resource("json-pig-createwithid", "data")+"' USING org.elasticsearch.hadoop.pig.EsStorage('"
+                "STORE A INTO '"+resource("json-pig-createwithid", "data", VERSION)+"' USING org.elasticsearch.hadoop.pig.EsStorage('"
                                 + ConfigurationOptions.ES_WRITE_OPERATION + "=create','"
                                 + ConfigurationOptions.ES_MAPPING_ID + "=number',"
                                 + "'es.input.json=true');";
@@ -94,7 +96,7 @@ public class AbstractPigSaveJsonTest extends AbstractPigTests {
         String script =
                 "REGISTER "+ Provisioner.ESHADOOP_TESTING_JAR + ";" +
                 loadSource() +
-                "STORE A INTO '"+resource("json-pig-updatewoid", "data")+"' USING org.elasticsearch.hadoop.pig.EsStorage('"
+                "STORE A INTO '"+resource("json-pig-updatewoid", "data", VERSION)+"' USING org.elasticsearch.hadoop.pig.EsStorage('"
                                 + ConfigurationOptions.ES_WRITE_OPERATION + "=update',"
                                 + "'es.input.json=true');";
         pig.executeScript(script);
@@ -105,7 +107,7 @@ public class AbstractPigSaveJsonTest extends AbstractPigTests {
         String script =
                 "REGISTER "+ Provisioner.ESHADOOP_TESTING_JAR + ";" +
                 loadSource() +
-                "STORE A INTO '"+resource("json-pig-update", "data")+"' USING org.elasticsearch.hadoop.pig.EsStorage('"
+                "STORE A INTO '"+resource("json-pig-update", "data", VERSION)+"' USING org.elasticsearch.hadoop.pig.EsStorage('"
                                 + ConfigurationOptions.ES_WRITE_OPERATION + "=upsert','"
                                 + ConfigurationOptions.ES_MAPPING_ID + "=number',"
                                 + "'es.input.json=true');";
@@ -117,7 +119,7 @@ public class AbstractPigSaveJsonTest extends AbstractPigTests {
         String script =
                 "REGISTER "+ Provisioner.ESHADOOP_TESTING_JAR + ";" +
                 loadSource() +
-                "STORE A INTO '"+resource("json-pig-updatewoupsert", "data")+"' USING org.elasticsearch.hadoop.pig.EsStorage('"
+                "STORE A INTO '"+resource("json-pig-updatewoupsert", "data", VERSION)+"' USING org.elasticsearch.hadoop.pig.EsStorage('"
                                 + ConfigurationOptions.ES_WRITE_OPERATION + "=update','"
                                 + ConfigurationOptions.ES_MAPPING_ID + "=number',"
                                 + "'es.input.json=true');";
@@ -145,7 +147,7 @@ public class AbstractPigSaveJsonTest extends AbstractPigTests {
         String script =
                 "REGISTER "+ Provisioner.ESHADOOP_TESTING_JAR + ";" +
                 loadSource() +
-                "STORE A INTO '"+resource("json-pig-pattern-{tag}", "data")+"' USING org.elasticsearch.hadoop.pig.EsStorage('es.input.json=true');";
+                "STORE A INTO '"+resource("json-pig-pattern-{tag}", "data", VERSION)+"' USING org.elasticsearch.hadoop.pig.EsStorage('es.input.json=true');";
 
         pig.executeScript(script);
     }
@@ -155,25 +157,9 @@ public class AbstractPigSaveJsonTest extends AbstractPigTests {
         String script =
                 "REGISTER "+ Provisioner.ESHADOOP_TESTING_JAR + ";" +
                 loadSource() +
-                "STORE A INTO '"+resource("json-pig-pattern-format-{@timestamp|YYYY-MM-dd}", "data")+"' USING org.elasticsearch.hadoop.pig.EsStorage('es.input.json=true');";
+                "STORE A INTO '"+resource("json-pig-pattern-format-{@timestamp|YYYY-MM-dd}", "data", VERSION)+"' USING org.elasticsearch.hadoop.pig.EsStorage('es.input.json=true');";
 
         pig.executeScript(script);
-    }
-
-    private String resource(String index, String type) {
-        if (TestUtils.isTypelessVersion(VERSION)) {
-            return index;
-        } else {
-            return index + "/" + type;
-        }
-    }
-
-    private String docEndpoint(String index, String type) {
-        if (TestUtils.isTypelessVersion(VERSION)) {
-            return index + "/_doc";
-        } else {
-            return index + "/" + type;
-        }
     }
 
     private String loadSource() {

--- a/pig/src/itest/java/org/elasticsearch/hadoop/integration/pig/AbstractPigSaveTest.java
+++ b/pig/src/itest/java/org/elasticsearch/hadoop/integration/pig/AbstractPigSaveTest.java
@@ -37,6 +37,8 @@ import org.junit.Test;
 import org.junit.runners.MethodSorters;
 
 import static org.elasticsearch.hadoop.util.EsMajorVersion.V_5_X;
+import static org.elasticsearch.hadoop.util.TestUtils.docEndpoint;
+import static org.elasticsearch.hadoop.util.TestUtils.resource;
 import static org.junit.Assert.*;
 
 import static org.hamcrest.CoreMatchers.*;
@@ -72,7 +74,7 @@ public class AbstractPigSaveTest extends AbstractPigTests {
                 "B = FOREACH A GENERATE name, TOTUPLE(url, picture) AS links;" +
                 "DESCRIBE B;" +
                 "ILLUSTRATE B;" +
-                "STORE B INTO '"+resource("pig-tupleartists", "data")+"' USING org.elasticsearch.hadoop.pig.EsStorage();";
+                "STORE B INTO '"+resource("pig-tupleartists", "data", VERSION)+"' USING org.elasticsearch.hadoop.pig.EsStorage();";
         //"es_total = LOAD 'radio/artists/_count?q=me*' USING org.elasticsearch.hadoop.pig.EsStorage();" +
         //"DUMP es_total;" +
         //"bartists = FILTER B BY name MATCHES 'me.*';" +
@@ -100,7 +102,7 @@ public class AbstractPigSaveTest extends AbstractPigTests {
                 loadArtistSource() +
                 "B = FOREACH A GENERATE name, TOBAG(url, picture) AS links;" +
                 "ILLUSTRATE B;" +
-                "STORE B INTO '"+resource("pig-bagartists", "data")+"' USING org.elasticsearch.hadoop.pig.EsStorage();";
+                "STORE B INTO '"+resource("pig-bagartists", "data", VERSION)+"' USING org.elasticsearch.hadoop.pig.EsStorage();";
         pig.executeScript(script);
     }
 
@@ -121,7 +123,7 @@ public class AbstractPigSaveTest extends AbstractPigTests {
                 loadArtistSource() +
                 "B = FOREACH A GENERATE name, ToDate(" + millis + "l) AS date, url;" +
                 "ILLUSTRATE B;" +
-                "STORE B INTO '"+resource("pig-timestamp", "data")+"' USING org.elasticsearch.hadoop.pig.EsStorage();";
+                "STORE B INTO '"+resource("pig-timestamp", "data", VERSION)+"' USING org.elasticsearch.hadoop.pig.EsStorage();";
 
         pig.executeScript(script);
     }
@@ -141,7 +143,7 @@ public class AbstractPigSaveTest extends AbstractPigTests {
                 loadArtistSource() +
                 "B = FOREACH A GENERATE name, ToDate(" + millis + "l) AS timestamp, url, picture;" +
                 "ILLUSTRATE B;" +
-                "STORE B INTO '"+resource("pig-fieldalias", "data")+"' USING org.elasticsearch.hadoop.pig.EsStorage('es.mapping.names=nAme:@name, timestamp:@timestamp, uRL:url, picturE:picture');";
+                "STORE B INTO '"+resource("pig-fieldalias", "data", VERSION)+"' USING org.elasticsearch.hadoop.pig.EsStorage('es.mapping.names=nAme:@name, timestamp:@timestamp, uRL:url, picturE:picture');";
 
         pig.executeScript(script);
     }
@@ -162,7 +164,7 @@ public class AbstractPigSaveTest extends AbstractPigTests {
                 "A = LOAD '" + TestUtils.sampleArtistsDat() + "' USING PigStorage() AS (id:long, Name:chararray, uRL:chararray, pIctUre: chararray, timestamp: chararray); " +
                 "B = FOREACH A GENERATE Name, uRL, pIctUre;" +
                 "ILLUSTRATE B;" +
-                "STORE B INTO '"+resource("pig-casesensitivity", "data")+"' USING org.elasticsearch.hadoop.pig.EsStorage();";
+                "STORE B INTO '"+resource("pig-casesensitivity", "data", VERSION)+"' USING org.elasticsearch.hadoop.pig.EsStorage();";
 
         pig.executeScript(script);
     }
@@ -182,7 +184,7 @@ public class AbstractPigSaveTest extends AbstractPigTests {
                 loadArtistSource() +
                 "AL = LIMIT A 10;" +
                 "B = FOREACH AL GENERATE (), [], {};" +
-                "STORE B INTO '"+resource("pig-emptyconst", "data")+"' USING org.elasticsearch.hadoop.pig.EsStorage();";
+                "STORE B INTO '"+resource("pig-emptyconst", "data", VERSION)+"' USING org.elasticsearch.hadoop.pig.EsStorage();";
 
         pig.executeScript(script);
     }
@@ -198,7 +200,7 @@ public class AbstractPigSaveTest extends AbstractPigTests {
                 "REGISTER "+ Provisioner.ESHADOOP_TESTING_JAR + ";" +
                 loadArtistSource() +
                 "B = FOREACH A GENERATE id, name, TOBAG(url, picture) AS links;" +
-                "STORE B INTO '"+resource("pig-createwithid", "data")+"' USING org.elasticsearch.hadoop.pig.EsStorage('"
+                "STORE B INTO '"+resource("pig-createwithid", "data", VERSION)+"' USING org.elasticsearch.hadoop.pig.EsStorage('"
                                 + ConfigurationOptions.ES_WRITE_OPERATION + "=create','"
                                 + ConfigurationOptions.ES_MAPPING_ID + "=id');";
         pig.executeScript(script);
@@ -223,7 +225,7 @@ public class AbstractPigSaveTest extends AbstractPigTests {
                 "REGISTER "+ Provisioner.ESHADOOP_TESTING_JAR + ";" +
                 loadArtistSource() +
                 "B = FOREACH A GENERATE id, name, TOBAG(url, picture) AS links;" +
-                "STORE B INTO '"+resource("pig-updatewoid", "data")+"' USING org.elasticsearch.hadoop.pig.EsStorage('"
+                "STORE B INTO '"+resource("pig-updatewoid", "data", VERSION)+"' USING org.elasticsearch.hadoop.pig.EsStorage('"
                                 + ConfigurationOptions.ES_WRITE_OPERATION + "=update');";
         pig.executeScript(script);
     }
@@ -234,7 +236,7 @@ public class AbstractPigSaveTest extends AbstractPigTests {
                 "REGISTER "+ Provisioner.ESHADOOP_TESTING_JAR + ";" +
                 loadArtistSource() +
                 "B = FOREACH A GENERATE id, name, TOBAG(url, picture) AS links;" +
-                "STORE B INTO '"+resource("pig-update", "data")+"' USING org.elasticsearch.hadoop.pig.EsStorage('"
+                "STORE B INTO '"+resource("pig-update", "data", VERSION)+"' USING org.elasticsearch.hadoop.pig.EsStorage('"
                                 + ConfigurationOptions.ES_WRITE_OPERATION + "=upsert','"
                                 + ConfigurationOptions.ES_MAPPING_ID + "=id');";
         pig.executeScript(script);
@@ -254,7 +256,7 @@ public class AbstractPigSaveTest extends AbstractPigTests {
                 "REGISTER "+ Provisioner.ESHADOOP_TESTING_JAR + ";" +
                 loadArtistSource() +
                 "B = FOREACH A GENERATE id, name, TOBAG(url, picture) AS links;" +
-                "STORE B INTO '"+resource("pig-updatewoupsert", "data")+"' USING org.elasticsearch.hadoop.pig.EsStorage('"
+                "STORE B INTO '"+resource("pig-updatewoupsert", "data", VERSION)+"' USING org.elasticsearch.hadoop.pig.EsStorage('"
                                 + ConfigurationOptions.ES_WRITE_OPERATION + "=update','"
                                 + ConfigurationOptions.ES_MAPPING_ID + "=id');";
         pig.executeScript(script);
@@ -309,8 +311,8 @@ public class AbstractPigSaveTest extends AbstractPigTests {
 
     @Test
     public void testNestedTuple() throws Exception {
-        RestUtils.postData(docEndpoint("pig-nestedtuple", "data"), "{\"my_array\" : [\"1.a\",\"1.b\"]}".getBytes(StringUtils.UTF_8));
-        RestUtils.postData(docEndpoint("pig-nestedtuple", "data"), "{\"my_array\" : [\"2.a\",\"2.b\"]}".getBytes(StringUtils.UTF_8));
+        RestUtils.postData(docEndpoint("pig-nestedtuple", "data", VERSION), "{\"my_array\" : [\"1.a\",\"1.b\"]}".getBytes(StringUtils.UTF_8));
+        RestUtils.postData(docEndpoint("pig-nestedtuple", "data", VERSION), "{\"my_array\" : [\"2.a\",\"2.b\"]}".getBytes(StringUtils.UTF_8));
         RestUtils.waitForYellow("pig-nestedtuple");
     }
 
@@ -320,7 +322,7 @@ public class AbstractPigSaveTest extends AbstractPigTests {
         String script =
                 "REGISTER "+ Provisioner.ESHADOOP_TESTING_JAR + ";" +
                 loadArtistSource() +
-                "STORE A INTO '"+resource("pig-pattern-{tag}", "data")+"' USING org.elasticsearch.hadoop.pig.EsStorage();";
+                "STORE A INTO '"+resource("pig-pattern-{tag}", "data", VERSION)+"' USING org.elasticsearch.hadoop.pig.EsStorage();";
 
         pig.executeScript(script);
     }
@@ -338,7 +340,7 @@ public class AbstractPigSaveTest extends AbstractPigTests {
         String script =
                 "REGISTER "+ Provisioner.ESHADOOP_TESTING_JAR + ";" +
                 loadArtistSource() +
-                "STORE A INTO '"+resource("pig-pattern-format-{timestamp|YYYY-MM-dd}", "data")+"' USING org.elasticsearch.hadoop.pig.EsStorage();";
+                "STORE A INTO '"+resource("pig-pattern-format-{timestamp|YYYY-MM-dd}", "data", VERSION)+"' USING org.elasticsearch.hadoop.pig.EsStorage();";
 
         pig.executeScript(script);
     }
@@ -349,22 +351,6 @@ public class AbstractPigSaveTest extends AbstractPigTests {
                 VERSION.onOrAfter(V_5_X)
                         ? is("*/*=[id=LONG, name=TEXT, picture=TEXT, tag=LONG, timestamp=DATE, url=TEXT]")
                         : is("*/*=[id=LONG, name=STRING, picture=STRING, tag=LONG, timestamp=DATE, url=STRING]"));
-    }
-
-    private String resource(String index, String type) {
-        if (TestUtils.isTypelessVersion(VERSION)) {
-            return index;
-        } else {
-            return index + "/" + type;
-        }
-    }
-
-    private String docEndpoint(String index, String type) {
-        if (TestUtils.isTypelessVersion(VERSION)) {
-            return index + "/_doc";
-        } else {
-            return index + "/" + type;
-        }
     }
 
     private String loadArtistSource() {

--- a/pig/src/itest/java/org/elasticsearch/hadoop/integration/pig/AbstractPigSaveTest.java
+++ b/pig/src/itest/java/org/elasticsearch/hadoop/integration/pig/AbstractPigSaveTest.java
@@ -72,7 +72,7 @@ public class AbstractPigSaveTest extends AbstractPigTests {
                 "B = FOREACH A GENERATE name, TOTUPLE(url, picture) AS links;" +
                 "DESCRIBE B;" +
                 "ILLUSTRATE B;" +
-                "STORE B INTO 'pig-tupleartists/data' USING org.elasticsearch.hadoop.pig.EsStorage();";
+                "STORE B INTO '"+resource("pig-tupleartists", "data")+"' USING org.elasticsearch.hadoop.pig.EsStorage();";
         //"es_total = LOAD 'radio/artists/_count?q=me*' USING org.elasticsearch.hadoop.pig.EsStorage();" +
         //"DUMP es_total;" +
         //"bartists = FILTER B BY name MATCHES 'me.*';" +
@@ -100,7 +100,7 @@ public class AbstractPigSaveTest extends AbstractPigTests {
                 loadArtistSource() +
                 "B = FOREACH A GENERATE name, TOBAG(url, picture) AS links;" +
                 "ILLUSTRATE B;" +
-                "STORE B INTO 'pig-bagartists/data' USING org.elasticsearch.hadoop.pig.EsStorage();";
+                "STORE B INTO '"+resource("pig-bagartists", "data")+"' USING org.elasticsearch.hadoop.pig.EsStorage();";
         pig.executeScript(script);
     }
 
@@ -121,7 +121,7 @@ public class AbstractPigSaveTest extends AbstractPigTests {
                 loadArtistSource() +
                 "B = FOREACH A GENERATE name, ToDate(" + millis + "l) AS date, url;" +
                 "ILLUSTRATE B;" +
-                "STORE B INTO 'pig-timestamp/data' USING org.elasticsearch.hadoop.pig.EsStorage();";
+                "STORE B INTO '"+resource("pig-timestamp", "data")+"' USING org.elasticsearch.hadoop.pig.EsStorage();";
 
         pig.executeScript(script);
     }
@@ -141,7 +141,7 @@ public class AbstractPigSaveTest extends AbstractPigTests {
                 loadArtistSource() +
                 "B = FOREACH A GENERATE name, ToDate(" + millis + "l) AS timestamp, url, picture;" +
                 "ILLUSTRATE B;" +
-                "STORE B INTO 'pig-fieldalias/data' USING org.elasticsearch.hadoop.pig.EsStorage('es.mapping.names=nAme:@name, timestamp:@timestamp, uRL:url, picturE:picture');";
+                "STORE B INTO '"+resource("pig-fieldalias", "data")+"' USING org.elasticsearch.hadoop.pig.EsStorage('es.mapping.names=nAme:@name, timestamp:@timestamp, uRL:url, picturE:picture');";
 
         pig.executeScript(script);
     }
@@ -162,7 +162,7 @@ public class AbstractPigSaveTest extends AbstractPigTests {
                 "A = LOAD '" + TestUtils.sampleArtistsDat() + "' USING PigStorage() AS (id:long, Name:chararray, uRL:chararray, pIctUre: chararray, timestamp: chararray); " +
                 "B = FOREACH A GENERATE Name, uRL, pIctUre;" +
                 "ILLUSTRATE B;" +
-                "STORE B INTO 'pig-casesensitivity/data' USING org.elasticsearch.hadoop.pig.EsStorage();";
+                "STORE B INTO '"+resource("pig-casesensitivity", "data")+"' USING org.elasticsearch.hadoop.pig.EsStorage();";
 
         pig.executeScript(script);
     }
@@ -182,7 +182,7 @@ public class AbstractPigSaveTest extends AbstractPigTests {
                 loadArtistSource() +
                 "AL = LIMIT A 10;" +
                 "B = FOREACH AL GENERATE (), [], {};" +
-                "STORE B INTO 'pig-emptyconst/data' USING org.elasticsearch.hadoop.pig.EsStorage();";
+                "STORE B INTO '"+resource("pig-emptyconst", "data")+"' USING org.elasticsearch.hadoop.pig.EsStorage();";
 
         pig.executeScript(script);
     }
@@ -198,7 +198,7 @@ public class AbstractPigSaveTest extends AbstractPigTests {
                 "REGISTER "+ Provisioner.ESHADOOP_TESTING_JAR + ";" +
                 loadArtistSource() +
                 "B = FOREACH A GENERATE id, name, TOBAG(url, picture) AS links;" +
-                "STORE B INTO 'pig-createwithid/data' USING org.elasticsearch.hadoop.pig.EsStorage('"
+                "STORE B INTO '"+resource("pig-createwithid", "data")+"' USING org.elasticsearch.hadoop.pig.EsStorage('"
                                 + ConfigurationOptions.ES_WRITE_OPERATION + "=create','"
                                 + ConfigurationOptions.ES_MAPPING_ID + "=id');";
         pig.executeScript(script);
@@ -223,7 +223,7 @@ public class AbstractPigSaveTest extends AbstractPigTests {
                 "REGISTER "+ Provisioner.ESHADOOP_TESTING_JAR + ";" +
                 loadArtistSource() +
                 "B = FOREACH A GENERATE id, name, TOBAG(url, picture) AS links;" +
-                "STORE B INTO 'pig-updatewoid/data' USING org.elasticsearch.hadoop.pig.EsStorage('"
+                "STORE B INTO '"+resource("pig-updatewoid", "data")+"' USING org.elasticsearch.hadoop.pig.EsStorage('"
                                 + ConfigurationOptions.ES_WRITE_OPERATION + "=update');";
         pig.executeScript(script);
     }
@@ -234,7 +234,7 @@ public class AbstractPigSaveTest extends AbstractPigTests {
                 "REGISTER "+ Provisioner.ESHADOOP_TESTING_JAR + ";" +
                 loadArtistSource() +
                 "B = FOREACH A GENERATE id, name, TOBAG(url, picture) AS links;" +
-                "STORE B INTO 'pig-update/data' USING org.elasticsearch.hadoop.pig.EsStorage('"
+                "STORE B INTO '"+resource("pig-update", "data")+"' USING org.elasticsearch.hadoop.pig.EsStorage('"
                                 + ConfigurationOptions.ES_WRITE_OPERATION + "=upsert','"
                                 + ConfigurationOptions.ES_MAPPING_ID + "=id');";
         pig.executeScript(script);
@@ -254,7 +254,7 @@ public class AbstractPigSaveTest extends AbstractPigTests {
                 "REGISTER "+ Provisioner.ESHADOOP_TESTING_JAR + ";" +
                 loadArtistSource() +
                 "B = FOREACH A GENERATE id, name, TOBAG(url, picture) AS links;" +
-                "STORE B INTO 'pig-updatewoupsert/data' USING org.elasticsearch.hadoop.pig.EsStorage('"
+                "STORE B INTO '"+resource("pig-updatewoupsert", "data")+"' USING org.elasticsearch.hadoop.pig.EsStorage('"
                                 + ConfigurationOptions.ES_WRITE_OPERATION + "=update','"
                                 + ConfigurationOptions.ES_MAPPING_ID + "=id');";
         pig.executeScript(script);
@@ -309,8 +309,8 @@ public class AbstractPigSaveTest extends AbstractPigTests {
 
     @Test
     public void testNestedTuple() throws Exception {
-        RestUtils.postData("pig-nestedtuple/data", "{\"my_array\" : [\"1.a\",\"1.b\"]}".getBytes(StringUtils.UTF_8));
-        RestUtils.postData("pig-nestedtuple/data", "{\"my_array\" : [\"2.a\",\"2.b\"]}".getBytes(StringUtils.UTF_8));
+        RestUtils.postData(docEndpoint("pig-nestedtuple", "data"), "{\"my_array\" : [\"1.a\",\"1.b\"]}".getBytes(StringUtils.UTF_8));
+        RestUtils.postData(docEndpoint("pig-nestedtuple", "data"), "{\"my_array\" : [\"2.a\",\"2.b\"]}".getBytes(StringUtils.UTF_8));
         RestUtils.waitForYellow("pig-nestedtuple");
     }
 
@@ -320,7 +320,7 @@ public class AbstractPigSaveTest extends AbstractPigTests {
         String script =
                 "REGISTER "+ Provisioner.ESHADOOP_TESTING_JAR + ";" +
                 loadArtistSource() +
-                "STORE A INTO 'pig-pattern-{tag}/data' USING org.elasticsearch.hadoop.pig.EsStorage();";
+                "STORE A INTO '"+resource("pig-pattern-{tag}", "data")+"' USING org.elasticsearch.hadoop.pig.EsStorage();";
 
         pig.executeScript(script);
     }
@@ -338,7 +338,7 @@ public class AbstractPigSaveTest extends AbstractPigTests {
         String script =
                 "REGISTER "+ Provisioner.ESHADOOP_TESTING_JAR + ";" +
                 loadArtistSource() +
-                "STORE A INTO 'pig-pattern-format-{timestamp|YYYY-MM-dd}/data' USING org.elasticsearch.hadoop.pig.EsStorage();";
+                "STORE A INTO '"+resource("pig-pattern-format-{timestamp|YYYY-MM-dd}", "data")+"' USING org.elasticsearch.hadoop.pig.EsStorage();";
 
         pig.executeScript(script);
     }
@@ -349,6 +349,22 @@ public class AbstractPigSaveTest extends AbstractPigTests {
                 VERSION.onOrAfter(V_5_X)
                         ? is("*/*=[id=LONG, name=TEXT, picture=TEXT, tag=LONG, timestamp=DATE, url=TEXT]")
                         : is("*/*=[id=LONG, name=STRING, picture=STRING, tag=LONG, timestamp=DATE, url=STRING]"));
+    }
+
+    private String resource(String index, String type) {
+        if (VERSION.onOrAfter(EsMajorVersion.V_8_X)) {
+            return index;
+        } else {
+            return index + "/" + type;
+        }
+    }
+
+    private String docEndpoint(String index, String type) {
+        if (VERSION.onOrAfter(EsMajorVersion.V_8_X)) {
+            return index + "/_doc";
+        } else {
+            return index + "/" + type;
+        }
     }
 
     private String loadArtistSource() {

--- a/pig/src/itest/java/org/elasticsearch/hadoop/integration/pig/AbstractPigSaveTest.java
+++ b/pig/src/itest/java/org/elasticsearch/hadoop/integration/pig/AbstractPigSaveTest.java
@@ -352,7 +352,7 @@ public class AbstractPigSaveTest extends AbstractPigTests {
     }
 
     private String resource(String index, String type) {
-        if (VERSION.onOrAfter(EsMajorVersion.V_8_X)) {
+        if (TestUtils.isTypelessVersion(VERSION)) {
             return index;
         } else {
             return index + "/" + type;
@@ -360,7 +360,7 @@ public class AbstractPigSaveTest extends AbstractPigTests {
     }
 
     private String docEndpoint(String index, String type) {
-        if (VERSION.onOrAfter(EsMajorVersion.V_8_X)) {
+        if (TestUtils.isTypelessVersion(VERSION)) {
             return index + "/_doc";
         } else {
             return index + "/" + type;

--- a/pig/src/itest/java/org/elasticsearch/hadoop/integration/pig/AbstractPigSearchJsonTest.java
+++ b/pig/src/itest/java/org/elasticsearch/hadoop/integration/pig/AbstractPigSearchJsonTest.java
@@ -25,7 +25,6 @@ import org.elasticsearch.hadoop.QueryTestParams;
 import org.elasticsearch.hadoop.mr.EsAssume;
 import org.elasticsearch.hadoop.mr.RestUtils;
 import org.elasticsearch.hadoop.util.EsMajorVersion;
-import org.elasticsearch.hadoop.util.StringUtils;
 import org.elasticsearch.hadoop.util.TestUtils;
 import org.junit.Assert;
 import org.junit.Before;
@@ -34,6 +33,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
+import static org.elasticsearch.hadoop.util.TestUtils.resource;
 import static org.junit.Assert.*;
 
 import static org.hamcrest.Matchers.*;
@@ -73,7 +73,7 @@ public class AbstractPigSearchJsonTest extends AbstractPigTests {
         String script =
                 "REGISTER "+ Provisioner.ESHADOOP_TESTING_JAR + ";" +
                 "DEFINE EsStorage org.elasticsearch.hadoop.pig.EsStorage('es.query=" + query + "','es.read.metadata=" + readMetadata +"');" +
-                "A = LOAD '"+resource("json-pig-tupleartists", "data")+"' USING EsStorage();" +
+                "A = LOAD '"+resource("json-pig-tupleartists", "data", VERSION)+"' USING EsStorage();" +
                 "X = LIMIT A 3;" +
                 //"DESCRIBE A;";
                 "STORE A INTO '" + tmpPig() + "/testtuple';";
@@ -92,7 +92,7 @@ public class AbstractPigSearchJsonTest extends AbstractPigTests {
         String script =
                 "REGISTER "+ Provisioner.ESHADOOP_TESTING_JAR + ";" +
                 "DEFINE EsStorage org.elasticsearch.hadoop.pig.EsStorage('es.query=" + query + "','es.read.metadata=" + readMetadata +"');" +
-                "A = LOAD '"+resource("json-pig-tupleartists", "data")+"' USING EsStorage() AS (name:chararray);" +
+                "A = LOAD '"+resource("json-pig-tupleartists", "data", VERSION)+"' USING EsStorage() AS (name:chararray);" +
                 "B = ORDER A BY name DESC;" +
                 "X = LIMIT B 3;" +
                 "STORE B INTO '" + tmpPig() + "/testtupleschema';";
@@ -109,7 +109,7 @@ public class AbstractPigSearchJsonTest extends AbstractPigTests {
         String script =
                       "REGISTER "+ Provisioner.ESHADOOP_TESTING_JAR + ";" +
                        "DEFINE EsStorage org.elasticsearch.hadoop.pig.EsStorage('es.query="+ query + "','es.read.metadata=" + readMetadata +"');"
-                      + "A = LOAD '"+resource("json-pig-fieldalias", "data")+"' USING EsStorage();"
+                      + "A = LOAD '"+resource("json-pig-fieldalias", "data", VERSION)+"' USING EsStorage();"
                       + "X = LIMIT A 3;"
                       + "STORE A INTO '" + tmpPig() + "/testfieldalias';";
         pig.executeScript(script);
@@ -126,7 +126,7 @@ public class AbstractPigSearchJsonTest extends AbstractPigTests {
         String script =
                       "REGISTER "+ Provisioner.ESHADOOP_TESTING_JAR + ";" +
                       "DEFINE EsStorage org.elasticsearch.hadoop.pig.EsStorage('es.index.read.missing.as.empty=true','es.query=" + query + "','es.read.metadata=" + readMetadata +"');"
-                      + "A = LOAD '"+resource("foo", "bar")+"' USING EsStorage();"
+                      + "A = LOAD '"+resource("foo", "bar", VERSION)+"' USING EsStorage();"
                       + "X = LIMIT A 3;"
                       + "STORE A INTO '" + tmpPig() + "/testmissingindex';";
         pig.executeScript(script);
@@ -155,24 +155,16 @@ public class AbstractPigSearchJsonTest extends AbstractPigTests {
 
     @Test
     public void testDynamicPattern() throws Exception {
-        Assert.assertTrue(RestUtils.exists(resource("json-pig-pattern-1", "data")));
-        Assert.assertTrue(RestUtils.exists(resource("json-pig-pattern-5", "data")));
-        Assert.assertTrue(RestUtils.exists(resource("json-pig-pattern-9", "data")));
+        Assert.assertTrue(RestUtils.exists(resource("json-pig-pattern-1", "data", VERSION)));
+        Assert.assertTrue(RestUtils.exists(resource("json-pig-pattern-5", "data", VERSION)));
+        Assert.assertTrue(RestUtils.exists(resource("json-pig-pattern-9", "data", VERSION)));
     }
 
     @Test
     public void testDynamicPatternFormat() throws Exception {
-        Assert.assertTrue(RestUtils.exists(resource("json-pig-pattern-format-2001-10-06", "data")));
-        Assert.assertTrue(RestUtils.exists(resource("json-pig-pattern-format-2005-10-06", "data")));
-        Assert.assertTrue(RestUtils.exists(resource("json-pig-pattern-format-2017-10-06", "data")));
-    }
-
-    private String resource(String index, String type) {
-        if (TestUtils.isTypelessVersion(VERSION)) {
-            return index;
-        } else {
-            return index + "/" + type;
-        }
+        Assert.assertTrue(RestUtils.exists(resource("json-pig-pattern-format-2001-10-06", "data", VERSION)));
+        Assert.assertTrue(RestUtils.exists(resource("json-pig-pattern-format-2005-10-06", "data", VERSION)));
+        Assert.assertTrue(RestUtils.exists(resource("json-pig-pattern-format-2017-10-06", "data", VERSION)));
     }
 
     private static String tmpPig() {

--- a/pig/src/itest/java/org/elasticsearch/hadoop/integration/pig/AbstractPigSearchJsonTest.java
+++ b/pig/src/itest/java/org/elasticsearch/hadoop/integration/pig/AbstractPigSearchJsonTest.java
@@ -168,7 +168,7 @@ public class AbstractPigSearchJsonTest extends AbstractPigTests {
     }
 
     private String resource(String index, String type) {
-        if (VERSION.onOrAfter(EsMajorVersion.V_8_X)) {
+        if (TestUtils.isTypelessVersion(VERSION)) {
             return index;
         } else {
             return index + "/" + type;

--- a/pig/src/itest/java/org/elasticsearch/hadoop/integration/pig/AbstractPigSearchTest.java
+++ b/pig/src/itest/java/org/elasticsearch/hadoop/integration/pig/AbstractPigSearchTest.java
@@ -280,7 +280,7 @@ public class AbstractPigSearchTest extends AbstractPigTests {
     }
 
     private String resource(String index, String type) {
-        if (VERSION.onOrAfter(EsMajorVersion.V_8_X)) {
+        if (TestUtils.isTypelessVersion(VERSION)) {
             return index;
         } else {
             return index + "/" + type;

--- a/pig/src/itest/java/org/elasticsearch/hadoop/integration/pig/AbstractPigSearchTest.java
+++ b/pig/src/itest/java/org/elasticsearch/hadoop/integration/pig/AbstractPigSearchTest.java
@@ -26,6 +26,7 @@ import org.elasticsearch.hadoop.QueryTestParams;
 import org.elasticsearch.hadoop.mr.EsAssume;
 import org.elasticsearch.hadoop.mr.RestUtils;
 import org.elasticsearch.hadoop.util.EsMajorVersion;
+import org.elasticsearch.hadoop.util.TestUtils;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -51,6 +52,7 @@ public class AbstractPigSearchTest extends AbstractPigTests {
 
     private final String query;
     private final boolean readMetadata;
+    private final EsMajorVersion VERSION = TestUtils.getEsClusterInfo().getMajorVersion();
 
     public AbstractPigSearchTest(String query, boolean readMetadata) {
         this.query = query;
@@ -72,7 +74,7 @@ public class AbstractPigSearchTest extends AbstractPigTests {
         String script =
                 "REGISTER "+ Provisioner.ESHADOOP_TESTING_JAR + ";" +
                 "DEFINE EsStorage org.elasticsearch.hadoop.pig.EsStorage('es.query=" + query + "','es.read.metadata=" + readMetadata +"');" +
-                "A = LOAD 'pig-tupleartists/data' USING EsStorage();" +
+                "A = LOAD '"+resource("pig-tupleartists", "data")+"' USING EsStorage();" +
                 "X = LIMIT A 3;" +
                 //"DESCRIBE A;";
                 "STORE A INTO '" + tmpPig() + "/testtuple';";
@@ -85,7 +87,7 @@ public class AbstractPigSearchTest extends AbstractPigTests {
 
     @Test
     public void testTupleCount() throws Exception {
-        String script = "A = LOAD 'pig-tupleartists/data' using org.elasticsearch.hadoop.pig.EsStorage();" +
+        String script = "A = LOAD '"+resource("pig-tupleartists", "data")+"' using org.elasticsearch.hadoop.pig.EsStorage();" +
                 "COUNT = FOREACH (GROUP A ALL) GENERATE COUNT(A);" +
                 "DUMP COUNT;";
 
@@ -97,7 +99,7 @@ public class AbstractPigSearchTest extends AbstractPigTests {
         String script =
                 "REGISTER "+ Provisioner.ESHADOOP_TESTING_JAR + ";" +
                 "DEFINE EsStorage org.elasticsearch.hadoop.pig.EsStorage('es.query=" + query + "','es.read.metadata=" + readMetadata +"');" +
-                "A = LOAD 'pig-tupleartists/data' USING EsStorage() AS (name:chararray);" +
+                "A = LOAD '"+resource("pig-tupleartists", "data")+"' USING EsStorage() AS (name:chararray);" +
                 "X = LIMIT A 3;" +
                 "STORE A INTO '" + tmpPig() + "/testtupleschema';";
         pig.executeScript(script);
@@ -112,7 +114,7 @@ public class AbstractPigSearchTest extends AbstractPigTests {
         String script =
                       "REGISTER "+ Provisioner.ESHADOOP_TESTING_JAR + ";" +
                       "DEFINE EsStorage org.elasticsearch.hadoop.pig.EsStorage('es.query=" + query + "');"
-                      + "A = LOAD 'pig-bagartists/data' USING EsStorage();"
+                      + "A = LOAD '"+resource("pig-bagartists", "data")+"' USING EsStorage();"
                       + "X = LIMIT A 3;"
                       + "STORE A INTO '" + tmpPig() + "/testbag';";
         pig.executeScript(script);
@@ -128,7 +130,7 @@ public class AbstractPigSearchTest extends AbstractPigTests {
         String script =
                       "REGISTER "+ Provisioner.ESHADOOP_TESTING_JAR + ";" +
                       "DEFINE EsStorage org.elasticsearch.hadoop.pig.EsStorage('es.query=" + query + "', 'es.mapping.names=data:name','es.read.metadata=" + readMetadata +"');"
-                      + "A = LOAD 'pig-bagartists/data' USING EsStorage() AS (data: chararray);"
+                      + "A = LOAD '"+resource("pig-bagartists", "data")+"' USING EsStorage() AS (data: chararray);"
                       + "B = ORDER A BY * DESC;"
                       + "X = LIMIT B 3;"
                       + "STORE X INTO '" + tmpPig() + "/testbagschema';";
@@ -144,7 +146,7 @@ public class AbstractPigSearchTest extends AbstractPigTests {
         String script =
                       "REGISTER "+ Provisioner.ESHADOOP_TESTING_JAR + ";" +
                       "DEFINE EsStorage org.elasticsearch.hadoop.pig.EsStorage('es.query=" + query + "','es.read.metadata=" + readMetadata +"');"
-                      + "A = LOAD 'pig-timestamp/data' USING EsStorage();"
+                      + "A = LOAD '"+resource("pig-timestamp", "data")+"' USING EsStorage();"
                       + "X = LIMIT A 3;"
                       + "STORE A INTO '" + tmpPig() + "/testtimestamp';";
         pig.executeScript(script);
@@ -157,7 +159,7 @@ public class AbstractPigSearchTest extends AbstractPigTests {
                       "REGISTER "+ Provisioner.ESHADOOP_TESTING_JAR + ";" +
                       "DEFINE EsStorage org.elasticsearch.hadoop.pig.EsStorage(" +
                       "'es.mapping.names=nAme:name, timestamp:@timestamp, uRL:url, picturE:picture', 'es.query=" + query + "','es.read.metadata=" + readMetadata +"');"
-                      + "A = LOAD 'pig-fieldalias/data' USING EsStorage();"
+                      + "A = LOAD '"+resource("pig-fieldalias", "data")+"' USING EsStorage();"
                       + "X = LIMIT A 3;"
                       + "STORE A INTO '" + tmpPig() + "/testfieldlalias';";
         pig.executeScript(script);
@@ -174,7 +176,7 @@ public class AbstractPigSearchTest extends AbstractPigTests {
         String script =
                       "REGISTER "+ Provisioner.ESHADOOP_TESTING_JAR + ";" +
                       "DEFINE EsStorage org.elasticsearch.hadoop.pig.EsStorage('es.index.read.missing.as.empty=true','es.query=" + query + "','es.read.metadata=" + readMetadata +"');"
-                      + "A = LOAD 'foo/bar' USING EsStorage();"
+                      + "A = LOAD '"+resource("foo", "bar")+"' USING EsStorage();"
                       + "X = LIMIT A 3;"
                       + "STORE X INTO '" + tmpPig() + "/testmissingindex';";
         pig.executeScript(script);
@@ -204,7 +206,7 @@ public class AbstractPigSearchTest extends AbstractPigTests {
         String script =
                 "REGISTER "+ Provisioner.ESHADOOP_TESTING_JAR + ";" +
                 "DEFINE EsStorage org.elasticsearch.hadoop.pig.EsStorage('es.query=" + query + "','es.read.metadata=" + readMetadata +"');" // , 'es.mapping.names=links:links.url'
-                + "A = LOAD 'pig-tupleartists/data' USING EsStorage() AS (name: chararray, links: tuple(chararray));"
+                + "A = LOAD '"+resource("pig-tupleartists", "data")+"' USING EsStorage() AS (name: chararray, links: tuple(chararray));"
                 + "B = FOREACH A GENERATE name, links;"
                 + "C = ORDER B BY name DESC;"
                 + "D = LIMIT C 3;"
@@ -222,7 +224,7 @@ public class AbstractPigSearchTest extends AbstractPigTests {
         String script =
                 "REGISTER "+ Provisioner.ESHADOOP_TESTING_JAR + ";" +
                         "DEFINE EsStorage org.elasticsearch.hadoop.pig.EsStorage('es.query=" + query + "','es.read.metadata=" + readMetadata + "','es.read.source.filter=name');" +
-                        "A = LOAD 'pig-tupleartists/data' USING EsStorage();" +
+                        "A = LOAD '"+resource("pig-tupleartists", "data")+"' USING EsStorage();" +
                         "X = LIMIT A 3;" +
                         "DUMP X;" +
                         "STORE A INTO '" + tmpPig() + "/nocollision';";
@@ -238,7 +240,7 @@ public class AbstractPigSearchTest extends AbstractPigTests {
         String script =
                 "REGISTER "+ Provisioner.ESHADOOP_TESTING_JAR + ";" +
                         "DEFINE EsStorage org.elasticsearch.hadoop.pig.EsStorage('es.query=" + query + "','es.read.metadata=" + readMetadata +"','es.read.source.filter=name');" +
-                        "A = LOAD 'pig-tupleartists/data' USING EsStorage() AS (name: chararray, links: chararray);" +
+                        "A = LOAD '"+resource("pig-tupleartists", "data")+"' USING EsStorage() AS (name: chararray, links: chararray);" +
                         "B = FOREACH A GENERATE name;" +
                         "X = LIMIT B 3;" +
                         //"DESCRIBE A;";
@@ -249,16 +251,16 @@ public class AbstractPigSearchTest extends AbstractPigTests {
 
     @Test
     public void testDynamicPattern() throws Exception {
-        Assert.assertTrue(RestUtils.exists("pig-pattern-1/data"));
-        Assert.assertTrue(RestUtils.exists("pig-pattern-5/data"));
-        Assert.assertTrue(RestUtils.exists("pig-pattern-9/data"));
+        Assert.assertTrue(RestUtils.exists(resource("pig-pattern-1", "data")));
+        Assert.assertTrue(RestUtils.exists(resource("pig-pattern-5", "data")));
+        Assert.assertTrue(RestUtils.exists(resource("pig-pattern-9", "data")));
     }
 
     @Test
     public void testDynamicPatternFormat() throws Exception {
-        Assert.assertTrue(RestUtils.exists("pig-pattern-format-2001-10-06/data"));
-        Assert.assertTrue(RestUtils.exists("pig-pattern-format-2005-10-06/data"));
-        Assert.assertTrue(RestUtils.exists("pig-pattern-format-2017-10-06/data"));
+        Assert.assertTrue(RestUtils.exists(resource("pig-pattern-format-2001-10-06", "data")));
+        Assert.assertTrue(RestUtils.exists(resource("pig-pattern-format-2005-10-06", "data")));
+        Assert.assertTrue(RestUtils.exists(resource("pig-pattern-format-2017-10-06", "data")));
     }
 
     @Test
@@ -266,7 +268,7 @@ public class AbstractPigSearchTest extends AbstractPigTests {
         String script = "REGISTER " + Provisioner.ESHADOOP_TESTING_JAR + ";"
                 + "DEFINE EsStorage org.elasticsearch.hadoop.pig.EsStorage('');"
                 //+ "A = LOAD 'pig-nestedtuple/data' USING EsStorage() AS (my_array:tuple(x:chararray));"
-                + "A = LOAD 'pig-nestedtuple/data' USING EsStorage() AS (my_array:tuple());"
+                + "A = LOAD '"+resource("pig-nestedtuple", "data")+"' USING EsStorage() AS (my_array:tuple());"
                 //+ "B = FOREACH A GENERATE COUNT(my_array) AS count;"
                 //+ "ILLUSTRATE B;"
                 + "X = LIMIT A 3;"
@@ -275,6 +277,14 @@ public class AbstractPigSearchTest extends AbstractPigTests {
         String results = getResults("" + tmpPig() + "/testnestedtuple");
         assertThat(results, containsString("(1.a,1.b)"));
         assertThat(results, containsString("(2.a,2.b)"));
+    }
+
+    private String resource(String index, String type) {
+        if (VERSION.onOrAfter(EsMajorVersion.V_8_X)) {
+            return index;
+        } else {
+            return index + "/" + type;
+        }
     }
 
     private static String tmpPig() {

--- a/pig/src/itest/java/org/elasticsearch/hadoop/integration/pig/AbstractPigSearchTest.java
+++ b/pig/src/itest/java/org/elasticsearch/hadoop/integration/pig/AbstractPigSearchTest.java
@@ -34,6 +34,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
+import static org.elasticsearch.hadoop.util.TestUtils.resource;
 import static org.junit.Assert.*;
 
 import static org.hamcrest.Matchers.*;
@@ -74,7 +75,7 @@ public class AbstractPigSearchTest extends AbstractPigTests {
         String script =
                 "REGISTER "+ Provisioner.ESHADOOP_TESTING_JAR + ";" +
                 "DEFINE EsStorage org.elasticsearch.hadoop.pig.EsStorage('es.query=" + query + "','es.read.metadata=" + readMetadata +"');" +
-                "A = LOAD '"+resource("pig-tupleartists", "data")+"' USING EsStorage();" +
+                "A = LOAD '"+resource("pig-tupleartists", "data", VERSION)+"' USING EsStorage();" +
                 "X = LIMIT A 3;" +
                 //"DESCRIBE A;";
                 "STORE A INTO '" + tmpPig() + "/testtuple';";
@@ -87,7 +88,7 @@ public class AbstractPigSearchTest extends AbstractPigTests {
 
     @Test
     public void testTupleCount() throws Exception {
-        String script = "A = LOAD '"+resource("pig-tupleartists", "data")+"' using org.elasticsearch.hadoop.pig.EsStorage();" +
+        String script = "A = LOAD '"+resource("pig-tupleartists", "data", VERSION)+"' using org.elasticsearch.hadoop.pig.EsStorage();" +
                 "COUNT = FOREACH (GROUP A ALL) GENERATE COUNT(A);" +
                 "DUMP COUNT;";
 
@@ -99,7 +100,7 @@ public class AbstractPigSearchTest extends AbstractPigTests {
         String script =
                 "REGISTER "+ Provisioner.ESHADOOP_TESTING_JAR + ";" +
                 "DEFINE EsStorage org.elasticsearch.hadoop.pig.EsStorage('es.query=" + query + "','es.read.metadata=" + readMetadata +"');" +
-                "A = LOAD '"+resource("pig-tupleartists", "data")+"' USING EsStorage() AS (name:chararray);" +
+                "A = LOAD '"+resource("pig-tupleartists", "data", VERSION)+"' USING EsStorage() AS (name:chararray);" +
                 "X = LIMIT A 3;" +
                 "STORE A INTO '" + tmpPig() + "/testtupleschema';";
         pig.executeScript(script);
@@ -114,7 +115,7 @@ public class AbstractPigSearchTest extends AbstractPigTests {
         String script =
                       "REGISTER "+ Provisioner.ESHADOOP_TESTING_JAR + ";" +
                       "DEFINE EsStorage org.elasticsearch.hadoop.pig.EsStorage('es.query=" + query + "');"
-                      + "A = LOAD '"+resource("pig-bagartists", "data")+"' USING EsStorage();"
+                      + "A = LOAD '"+resource("pig-bagartists", "data", VERSION)+"' USING EsStorage();"
                       + "X = LIMIT A 3;"
                       + "STORE A INTO '" + tmpPig() + "/testbag';";
         pig.executeScript(script);
@@ -130,7 +131,7 @@ public class AbstractPigSearchTest extends AbstractPigTests {
         String script =
                       "REGISTER "+ Provisioner.ESHADOOP_TESTING_JAR + ";" +
                       "DEFINE EsStorage org.elasticsearch.hadoop.pig.EsStorage('es.query=" + query + "', 'es.mapping.names=data:name','es.read.metadata=" + readMetadata +"');"
-                      + "A = LOAD '"+resource("pig-bagartists", "data")+"' USING EsStorage() AS (data: chararray);"
+                      + "A = LOAD '"+resource("pig-bagartists", "data", VERSION)+"' USING EsStorage() AS (data: chararray);"
                       + "B = ORDER A BY * DESC;"
                       + "X = LIMIT B 3;"
                       + "STORE X INTO '" + tmpPig() + "/testbagschema';";
@@ -146,7 +147,7 @@ public class AbstractPigSearchTest extends AbstractPigTests {
         String script =
                       "REGISTER "+ Provisioner.ESHADOOP_TESTING_JAR + ";" +
                       "DEFINE EsStorage org.elasticsearch.hadoop.pig.EsStorage('es.query=" + query + "','es.read.metadata=" + readMetadata +"');"
-                      + "A = LOAD '"+resource("pig-timestamp", "data")+"' USING EsStorage();"
+                      + "A = LOAD '"+resource("pig-timestamp", "data", VERSION)+"' USING EsStorage();"
                       + "X = LIMIT A 3;"
                       + "STORE A INTO '" + tmpPig() + "/testtimestamp';";
         pig.executeScript(script);
@@ -159,7 +160,7 @@ public class AbstractPigSearchTest extends AbstractPigTests {
                       "REGISTER "+ Provisioner.ESHADOOP_TESTING_JAR + ";" +
                       "DEFINE EsStorage org.elasticsearch.hadoop.pig.EsStorage(" +
                       "'es.mapping.names=nAme:name, timestamp:@timestamp, uRL:url, picturE:picture', 'es.query=" + query + "','es.read.metadata=" + readMetadata +"');"
-                      + "A = LOAD '"+resource("pig-fieldalias", "data")+"' USING EsStorage();"
+                      + "A = LOAD '"+resource("pig-fieldalias", "data", VERSION)+"' USING EsStorage();"
                       + "X = LIMIT A 3;"
                       + "STORE A INTO '" + tmpPig() + "/testfieldlalias';";
         pig.executeScript(script);
@@ -176,7 +177,7 @@ public class AbstractPigSearchTest extends AbstractPigTests {
         String script =
                       "REGISTER "+ Provisioner.ESHADOOP_TESTING_JAR + ";" +
                       "DEFINE EsStorage org.elasticsearch.hadoop.pig.EsStorage('es.index.read.missing.as.empty=true','es.query=" + query + "','es.read.metadata=" + readMetadata +"');"
-                      + "A = LOAD '"+resource("foo", "bar")+"' USING EsStorage();"
+                      + "A = LOAD '"+resource("foo", "bar", VERSION)+"' USING EsStorage();"
                       + "X = LIMIT A 3;"
                       + "STORE X INTO '" + tmpPig() + "/testmissingindex';";
         pig.executeScript(script);
@@ -206,7 +207,7 @@ public class AbstractPigSearchTest extends AbstractPigTests {
         String script =
                 "REGISTER "+ Provisioner.ESHADOOP_TESTING_JAR + ";" +
                 "DEFINE EsStorage org.elasticsearch.hadoop.pig.EsStorage('es.query=" + query + "','es.read.metadata=" + readMetadata +"');" // , 'es.mapping.names=links:links.url'
-                + "A = LOAD '"+resource("pig-tupleartists", "data")+"' USING EsStorage() AS (name: chararray, links: tuple(chararray));"
+                + "A = LOAD '"+resource("pig-tupleartists", "data", VERSION)+"' USING EsStorage() AS (name: chararray, links: tuple(chararray));"
                 + "B = FOREACH A GENERATE name, links;"
                 + "C = ORDER B BY name DESC;"
                 + "D = LIMIT C 3;"
@@ -224,7 +225,7 @@ public class AbstractPigSearchTest extends AbstractPigTests {
         String script =
                 "REGISTER "+ Provisioner.ESHADOOP_TESTING_JAR + ";" +
                         "DEFINE EsStorage org.elasticsearch.hadoop.pig.EsStorage('es.query=" + query + "','es.read.metadata=" + readMetadata + "','es.read.source.filter=name');" +
-                        "A = LOAD '"+resource("pig-tupleartists", "data")+"' USING EsStorage();" +
+                        "A = LOAD '"+resource("pig-tupleartists", "data", VERSION)+"' USING EsStorage();" +
                         "X = LIMIT A 3;" +
                         "DUMP X;" +
                         "STORE A INTO '" + tmpPig() + "/nocollision';";
@@ -240,7 +241,7 @@ public class AbstractPigSearchTest extends AbstractPigTests {
         String script =
                 "REGISTER "+ Provisioner.ESHADOOP_TESTING_JAR + ";" +
                         "DEFINE EsStorage org.elasticsearch.hadoop.pig.EsStorage('es.query=" + query + "','es.read.metadata=" + readMetadata +"','es.read.source.filter=name');" +
-                        "A = LOAD '"+resource("pig-tupleartists", "data")+"' USING EsStorage() AS (name: chararray, links: chararray);" +
+                        "A = LOAD '"+resource("pig-tupleartists", "data", VERSION)+"' USING EsStorage() AS (name: chararray, links: chararray);" +
                         "B = FOREACH A GENERATE name;" +
                         "X = LIMIT B 3;" +
                         //"DESCRIBE A;";
@@ -251,16 +252,16 @@ public class AbstractPigSearchTest extends AbstractPigTests {
 
     @Test
     public void testDynamicPattern() throws Exception {
-        Assert.assertTrue(RestUtils.exists(resource("pig-pattern-1", "data")));
-        Assert.assertTrue(RestUtils.exists(resource("pig-pattern-5", "data")));
-        Assert.assertTrue(RestUtils.exists(resource("pig-pattern-9", "data")));
+        Assert.assertTrue(RestUtils.exists(resource("pig-pattern-1", "data", VERSION)));
+        Assert.assertTrue(RestUtils.exists(resource("pig-pattern-5", "data", VERSION)));
+        Assert.assertTrue(RestUtils.exists(resource("pig-pattern-9", "data", VERSION)));
     }
 
     @Test
     public void testDynamicPatternFormat() throws Exception {
-        Assert.assertTrue(RestUtils.exists(resource("pig-pattern-format-2001-10-06", "data")));
-        Assert.assertTrue(RestUtils.exists(resource("pig-pattern-format-2005-10-06", "data")));
-        Assert.assertTrue(RestUtils.exists(resource("pig-pattern-format-2017-10-06", "data")));
+        Assert.assertTrue(RestUtils.exists(resource("pig-pattern-format-2001-10-06", "data", VERSION)));
+        Assert.assertTrue(RestUtils.exists(resource("pig-pattern-format-2005-10-06", "data", VERSION)));
+        Assert.assertTrue(RestUtils.exists(resource("pig-pattern-format-2017-10-06", "data", VERSION)));
     }
 
     @Test
@@ -268,7 +269,7 @@ public class AbstractPigSearchTest extends AbstractPigTests {
         String script = "REGISTER " + Provisioner.ESHADOOP_TESTING_JAR + ";"
                 + "DEFINE EsStorage org.elasticsearch.hadoop.pig.EsStorage('');"
                 //+ "A = LOAD 'pig-nestedtuple/data' USING EsStorage() AS (my_array:tuple(x:chararray));"
-                + "A = LOAD '"+resource("pig-nestedtuple", "data")+"' USING EsStorage() AS (my_array:tuple());"
+                + "A = LOAD '"+resource("pig-nestedtuple", "data", VERSION)+"' USING EsStorage() AS (my_array:tuple());"
                 //+ "B = FOREACH A GENERATE COUNT(my_array) AS count;"
                 //+ "ILLUSTRATE B;"
                 + "X = LIMIT A 3;"
@@ -277,14 +278,6 @@ public class AbstractPigSearchTest extends AbstractPigTests {
         String results = getResults("" + tmpPig() + "/testnestedtuple");
         assertThat(results, containsString("(1.a,1.b)"));
         assertThat(results, containsString("(2.a,2.b)"));
-    }
-
-    private String resource(String index, String type) {
-        if (TestUtils.isTypelessVersion(VERSION)) {
-            return index;
-        } else {
-            return index + "/" + type;
-        }
     }
 
     private static String tmpPig() {

--- a/spark/core/itest/java/org/elasticsearch/spark/integration/AbstractJavaEsSparkTest.java
+++ b/spark/core/itest/java/org/elasticsearch/spark/integration/AbstractJavaEsSparkTest.java
@@ -338,7 +338,7 @@ public class AbstractJavaEsSparkTest implements Serializable {
     }
 
     public String resource(String index, String type) {
-        if (version.onOrAfter(EsMajorVersion.V_7_X)) {
+        if (TestUtils.isTypelessVersion(version)) {
             return index;
         } else {
             return index + "/" + type;
@@ -346,7 +346,7 @@ public class AbstractJavaEsSparkTest implements Serializable {
     }
 
     public String docEndpoint(String index, String type) {
-        if (version.onOrAfter(EsMajorVersion.V_7_X)) {
+        if (TestUtils.isTypelessVersion(version)) {
             return index + "/_doc";
         } else {
             return index + "/" + type;

--- a/spark/core/itest/java/org/elasticsearch/spark/integration/AbstractJavaEsSparkTest.java
+++ b/spark/core/itest/java/org/elasticsearch/spark/integration/AbstractJavaEsSparkTest.java
@@ -19,6 +19,7 @@
 package org.elasticsearch.spark.integration;
 
 import java.io.Serializable;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -44,6 +45,8 @@ import org.junit.runners.MethodSorters;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
+import static org.elasticsearch.hadoop.util.TestUtils.docEndpoint;
+import static org.elasticsearch.hadoop.util.TestUtils.resource;
 import static org.junit.Assert.*;
 
 import static org.elasticsearch.hadoop.cfg.ConfigurationOptions.*;
@@ -318,8 +321,8 @@ public class AbstractJavaEsSparkTest implements Serializable {
 
     @Test
     public void testEsRDDZReadWithGroupBy() throws Exception {
-        String target = resource("spark-test-java-basic-group", "data");
-        String docEndpoint = docEndpoint("spark-test-java-basic-group", "data");
+        String target = resource("spark-test-java-basic-group", "data", version);
+        String docEndpoint = docEndpoint("spark-test-java-basic-group", "data", version);
 
         RestUtils.touch("spark-test-java-basic-group");
         RestUtils.postData(docEndpoint,
@@ -337,19 +340,4 @@ public class AbstractJavaEsSparkTest implements Serializable {
         rdd.count();
     }
 
-    public String resource(String index, String type) {
-        if (TestUtils.isTypelessVersion(version)) {
-            return index;
-        } else {
-            return index + "/" + type;
-        }
-    }
-
-    public String docEndpoint(String index, String type) {
-        if (TestUtils.isTypelessVersion(version)) {
-            return index + "/_doc";
-        } else {
-            return index + "/" + type;
-        }
-    }
 }

--- a/spark/core/itest/scala/org/elasticsearch/spark/integration/AbstractScalaEsSpark.scala
+++ b/spark/core/itest/scala/org/elasticsearch/spark/integration/AbstractScalaEsSpark.scala
@@ -30,7 +30,6 @@ import org.apache.spark.SparkConf
 import org.apache.spark.SparkContext
 import org.apache.spark.SparkException
 import org.elasticsearch.hadoop.EsHadoopIllegalArgumentException
-import org.elasticsearch.hadoop.EsHadoopUnsupportedOperationException
 import org.elasticsearch.hadoop.cfg.ConfigurationOptions
 import org.elasticsearch.hadoop.cfg.ConfigurationOptions.ES_INDEX_AUTO_CREATE
 import org.elasticsearch.hadoop.cfg.ConfigurationOptions.ES_INDEX_READ_MISSING_AS_EMPTY
@@ -38,7 +37,6 @@ import org.elasticsearch.hadoop.cfg.ConfigurationOptions.ES_INPUT_JSON
 import org.elasticsearch.hadoop.cfg.ConfigurationOptions.ES_MAPPING_EXCLUDE
 import org.elasticsearch.hadoop.cfg.ConfigurationOptions.ES_MAPPING_ID
 import org.elasticsearch.hadoop.cfg.ConfigurationOptions.ES_MAPPING_JOIN
-import org.elasticsearch.hadoop.cfg.ConfigurationOptions.ES_MAPPING_TIMESTAMP
 import org.elasticsearch.hadoop.cfg.ConfigurationOptions.ES_QUERY
 import org.elasticsearch.hadoop.cfg.ConfigurationOptions.ES_READ_METADATA
 import org.elasticsearch.hadoop.cfg.ConfigurationOptions.ES_RESOURCE
@@ -71,7 +69,6 @@ import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertThat
 import org.junit.Assert.assertTrue
 import org.junit.Assert.fail
-import org.junit.Assume
 import org.junit.Assume.assumeNoException
 import org.junit.BeforeClass
 import org.junit.Test
@@ -152,7 +149,7 @@ class AbstractScalaEsScalaSpark(prefix: String, readMetadata: jl.Boolean) extend
 
   @Test
   def testRDDEmptyRead() {
-    val target = wrapIndex("spark-test-empty-rdd/data")
+    val target = wrapIndex(resource("spark-test-empty-rdd", "data"))
     sc.emptyRDD.saveToEs(target, cfg)
   }
 
@@ -161,7 +158,7 @@ class AbstractScalaEsScalaSpark(prefix: String, readMetadata: jl.Boolean) extend
     val doc1 = Map("one" -> null, "two" -> Set("2"), "three" -> (".", "..", "..."))
     val doc2 = Map("OTP" -> "Otopeni", "SFO" -> "San Fran")
 
-    val target = wrapIndex("spark-test-nonexisting-scala-basic-write/data")
+    val target = wrapIndex(resource("spark-test-nonexisting-scala-basic-write", "data"))
 
     sc.makeRDD(Seq(doc1, doc2)).saveToEs(target, collection.mutable.Map(cfg.toSeq: _*) += (
       ES_INDEX_AUTO_CREATE -> "no"))
@@ -173,7 +170,7 @@ class AbstractScalaEsScalaSpark(prefix: String, readMetadata: jl.Boolean) extend
     val doc1 = Map("one" -> null, "two" -> Set("2"), "three" -> (".", "..", "..."))
     val doc2 = Map("OTP" -> "Otopeni", "SFO" -> "San Fran")
 
-    val target = wrapIndex("spark-test-scala-basic-write/data")
+    val target = wrapIndex(resource("spark-test-scala-basic-write", "data"))
 
     sc.makeRDD(Seq(doc1, doc2)).saveToEs(target, cfg)
     assertTrue(RestUtils.exists(target))
@@ -183,7 +180,7 @@ class AbstractScalaEsScalaSpark(prefix: String, readMetadata: jl.Boolean) extend
   @Test(expected = classOf[SparkException])
   def testNestedUnknownCharacter() {
     val doc = Map("itemId" -> "1", "map" -> Map("lat" -> 1.23, "lon" -> -70.12), "list" -> ("A", "B", "C"), "unknown" -> new Garbage(0))
-    sc.makeRDD(Seq(doc)).saveToEs(wrapIndex("spark-test-nested-map/data"), cfg)
+    sc.makeRDD(Seq(doc)).saveToEs(wrapIndex(resource("spark-test-nested-map", "data")), cfg)
   }
 
   @Test
@@ -194,13 +191,13 @@ class AbstractScalaEsScalaSpark(prefix: String, readMetadata: jl.Boolean) extend
 
     val vals = ReflectionUtils.caseClassValues(caseClass2)
 
-     val target = wrapIndex("spark-test-scala-basic-write-objects/data")
+     val target = wrapIndex(resource("spark-test-scala-basic-write-objects", "data"))
 
     sc.makeRDD(Seq(javaBean, caseClass1)).saveToEs(target, cfg)
     sc.makeRDD(Seq(javaBean, caseClass2)).saveToEs(target, Map("es.mapping.id"->"id"))
 
     assertTrue(RestUtils.exists(target))
-    assertEquals(3, EsSpark.esRDD(sc, target).count());
+    assertEquals(3, EsSpark.esRDD(sc, target).count())
     assertThat(RestUtils.get(target + "/_search?"), containsString(""))
   }
 
@@ -209,13 +206,14 @@ class AbstractScalaEsScalaSpark(prefix: String, readMetadata: jl.Boolean) extend
     val doc1 = Map("one" -> null, "two" -> Set("2"), "three" -> (".", "..", "..."), "number" -> 1)
     val doc2 = Map("OTP" -> "Otopeni", "SFO" -> "San Fran", "number" -> 2)
 
-    val target = "spark-test-scala-id-write/data"
+    val target = resource("spark-test-scala-id-write", "data")
+    val docEndpoint = docPath("spark-test-scala-id-write", "data")
 
     sc.makeRDD(Seq(doc1, doc2)).saveToEs(target, Map(ES_MAPPING_ID -> "number"))
 
-    assertEquals(2, EsSpark.esRDD(sc, target).count());
-    assertTrue(RestUtils.exists(target + "/1"))
-    assertTrue(RestUtils.exists(target + "/2"))
+    assertEquals(2, EsSpark.esRDD(sc, target).count())
+    assertTrue(RestUtils.exists(docEndpoint + "/1"))
+    assertTrue(RestUtils.exists(docEndpoint + "/2"))
 
     assertThat(RestUtils.get(target + "/_search?"), containsString("SFO"))
   }
@@ -225,13 +223,14 @@ class AbstractScalaEsScalaSpark(prefix: String, readMetadata: jl.Boolean) extend
     val doc1 = Map("one" -> null, "two" -> Set("2"), "three" -> (".", "..", "..."), "number" -> 1)
     val doc2 = Map("OTP" -> "Otopeni", "SFO" -> "San Fran", "number" -> 2)
 
-    val target = wrapIndex("spark-test-scala-dyn-id-write/data")
+    val target = wrapIndex(resource("spark-test-scala-dyn-id-write", "data"))
+    val docEndpoint = wrapIndex(docPath("spark-test-scala-dyn-id-write", "data"))
 
     val pairRDD = sc.makeRDD(Seq((3, doc1), (4, doc2))).saveToEsWithMeta(target, cfg)
 
-    assertEquals(2, EsSpark.esRDD(sc, target).count());
-    assertTrue(RestUtils.exists(target + "/3"))
-    assertTrue(RestUtils.exists(target + "/4"))
+    assertEquals(2, EsSpark.esRDD(sc, target).count())
+    assertTrue(RestUtils.exists(docEndpoint + "/3"))
+    assertTrue(RestUtils.exists(docEndpoint + "/4"))
 
     assertThat(RestUtils.get(target + "/_search?"), containsString("SFO"))
   }
@@ -241,7 +240,8 @@ class AbstractScalaEsScalaSpark(prefix: String, readMetadata: jl.Boolean) extend
     val doc1 = Map("one" -> null, "two" -> Set("2"), "three" -> (".", "..", "..."), "number" -> 1)
     val doc2 = Map("OTP" -> "Otopeni", "SFO" -> "San Fran", "number" -> 2)
 
-    val target = wrapIndex("spark-test-scala-dyn-id-write/data")
+    val target = wrapIndex(resource("spark-test-scala-dyn-id-write", "data"))
+    val docEndpoint = wrapIndex(docPath("spark-test-scala-dyn-id-write", "data"))
 
     val metadata1 = Map(ID -> 5)
     val metadata2 = Map(ID -> 6, VERSION -> "23")
@@ -253,8 +253,8 @@ class AbstractScalaEsScalaSpark(prefix: String, readMetadata: jl.Boolean) extend
 
     pairRDD.saveToEsWithMeta(target, cfg)
 
-    assertTrue(RestUtils.exists(target + "/5"))
-    assertTrue(RestUtils.exists(target + "/6"))
+    assertTrue(RestUtils.exists(docEndpoint + "/5"))
+    assertTrue(RestUtils.exists(docEndpoint + "/6"))
 
     assertThat(RestUtils.get(target + "/_search?"), containsString("SFO"))
   }
@@ -266,7 +266,7 @@ class AbstractScalaEsScalaSpark(prefix: String, readMetadata: jl.Boolean) extend
     val doc1 = Map("one" -> null, "two" -> Set("2"), "three" -> (".", "..", "..."), "number" -> 1)
     val doc2 = Map("OTP" -> "Otopeni", "SFO" -> "San Fran", "number" -> 2)
 
-    val target = wrapIndex("spark-test-scala-dyn-id-write-fail/data")
+    val target = wrapIndex(resource("spark-test-scala-dyn-id-write-fail", "data"))
 
     val metadata1 = Map(ID -> 5)
     val metadata2 = Map(ID -> 6, TTL -> "23")
@@ -291,7 +291,7 @@ class AbstractScalaEsScalaSpark(prefix: String, readMetadata: jl.Boolean) extend
     val trip1 = Map("reason" -> "business", "airport" -> "SFO")
     val trip2 = Map("participants" -> 5, "airport" -> "OTP")
 
-    val target = wrapIndex("spark-test-scala-write-exclude/data")
+    val target = wrapIndex(resource("spark-test-scala-write-exclude", "data"))
 
     sc.makeRDD(Seq(trip1, trip2)).saveToEs(target, Map(ES_MAPPING_EXCLUDE -> "airport"))
     assertTrue(RestUtils.exists(target))
@@ -323,12 +323,13 @@ class AbstractScalaEsScalaSpark(prefix: String, readMetadata: jl.Boolean) extend
     {
       val index = wrapIndex("spark-test-scala-write-join-separate")
       val typename = "join"
-      val (target, getEndpoint) = if (version.onOrAfter(EsMajorVersion.V_7_X)) {
+      val target = resource(index, typename)
+      val getEndpoint = docPath(index, typename)
+
+      if (version.onOrAfter(EsMajorVersion.V_7_X)) {
         RestUtils.putMapping(index, typename, "data/join/mapping/typeless.json")
-        (index, s"$index/_doc")
       } else {
         RestUtils.putMapping(index, typename, "data/join/mapping/typed.json")
-        (s"$index/$typename", s"$index/$typename")
       }
 
       sc.makeRDD(parents).saveToEs(target, Map(ES_MAPPING_ID -> "id", ES_MAPPING_JOIN -> "joiner"))
@@ -360,12 +361,13 @@ class AbstractScalaEsScalaSpark(prefix: String, readMetadata: jl.Boolean) extend
     {
       val index = wrapIndex("spark-test-scala-write-join-combined")
       val typename = "join"
-      val (target, getEndpoint) = if (version.onOrAfter(EsMajorVersion.V_7_X)) {
+      val target = resource(index, typename)
+      val getEndpoint = docPath(index, typename)
+
+      if (version.onOrAfter(EsMajorVersion.V_7_X)) {
         RestUtils.putMapping(index, typename, "data/join/mapping/typeless.json")
-        (index, s"$index/_doc")
       } else {
         RestUtils.putMapping(index, typename, "data/join/mapping/typed.json")
-        (s"$index/$typename", s"$index/$typename")
       }
 
       sc.makeRDD(docs).saveToEs(target, Map(ES_MAPPING_ID -> "id", ES_MAPPING_JOIN -> "joiner"))
@@ -407,7 +409,7 @@ class AbstractScalaEsScalaSpark(prefix: String, readMetadata: jl.Boolean) extend
     val doc1 = Map("one" -> null, "two" -> Set("2"), "three" -> (".", "..", "..."))
     val doc2 = Map("OTP" -> "Otopeni", "SFO" -> "San Fran")
 
-    val target = wrapIndex("spark-test-scala-ingest-write/data")
+    val target = wrapIndex(resource("spark-test-scala-ingest-write", "data"))
 
     val ingestCfg = cfg + (ConfigurationOptions.ES_INGEST_PIPELINE -> "spark-pipeline") + (ConfigurationOptions.ES_NODES_INGEST_ONLY -> "true")
 
@@ -423,13 +425,13 @@ class AbstractScalaEsScalaSpark(prefix: String, readMetadata: jl.Boolean) extend
     val trip1 = Map("reason" -> "business", "airport" -> "sfo")
     val trip2 = Map("participants" -> 5, "airport" -> "otp")
 
-    val target = wrapIndex("spark-test-trip-{airport}/data")
+    val target = wrapIndex(resource("spark-test-trip-{airport}", "data"))
     sc.makeRDD(Seq(trip1, trip2)).saveToEs(target, cfg)
-    assertTrue(RestUtils.exists(wrapIndex("spark-test-trip-otp/data")))
-    assertTrue(RestUtils.exists(wrapIndex("spark-test-trip-sfo/data")))
+    assertTrue(RestUtils.exists(wrapIndex(resource("spark-test-trip-otp", "data"))))
+    assertTrue(RestUtils.exists(wrapIndex(resource("spark-test-trip-sfo", "data"))))
 
-    assertThat(RestUtils.get(wrapIndex("spark-test-trip-sfo/data/_search?")), containsString("business"))
-    assertThat(RestUtils.get(wrapIndex("spark-test-trip-otp/data/_search?")), containsString("participants"))
+    assertThat(RestUtils.get(wrapIndex(resource("spark-test-trip-sfo", "data") + "/_search?")), containsString("business"))
+    assertThat(RestUtils.get(wrapIndex(resource("spark-test-trip-otp", "data") + "/_search?")), containsString("participants"))
   }
 
   @Test
@@ -437,21 +439,21 @@ class AbstractScalaEsScalaSpark(prefix: String, readMetadata: jl.Boolean) extend
     val json1 = "{\"reason\" : \"business\",\"airport\" : \"sfo\"}";
     val json2 = "{\"participants\" : 5,\"airport\" : \"otp\"}"
 
-    sc.makeRDD(Seq(json1, json2)).saveJsonToEs(wrapIndex("spark-test-json-{airport}/data"), cfg)
+    sc.makeRDD(Seq(json1, json2)).saveJsonToEs(wrapIndex(resource("spark-test-json-{airport}", "data")), cfg)
 
     val json1BA = json1.getBytes()
     val json2BA = json2.getBytes()
 
-    sc.makeRDD(Seq(json1BA, json2BA)).saveJsonToEs(wrapIndex("spark-test-json-ba-{airport}/data"), cfg)
+    sc.makeRDD(Seq(json1BA, json2BA)).saveJsonToEs(wrapIndex(resource("spark-test-json-ba-{airport}", "data")), cfg)
 
-    assertTrue(RestUtils.exists(wrapIndex("spark-test-json-sfo/data")))
-    assertTrue(RestUtils.exists(wrapIndex("spark-test-json-otp/data")))
+    assertTrue(RestUtils.exists(wrapIndex(resource("spark-test-json-sfo", "data"))))
+    assertTrue(RestUtils.exists(wrapIndex(resource("spark-test-json-otp", "data"))))
 
-    assertTrue(RestUtils.exists(wrapIndex("spark-test-json-ba-sfo/data")))
-    assertTrue(RestUtils.exists(wrapIndex("spark-test-json-ba-otp/data")))
+    assertTrue(RestUtils.exists(wrapIndex(resource("spark-test-json-ba-sfo", "data"))))
+    assertTrue(RestUtils.exists(wrapIndex(resource("spark-test-json-ba-otp", "data"))))
 
-    assertThat(RestUtils.get(wrapIndex("spark-test-json-sfo/data/_search?")), containsString("business"))
-    assertThat(RestUtils.get(wrapIndex("spark-test-json-otp/data/_search?")), containsString("participants"))
+    assertThat(RestUtils.get(wrapIndex(resource("spark-test-json-sfo", "data") + "/_search?")), containsString("business"))
+    assertThat(RestUtils.get(wrapIndex(resource("spark-test-json-otp", "data") + "/_search?")), containsString("participants"))
   }
 
   @Test(expected = classOf[EsHadoopIllegalArgumentException ])
@@ -490,12 +492,13 @@ class AbstractScalaEsScalaSpark(prefix: String, readMetadata: jl.Boolean) extend
     RestUtils.touch(index)
 
     val typename = "data"
-    val (target, docEndpoint) = if (version.onOrAfter(EsMajorVersion.V_7_X)) {
+    val target = resource(index, typename)
+    val docEndpoint = docPath(index, typename)
+
+    if (version.onOrAfter(EsMajorVersion.V_7_X)) {
       RestUtils.putMapping(index, typename, mapping)
-      (index, s"$index/_doc")
     } else {
       RestUtils.putMapping(index, typename, mapping)
-      (s"$index/$typename", s"$index/$typename")
     }
 
     RestUtils.refresh(index)
@@ -546,13 +549,14 @@ class AbstractScalaEsScalaSpark(prefix: String, readMetadata: jl.Boolean) extend
 
     val index = wrapIndex("spark-test-stored")
     val typename = "data"
+    val target = resource(index, typename)
+    val docEndpoint = docPath(index, typename)
+
     RestUtils.touch(index)
-    val (target, docEndpoint) = if (version.onOrAfter(EsMajorVersion.V_7_X)) {
+    if (version.onOrAfter(EsMajorVersion.V_7_X)) {
       RestUtils.putMapping(index, typename, mapping.getBytes())
-      (index, s"$index/_doc")
     } else {
       RestUtils.putMapping(index, typename, mapping.getBytes())
-      (s"$index/$typename", s"$index/$typename")
     }
     RestUtils.put(s"$docEndpoint/1", """{"id":"1", "counter":5}""".getBytes(StringUtils.UTF_8))
 
@@ -600,14 +604,15 @@ class AbstractScalaEsScalaSpark(prefix: String, readMetadata: jl.Boolean) extend
 
     val index = wrapIndex("spark-test-contact")
     val typename = "data"
+    val target = resource(index, typename)
+    val docEndpoint = docPath(index, typename)
+
     RestUtils.touch(index)
 
-    val (target, docEndpoint) = if (version.onOrAfter(EsMajorVersion.V_7_X)) {
+    if (version.onOrAfter(EsMajorVersion.V_7_X)) {
       RestUtils.putMapping(index, typename, mapping.getBytes())
-      (index, s"$index/_doc")
     } else {
       RestUtils.putMapping(index, typename, mapping.getBytes())
-      (s"$index/$typename", s"$index/$typename")
     }
     RestUtils.postData(s"$docEndpoint/1", """{ "id" : "1", "note": "First", "address": [] }""".getBytes(StringUtils.UTF_8))
     RestUtils.postData(s"$docEndpoint/2", """{ "id" : "2", "note": "First", "address": [] }""".getBytes(StringUtils.UTF_8))
@@ -652,10 +657,11 @@ class AbstractScalaEsScalaSpark(prefix: String, readMetadata: jl.Boolean) extend
 
   @Test
   def testEsRDDRead() {
-    val target = wrapIndex("spark-test-scala-basic-read/data")
+    val target = wrapIndex(resource("spark-test-scala-basic-read", "data"))
+    val docEndpoint = wrapIndex(docPath("spark-test-scala-basic-read", "data"))
     RestUtils.touch(wrapIndex("spark-test-scala-basic-read"))
-    RestUtils.postData(target, "{\"message\" : \"Hello World\",\"message_date\" : \"2014-05-25\"}".getBytes())
-    RestUtils.postData(target, "{\"message\" : \"Goodbye World\",\"message_date\" : \"2014-05-25\"}".getBytes())
+    RestUtils.postData(docEndpoint, "{\"message\" : \"Hello World\",\"message_date\" : \"2014-05-25\"}".getBytes())
+    RestUtils.postData(docEndpoint, "{\"message\" : \"Goodbye World\",\"message_date\" : \"2014-05-25\"}".getBytes())
     RestUtils.refresh(wrapIndex("spark-test-scala-basic-read"))
 
     val esData = EsSpark.esRDD(sc, target, cfg)
@@ -689,11 +695,9 @@ class AbstractScalaEsScalaSpark(prefix: String, readMetadata: jl.Boolean) extend
   def testEsRDDReadQuery() {
     val index = "spark-test-scala-basic-query-read"
     val typename = "data"
-    val (target, docEndpoint) = if (version.onOrAfter(EsMajorVersion.V_7_X)) {
-      (index, s"$index/_doc")
-    } else {
-      (s"$index/$typename", s"$index/$typename")
-    }
+    val target = resource(index, typename)
+    val docEndpoint = docPath(index, typename)
+
     RestUtils.touch(index)
     RestUtils.postData(docEndpoint, "{\"message\" : \"Hello World\",\"message_date\" : \"2014-05-25\"}".getBytes())
     RestUtils.postData(docEndpoint, "{\"message\" : \"Goodbye World\",\"message_date\" : \"2014-05-25\"}".getBytes())
@@ -723,11 +727,9 @@ class AbstractScalaEsScalaSpark(prefix: String, readMetadata: jl.Boolean) extend
   def testEsRDDReadAsJson() {
     val index = wrapIndex("spark-test-scala-basic-json-read")
     val typename = "data"
-    val (target, docEndpoint) = if (version.onOrAfter(EsMajorVersion.V_7_X)) {
-      (index, s"$index/_doc")
-    } else {
-      (s"$index/$typename", s"$index/$typename")
-    }
+    val target = resource(index, typename)
+    val docEndpoint = docPath(index, typename)
+
     RestUtils.touch(index)
     RestUtils.postData(docEndpoint, "{\"message\" : \"Hello World\",\"message_date\" : \"2014-05-25\"}".getBytes())
     RestUtils.postData(docEndpoint, "{\"message\" : \"Goodbye World\",\"message_date\" : \"2014-05-25\"}".getBytes())
@@ -745,11 +747,9 @@ class AbstractScalaEsScalaSpark(prefix: String, readMetadata: jl.Boolean) extend
   def testEsRDDReadWithSourceFilter() {
     val index = wrapIndex("spark-test-scala-source-filter-read")
     val typename = "data"
-    val (target, docEndpoint) = if (version.onOrAfter(EsMajorVersion.V_7_X)) {
-      (index, s"$index/_doc")
-    } else {
-      (s"$index/$typename", s"$index/$typename")
-    }
+    val target = resource(index, typename)
+    val docEndpoint = docPath(index, typename)
+
     RestUtils.touch(index)
     RestUtils.postData(docEndpoint, "{\"message\" : \"Hello World\",\"message_date\" : \"2014-05-25\"}".getBytes())
     RestUtils.postData(docEndpoint, "{\"message\" : \"Goodbye World\",\"message_date\" : \"2014-05-25\"}".getBytes())
@@ -807,11 +807,8 @@ class AbstractScalaEsScalaSpark(prefix: String, readMetadata: jl.Boolean) extend
     )
     val index = wrapIndex("spark-test-nullasempty")
     val typename = "data"
-    val target = if (version.onOrAfter(EsMajorVersion.V_7_X)) {
-      index
-    } else {
-      s"$index/$typename"
-    }
+    val target = resource(index, typename)
+
     sc.makeRDD(data).saveToEs(target)
 
     assertEquals(3, EsSpark.esRDD(sc, target, cfg).count())
@@ -821,11 +818,8 @@ class AbstractScalaEsScalaSpark(prefix: String, readMetadata: jl.Boolean) extend
   def testNewIndexWithTemplate() {
     val index = wrapIndex("spark-template-index")
     val typename = "alias"
-    val target = if (version.onOrAfter(EsMajorVersion.V_7_X)) {
-      index
-    } else {
-      s"$index/alias"
-    }
+    val target = resource(index, typename)
+
 
     val template = s"""
         |{
@@ -856,32 +850,45 @@ class AbstractScalaEsScalaSpark(prefix: String, readMetadata: jl.Boolean) extend
     erc.close()
   }
 
-  
+
   @Test
   def testEsSparkVsScCount() {
     val index = wrapIndex("spark-test-check-counting")
     val typename = "data"
-    val target = if (version.onOrAfter(EsMajorVersion.V_7_X)) {
-      index
-    } else {
-      s"$index/$typename"
-    }
+    val target = resource(index, typename)
+
     val rawCore = List( Map("colint" -> 1, "colstr" -> "s"),
                          Map("colint" -> null, "colstr" -> null) )
     sc.parallelize(rawCore, 1).saveToEs(target)
     val qjson =
       """{"query":{"range":{"colint":{"from":null,"to":"9","include_lower":true,"include_upper":true}}}}"""
-    
+
     val esRDD = EsSpark.esRDD(sc, target, qjson)
     val scRDD = sc.esRDD(target, qjson)
     assertEquals(esRDD.collect().size, scRDD.collect().size)
   }
 
-  
+
   @Test
   def testMultiIndexNonExisting() {
     val rdd = EsSpark.esJsonRDD(sc, "bumpA,Stump", Map(ES_INDEX_READ_MISSING_AS_EMPTY -> "yes"))
     assertEquals(0, rdd.count)
+  }
+
+  def resource(index: String, typeName: String): String = {
+    if (version.onOrAfter(EsMajorVersion.V_7_X)) {
+      index
+    } else {
+      s"$index/$typeName"
+    }
+  }
+
+  def docPath(index: String, typeName: String): String = {
+    if (version.onOrAfter(EsMajorVersion.V_7_X)) {
+      s"$index/_doc"
+    } else {
+      s"$index/$typeName"
+    }
   }
 
   def wrapIndex(index: String) = {

--- a/spark/sql-13/src/itest/java/org/elasticsearch/spark/integration/AbstractJavaEsSparkSQLTest.java
+++ b/spark/sql-13/src/itest/java/org/elasticsearch/spark/integration/AbstractJavaEsSparkSQLTest.java
@@ -199,7 +199,7 @@ public class AbstractJavaEsSparkSQLTest implements Serializable {
 	}
 
 	private String resource(String index, String type) {
-		if (version.onOrAfter(EsMajorVersion.V_8_X)) {
+		if (TestUtils.isTypelessVersion(version)) {
 			return index;
 		} else {
 			return index + "/" + type;
@@ -207,7 +207,7 @@ public class AbstractJavaEsSparkSQLTest implements Serializable {
 	}
 
 	private String docEndpoint(String index, String type) {
-		if (version.onOrAfter(EsMajorVersion.V_8_X)) {
+		if (TestUtils.isTypelessVersion(version)) {
 			return index + "/_doc";
 		} else {
 			return index + "/" + type;

--- a/spark/sql-13/src/itest/java/org/elasticsearch/spark/integration/AbstractJavaEsSparkSQLTest.java
+++ b/spark/sql-13/src/itest/java/org/elasticsearch/spark/integration/AbstractJavaEsSparkSQLTest.java
@@ -48,6 +48,8 @@ import org.junit.runners.MethodSorters;
 
 import com.google.common.collect.ImmutableMap;
 
+import static org.elasticsearch.hadoop.util.TestUtils.docEndpoint;
+import static org.elasticsearch.hadoop.util.TestUtils.resource;
 import static org.junit.Assert.*;
 
 import static org.elasticsearch.hadoop.cfg.ConfigurationOptions.*;
@@ -100,7 +102,7 @@ public class AbstractJavaEsSparkSQLTest implements Serializable {
 	public void testEsdataFrame1Write() throws Exception {
 		DataFrame dataFrame = artistsAsDataFrame();
 
-		String target = resource("sparksql-test-scala-basic-write", "data");
+		String target = resource("sparksql-test-scala-basic-write", "data", version);
 		JavaEsSparkSQL.saveToEs(dataFrame, target);
 		assertTrue(RestUtils.exists(target));
 		assertThat(RestUtils.get(target + "/_search?"), containsString("345"));
@@ -110,8 +112,8 @@ public class AbstractJavaEsSparkSQLTest implements Serializable {
 	public void testEsdataFrame1WriteWithId() throws Exception {
 		DataFrame dataFrame = artistsAsDataFrame();
 
-		String target = resource("sparksql-test-scala-basic-write-id-mapping", "data");
-		String docEndpoint = docEndpoint("sparksql-test-scala-basic-write-id-mapping", "data");
+		String target = resource("sparksql-test-scala-basic-write-id-mapping", "data", version);
+		String docEndpoint = docEndpoint("sparksql-test-scala-basic-write-id-mapping", "data", version);
 
 		JavaEsSparkSQL.saveToEs(dataFrame, target,
 				ImmutableMap.of(ES_MAPPING_ID, "id"));
@@ -124,7 +126,7 @@ public class AbstractJavaEsSparkSQLTest implements Serializable {
     public void testEsSchemaRDD1WriteWithMappingExclude() throws Exception {
     	DataFrame dataFrame = artistsAsDataFrame();
 
-        String target = resource("sparksql-test-scala-basic-write-exclude-mapping", "data");
+        String target = resource("sparksql-test-scala-basic-write-exclude-mapping", "data", version);
         JavaEsSparkSQL.saveToEs(dataFrame, target,ImmutableMap.of(ES_MAPPING_EXCLUDE, "url"));
         assertTrue(RestUtils.exists(target));
         assertThat(RestUtils.get(target + "/_search?"), not(containsString("url")));
@@ -132,7 +134,7 @@ public class AbstractJavaEsSparkSQLTest implements Serializable {
     
 	@Test
 	public void testEsdataFrame2Read() throws Exception {
-		String target = resource("sparksql-test-scala-basic-write", "data");
+		String target = resource("sparksql-test-scala-basic-write", "data", version);
 
         // DataFrame dataFrame = JavaEsSparkSQL.esDF(sqc, target);
         DataFrame dataFrame = sqc.read().format("es").load(target);
@@ -156,7 +158,7 @@ public class AbstractJavaEsSparkSQLTest implements Serializable {
 	@Test
 	public void testEsDataFrameReadMetadata() throws Exception {
 		DataFrame artists = artistsAsDataFrame();
-		String target = resource("sparksql-test-scala-dataframe-read-metadata", "data");
+		String target = resource("sparksql-test-scala-dataframe-read-metadata", "data", version);
 		JavaEsSparkSQL.saveToEs(artists, target);
 
 		DataFrame dataframe = sqc.read().format("es").option("es.read.metadata", "true").load(target).where("id = 1");
@@ -196,21 +198,5 @@ public class AbstractJavaEsSparkSQLTest implements Serializable {
 		});
 
 		return sqc.createDataFrame(rowData, schema);
-	}
-
-	private String resource(String index, String type) {
-		if (TestUtils.isTypelessVersion(version)) {
-			return index;
-		} else {
-			return index + "/" + type;
-		}
-	}
-
-	private String docEndpoint(String index, String type) {
-		if (TestUtils.isTypelessVersion(version)) {
-			return index + "/_doc";
-		} else {
-			return index + "/" + type;
-		}
 	}
 }

--- a/spark/sql-13/src/itest/java/org/elasticsearch/spark/integration/AbstractJavaEsSparkStreamingTest.java
+++ b/spark/sql-13/src/itest/java/org/elasticsearch/spark/integration/AbstractJavaEsSparkStreamingTest.java
@@ -50,11 +50,9 @@ import org.elasticsearch.spark.streaming.api.java.JavaEsSparkStreaming;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
-import org.junit.Assume;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.FixMethodOrder;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.MethodSorters;
@@ -75,6 +73,8 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import static org.elasticsearch.hadoop.cfg.ConfigurationOptions.*;
+import static org.elasticsearch.hadoop.util.TestUtils.docEndpoint;
+import static org.elasticsearch.hadoop.util.TestUtils.resource;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 import static scala.collection.JavaConversions.propertiesAsScalaMap;
@@ -154,7 +154,7 @@ public class AbstractJavaEsSparkStreamingTest implements Serializable {
         docs.add(doc1);
         docs.add(doc2);
 
-        String target = wrapIndex(resource("spark-test-nonexisting-scala-basic-write", "data"));
+        String target = wrapIndex(resource("spark-test-nonexisting-scala-basic-write", "data", version));
 
         Map<String, String> localConf = new HashMap<>(cfg);
         localConf.put(ES_INDEX_AUTO_CREATE, "no");
@@ -190,7 +190,7 @@ public class AbstractJavaEsSparkStreamingTest implements Serializable {
         docs.add(doc1);
         docs.add(doc2);
 
-        String target = wrapIndex(resource("spark-test-scala-basic-write", "data"));
+        String target = wrapIndex(resource("spark-test-scala-basic-write", "data", version));
 
         JavaRDD<Map<String, Object>> batch = sc.parallelize(docs);
         Queue<JavaRDD<Map<String, Object>>> rddQueue = new LinkedList<>();
@@ -228,8 +228,8 @@ public class AbstractJavaEsSparkStreamingTest implements Serializable {
         Map<String, String> localConf = new HashMap<>(cfg);
         localConf.put("es.mapping.id", "number");
 
-        String target = wrapIndex(resource("spark-test-scala-id-write", "data"));
-        String docEndpoint = wrapIndex(docEndpoint("spark-test-scala-id-write", "data"));
+        String target = wrapIndex(resource("spark-test-scala-id-write", "data", version));
+        String docEndpoint = wrapIndex(docEndpoint("spark-test-scala-id-write", "data", version));
 
         JavaRDD<Map<String,Object>> batch = sc.parallelize(docs);
         Queue<JavaRDD<Map<String, Object>>> rddQueue = new LinkedList<>();
@@ -266,8 +266,8 @@ public class AbstractJavaEsSparkStreamingTest implements Serializable {
         docs.add(doc1);
         docs.add(doc2);
 
-        String target = wrapIndex(resource("spark-test-scala-dyn-id-write", "data"));
-        String docEndpoint = wrapIndex(docEndpoint("spark-test-scala-dyn-id-write", "data"));
+        String target = wrapIndex(resource("spark-test-scala-dyn-id-write", "data", version));
+        String docEndpoint = wrapIndex(docEndpoint("spark-test-scala-dyn-id-write", "data", version));
 
         JavaRDD<Map<String,Object>> batch = sc.parallelize(docs);
         Queue<JavaRDD<Map<String, Object>>> rddQueue = new LinkedList<>();
@@ -317,8 +317,8 @@ public class AbstractJavaEsSparkStreamingTest implements Serializable {
         docs.add(doc1);
         docs.add(doc2);
 
-        String target = wrapIndex(resource("spark-test-scala-dyn-id-write-map", "data"));
-        String docEndpoint = wrapIndex(docEndpoint("spark-test-scala-dyn-id-write-map", "data"));
+        String target = wrapIndex(resource("spark-test-scala-dyn-id-write-map", "data", version));
+        String docEndpoint = wrapIndex(docEndpoint("spark-test-scala-dyn-id-write-map", "data", version));
 
         JavaRDD<Map<String,Object>> batch = sc.parallelize(docs);
         Queue<JavaRDD<Map<String, Object>>> rddQueue = new LinkedList<>();
@@ -365,7 +365,7 @@ public class AbstractJavaEsSparkStreamingTest implements Serializable {
         docs.add(trip1);
         docs.add(trip2);
 
-        String target = wrapIndex(resource("spark-test-scala-write-exclude", "data"));
+        String target = wrapIndex(resource("spark-test-scala-write-exclude", "data", version));
 
         Map<String, String> localConf = new HashMap<>(cfg);
         localConf.put(ES_MAPPING_EXCLUDE, "airport");
@@ -410,7 +410,7 @@ public class AbstractJavaEsSparkStreamingTest implements Serializable {
         docs.add(doc1);
         docs.add(doc2);
 
-        String target = wrapIndex(resource("spark-test-scala-ingest-write", "data"));
+        String target = wrapIndex(resource("spark-test-scala-ingest-write", "data", version));
 
         Map<String, String> localConf = new HashMap<>(cfg);
         localConf.put(ES_INGEST_PIPELINE, pipelineName);
@@ -443,7 +443,7 @@ public class AbstractJavaEsSparkStreamingTest implements Serializable {
         docs.add(trip1);
         docs.add(trip2);
 
-        String target = wrapIndex(resource("spark-test-trip-{airport}", "data"));
+        String target = wrapIndex(resource("spark-test-trip-{airport}", "data", version));
 
         JavaRDD<Map<String, Object>> batch = sc.parallelize(docs);
         Queue<JavaRDD<Map<String, Object>>> rddQueue = new LinkedList<>();
@@ -454,11 +454,11 @@ public class AbstractJavaEsSparkStreamingTest implements Serializable {
         TimeUnit.SECONDS.sleep(2);
         ssc.stop(false, true);
 
-        assertTrue(RestUtils.exists(wrapIndex(resource("spark-test-trip-otp", "data"))));
-        assertTrue(RestUtils.exists(wrapIndex(resource("spark-test-trip-sfo", "data"))));
+        assertTrue(RestUtils.exists(wrapIndex(resource("spark-test-trip-otp", "data", version))));
+        assertTrue(RestUtils.exists(wrapIndex(resource("spark-test-trip-sfo", "data", version))));
 
-        assertThat(RestUtils.get(wrapIndex(resource("spark-test-trip-sfo", "data") + "/_search?")), containsString("business"));
-        assertThat(RestUtils.get(wrapIndex(resource("spark-test-trip-otp", "data") + "/_search?")), containsString("participants"));
+        assertThat(RestUtils.get(wrapIndex(resource("spark-test-trip-sfo", "data", version) + "/_search?")), containsString("business"));
+        assertThat(RestUtils.get(wrapIndex(resource("spark-test-trip-otp", "data", version) + "/_search?")), containsString("participants"));
     }
 
     @Test
@@ -470,7 +470,7 @@ public class AbstractJavaEsSparkStreamingTest implements Serializable {
         docs.add(json1);
         docs.add(json2);
 
-        String jsonTarget = wrapIndex(resource("spark-test-json-{airport}", "data"));
+        String jsonTarget = wrapIndex(resource("spark-test-json-{airport}", "data", version));
 
         JavaRDD<String> batch1 = sc.parallelize(docs);
         Queue<JavaRDD<String>> rddQueue1 = new LinkedList<>();
@@ -489,7 +489,7 @@ public class AbstractJavaEsSparkStreamingTest implements Serializable {
         byteDocs.add(json1BA);
         byteDocs.add(json2BA);
 
-        String jsonBATarget = wrapIndex(resource("spark-test-json-ba-{airport}", "data"));
+        String jsonBATarget = wrapIndex(resource("spark-test-json-ba-{airport}", "data", version));
 
         JavaRDD<byte[]> batch2 = sc.parallelize(byteDocs);
         Queue<JavaRDD<byte[]>> rddQueue2 = new LinkedList<>();
@@ -500,14 +500,14 @@ public class AbstractJavaEsSparkStreamingTest implements Serializable {
         TimeUnit.SECONDS.sleep(2);
         ssc.stop(false, true);
 
-        assertTrue(RestUtils.exists(wrapIndex(resource("spark-test-json-sfo", "data"))));
-        assertTrue(RestUtils.exists(wrapIndex(resource("spark-test-json-otp", "data"))));
+        assertTrue(RestUtils.exists(wrapIndex(resource("spark-test-json-sfo", "data", version))));
+        assertTrue(RestUtils.exists(wrapIndex(resource("spark-test-json-otp", "data", version))));
 
-        assertTrue(RestUtils.exists(wrapIndex(resource("spark-test-json-ba-sfo", "data"))));
-        assertTrue(RestUtils.exists(wrapIndex(resource("spark-test-json-ba-otp", "data"))));
+        assertTrue(RestUtils.exists(wrapIndex(resource("spark-test-json-ba-sfo", "data", version))));
+        assertTrue(RestUtils.exists(wrapIndex(resource("spark-test-json-ba-otp", "data", version))));
 
-        assertThat(RestUtils.get(wrapIndex(resource("spark-test-json-sfo", "data") + "/_search?")), containsString("business"));
-        assertThat(RestUtils.get(wrapIndex(resource("spark-test-json-otp", "data") + "/_search?")), containsString("participants"));
+        assertThat(RestUtils.get(wrapIndex(resource("spark-test-json-sfo", "data", version) + "/_search?")), containsString("business"));
+        assertThat(RestUtils.get(wrapIndex(resource("spark-test-json-otp", "data", version) + "/_search?")), containsString("participants"));
     }
 
     @Test
@@ -524,8 +524,8 @@ public class AbstractJavaEsSparkStreamingTest implements Serializable {
         }
         String index = wrapIndex("spark-test-contact");
         String type = "data";
-        String target = resource(index, type);
-        String docEndpoint = docEndpoint(index, type);
+        String target = resource(index, type, version);
+        String docEndpoint = docEndpoint(index, type, version);
 
         RestUtils.touch(index);
         RestUtils.putMapping(index, type, mapping.getBytes());
@@ -598,22 +598,6 @@ public class AbstractJavaEsSparkStreamingTest implements Serializable {
 
         assertTrue(RestUtils.exists(docEndpoint + "/2"));
         assertThat(RestUtils.get(docEndpoint + "/2"), both(not(containsString("\"zipcode\":\"12345\""))).and(containsString("\"note\":\"Second\"")));
-    }
-
-    private String resource(String index, String type) {
-        if (TestUtils.isTypelessVersion(version)) {
-            return index;
-        } else {
-            return index + "/" + type;
-        }
-    }
-
-    private String docEndpoint(String index, String type) {
-        if (TestUtils.isTypelessVersion(version)) {
-            return index + "/_doc";
-        } else {
-            return index + "/" + type;
-        }
     }
 
     private String wrapIndex(String index) {

--- a/spark/sql-13/src/itest/java/org/elasticsearch/spark/integration/AbstractJavaEsSparkStreamingTest.java
+++ b/spark/sql-13/src/itest/java/org/elasticsearch/spark/integration/AbstractJavaEsSparkStreamingTest.java
@@ -154,7 +154,7 @@ public class AbstractJavaEsSparkStreamingTest implements Serializable {
         docs.add(doc1);
         docs.add(doc2);
 
-        String target = wrapIndex("spark-test-nonexisting/scala-basic-write");
+        String target = wrapIndex(resource("spark-test-nonexisting-scala-basic-write", "data"));
 
         Map<String, String> localConf = new HashMap<>(cfg);
         localConf.put(ES_INDEX_AUTO_CREATE, "no");
@@ -190,7 +190,7 @@ public class AbstractJavaEsSparkStreamingTest implements Serializable {
         docs.add(doc1);
         docs.add(doc2);
 
-        String target = wrapIndex("spark-test-scala-basic-write/data");
+        String target = wrapIndex(resource("spark-test-scala-basic-write", "data"));
 
         JavaRDD<Map<String, Object>> batch = sc.parallelize(docs);
         Queue<JavaRDD<Map<String, Object>>> rddQueue = new LinkedList<>();
@@ -228,7 +228,8 @@ public class AbstractJavaEsSparkStreamingTest implements Serializable {
         Map<String, String> localConf = new HashMap<>(cfg);
         localConf.put("es.mapping.id", "number");
 
-        String target = wrapIndex("spark-test-scala-id-write/data");
+        String target = wrapIndex(resource("spark-test-scala-id-write", "data"));
+        String docEndpoint = wrapIndex(docEndpoint("spark-test-scala-id-write", "data"));
 
         JavaRDD<Map<String,Object>> batch = sc.parallelize(docs);
         Queue<JavaRDD<Map<String, Object>>> rddQueue = new LinkedList<>();
@@ -240,8 +241,8 @@ public class AbstractJavaEsSparkStreamingTest implements Serializable {
         ssc.stop(false, true);
 
         assertEquals(2, JavaEsSpark.esRDD(sc, target).count());
-        assertTrue(RestUtils.exists(target + "/1"));
-        assertTrue(RestUtils.exists(target + "/2"));
+        assertTrue(RestUtils.exists(docEndpoint + "/1"));
+        assertTrue(RestUtils.exists(docEndpoint + "/2"));
 
         assertThat(RestUtils.get(target + "/_search?"), containsString("SFO"));
     }
@@ -265,7 +266,8 @@ public class AbstractJavaEsSparkStreamingTest implements Serializable {
         docs.add(doc1);
         docs.add(doc2);
 
-        String target = wrapIndex("spark-test-scala-dyn-id-write/data");
+        String target = wrapIndex(resource("spark-test-scala-dyn-id-write", "data"));
+        String docEndpoint = wrapIndex(docEndpoint("spark-test-scala-dyn-id-write", "data"));
 
         JavaRDD<Map<String,Object>> batch = sc.parallelize(docs);
         Queue<JavaRDD<Map<String, Object>>> rddQueue = new LinkedList<>();
@@ -280,8 +282,8 @@ public class AbstractJavaEsSparkStreamingTest implements Serializable {
         ssc.stop(false, true);
 
         assertEquals(2, JavaEsSpark.esRDD(sc, target).count());
-        assertTrue(RestUtils.exists(target + "/3"));
-        assertTrue(RestUtils.exists(target + "/4"));
+        assertTrue(RestUtils.exists(docEndpoint + "/3"));
+        assertTrue(RestUtils.exists(docEndpoint + "/4"));
 
         assertThat(RestUtils.get(target + "/_search?"), containsString("SFO"));
     }
@@ -315,7 +317,8 @@ public class AbstractJavaEsSparkStreamingTest implements Serializable {
         docs.add(doc1);
         docs.add(doc2);
 
-        String target = wrapIndex("spark-test-scala-dyn-id-write-map/data");
+        String target = wrapIndex(resource("spark-test-scala-dyn-id-write-map", "data"));
+        String docEndpoint = wrapIndex(docEndpoint("spark-test-scala-dyn-id-write-map", "data"));
 
         JavaRDD<Map<String,Object>> batch = sc.parallelize(docs);
         Queue<JavaRDD<Map<String, Object>>> rddQueue = new LinkedList<>();
@@ -330,8 +333,8 @@ public class AbstractJavaEsSparkStreamingTest implements Serializable {
         ssc.stop(false, true);
 
         assertEquals(2, JavaEsSpark.esRDD(sc, target).count());
-        assertTrue(RestUtils.exists(target + "/5"));
-        assertTrue(RestUtils.exists(target + "/6"));
+        assertTrue(RestUtils.exists(docEndpoint + "/5"));
+        assertTrue(RestUtils.exists(docEndpoint + "/6"));
 
         assertThat(RestUtils.get(target + "/_search?"), containsString("SFO"));
     }
@@ -362,7 +365,7 @@ public class AbstractJavaEsSparkStreamingTest implements Serializable {
         docs.add(trip1);
         docs.add(trip2);
 
-        String target = wrapIndex("spark-test-scala-write-exclude/data");
+        String target = wrapIndex(resource("spark-test-scala-write-exclude", "data"));
 
         Map<String, String> localConf = new HashMap<>(cfg);
         localConf.put(ES_MAPPING_EXCLUDE, "airport");
@@ -407,7 +410,7 @@ public class AbstractJavaEsSparkStreamingTest implements Serializable {
         docs.add(doc1);
         docs.add(doc2);
 
-        String target = wrapIndex("spark-test-scala-ingest-write/data");
+        String target = wrapIndex(resource("spark-test-scala-ingest-write", "data"));
 
         Map<String, String> localConf = new HashMap<>(cfg);
         localConf.put(ES_INGEST_PIPELINE, pipelineName);
@@ -440,7 +443,7 @@ public class AbstractJavaEsSparkStreamingTest implements Serializable {
         docs.add(trip1);
         docs.add(trip2);
 
-        String target = wrapIndex("spark-test-trip-{airport}/data");
+        String target = wrapIndex(resource("spark-test-trip-{airport}", "data"));
 
         JavaRDD<Map<String, Object>> batch = sc.parallelize(docs);
         Queue<JavaRDD<Map<String, Object>>> rddQueue = new LinkedList<>();
@@ -451,11 +454,11 @@ public class AbstractJavaEsSparkStreamingTest implements Serializable {
         TimeUnit.SECONDS.sleep(2);
         ssc.stop(false, true);
 
-        assertTrue(RestUtils.exists(wrapIndex("spark-test-trip-otp/data")));
-        assertTrue(RestUtils.exists(wrapIndex("spark-test-trip-sfo/data")));
+        assertTrue(RestUtils.exists(wrapIndex(resource("spark-test-trip-otp", "data"))));
+        assertTrue(RestUtils.exists(wrapIndex(resource("spark-test-trip-sfo", "data"))));
 
-        assertThat(RestUtils.get(wrapIndex("spark-test-trip-sfo/data/_search?")), containsString("business"));
-        assertThat(RestUtils.get(wrapIndex("spark-test-trip-otp/data/_search?")), containsString("participants"));
+        assertThat(RestUtils.get(wrapIndex(resource("spark-test-trip-sfo", "data") + "/_search?")), containsString("business"));
+        assertThat(RestUtils.get(wrapIndex(resource("spark-test-trip-otp", "data") + "/_search?")), containsString("participants"));
     }
 
     @Test
@@ -467,7 +470,7 @@ public class AbstractJavaEsSparkStreamingTest implements Serializable {
         docs.add(json1);
         docs.add(json2);
 
-        String jsonTarget = wrapIndex("spark-test-json-{airport}/data");
+        String jsonTarget = wrapIndex(resource("spark-test-json-{airport}", "data"));
 
         JavaRDD<String> batch1 = sc.parallelize(docs);
         Queue<JavaRDD<String>> rddQueue1 = new LinkedList<>();
@@ -486,7 +489,7 @@ public class AbstractJavaEsSparkStreamingTest implements Serializable {
         byteDocs.add(json1BA);
         byteDocs.add(json2BA);
 
-        String jsonBATarget = wrapIndex("spark-test-json-ba-{airport}/data");
+        String jsonBATarget = wrapIndex(resource("spark-test-json-ba-{airport}", "data"));
 
         JavaRDD<byte[]> batch2 = sc.parallelize(byteDocs);
         Queue<JavaRDD<byte[]>> rddQueue2 = new LinkedList<>();
@@ -497,14 +500,14 @@ public class AbstractJavaEsSparkStreamingTest implements Serializable {
         TimeUnit.SECONDS.sleep(2);
         ssc.stop(false, true);
 
-        assertTrue(RestUtils.exists(wrapIndex("spark-test-json-sfo/data")));
-        assertTrue(RestUtils.exists(wrapIndex("spark-test-json-otp/data")));
+        assertTrue(RestUtils.exists(wrapIndex(resource("spark-test-json-sfo", "data"))));
+        assertTrue(RestUtils.exists(wrapIndex(resource("spark-test-json-otp", "data"))));
 
-        assertTrue(RestUtils.exists(wrapIndex("spark-test-json-ba-sfo/data")));
-        assertTrue(RestUtils.exists(wrapIndex("spark-test-json-ba-otp/data")));
+        assertTrue(RestUtils.exists(wrapIndex(resource("spark-test-json-ba-sfo", "data"))));
+        assertTrue(RestUtils.exists(wrapIndex(resource("spark-test-json-ba-otp", "data"))));
 
-        assertThat(RestUtils.get(wrapIndex("spark-test-json-sfo/data/_search?")), containsString("business"));
-        assertThat(RestUtils.get(wrapIndex("spark-test-json-otp/data/_search?")), containsString("participants"));
+        assertThat(RestUtils.get(wrapIndex(resource("spark-test-json-sfo", "data") + "/_search?")), containsString("business"));
+        assertThat(RestUtils.get(wrapIndex(resource("spark-test-json-otp", "data") + "/_search?")), containsString("participants"));
     }
 
     @Test
@@ -521,13 +524,8 @@ public class AbstractJavaEsSparkStreamingTest implements Serializable {
         }
         String index = wrapIndex("spark-test-contact");
         String type = "data";
-        String target = index + "/" + type;
-        String docEndpoint = target;
-
-        if (version.onOrAfter(EsMajorVersion.V_7_X)) {
-            target = index;
-            docEndpoint = index + "/_doc";
-        }
+        String target = resource(index, type);
+        String docEndpoint = docEndpoint(index, type);
 
         RestUtils.touch(index);
         RestUtils.putMapping(index, type, mapping.getBytes());
@@ -600,6 +598,22 @@ public class AbstractJavaEsSparkStreamingTest implements Serializable {
 
         assertTrue(RestUtils.exists(docEndpoint + "/2"));
         assertThat(RestUtils.get(docEndpoint + "/2"), both(not(containsString("\"zipcode\":\"12345\""))).and(containsString("\"note\":\"Second\"")));
+    }
+
+    private String resource(String index, String type) {
+        if (version.onOrAfter(EsMajorVersion.V_8_X)) {
+            return index;
+        } else {
+            return index + "/" + type;
+        }
+    }
+
+    private String docEndpoint(String index, String type) {
+        if (version.onOrAfter(EsMajorVersion.V_8_X)) {
+            return index + "/_doc";
+        } else {
+            return index + "/" + type;
+        }
     }
 
     private String wrapIndex(String index) {

--- a/spark/sql-13/src/itest/java/org/elasticsearch/spark/integration/AbstractJavaEsSparkStreamingTest.java
+++ b/spark/sql-13/src/itest/java/org/elasticsearch/spark/integration/AbstractJavaEsSparkStreamingTest.java
@@ -519,7 +519,7 @@ public class AbstractJavaEsSparkStreamingTest implements Serializable {
         }
 
         String mapping = "{\"properties\":{\"id\":{\"type\":\""+keyword+"\"},\"note\":{\"type\":\""+keyword+"\"},\"address\":{\"type\":\"nested\",\"properties\":{\"id\":{\"type\":\""+keyword+"\"},\"zipcode\":{\"type\":\""+keyword+"\"}}}}}";
-        if (version.onOrBefore(EsMajorVersion.V_6_X)) {
+        if (!TestUtils.isTypelessVersion(version)) {
             mapping = "{\"data\":" + mapping + "}";
         }
         String index = wrapIndex("spark-test-contact");
@@ -601,7 +601,7 @@ public class AbstractJavaEsSparkStreamingTest implements Serializable {
     }
 
     private String resource(String index, String type) {
-        if (version.onOrAfter(EsMajorVersion.V_8_X)) {
+        if (TestUtils.isTypelessVersion(version)) {
             return index;
         } else {
             return index + "/" + type;
@@ -609,7 +609,7 @@ public class AbstractJavaEsSparkStreamingTest implements Serializable {
     }
 
     private String docEndpoint(String index, String type) {
-        if (version.onOrAfter(EsMajorVersion.V_8_X)) {
+        if (TestUtils.isTypelessVersion(version)) {
             return index + "/_doc";
         } else {
             return index + "/" + type;

--- a/spark/sql-13/src/itest/scala/org/elasticsearch/spark/integration/AbstractScalaEsScalaSparkStreaming.scala
+++ b/spark/sql-13/src/itest/scala/org/elasticsearch/spark/integration/AbstractScalaEsScalaSparkStreaming.scala
@@ -114,7 +114,7 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
     val doc1 = Map("one" -> null, "two" -> Set("2"), "three" -> (".", "..", "..."))
     val doc2 = Map("OTP" -> "Otopeni", "SFO" -> "San Fran")
 
-    val target = wrapIndex("spark-test-nonexisting/scala-basic-write")
+    val target = wrapIndex(resource("spark-test-nonexisting", "scala-basic-write"))
 
     val batch = sc.makeRDD(Seq(doc1, doc2))
     runStream(batch)(_.saveToEs(target, cfg + (ES_INDEX_AUTO_CREATE -> "no")))
@@ -128,7 +128,7 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
     val doc1 = Map("one" -> null, "two" -> Set("2"), "three" ->(".", "..", "..."))
     val doc2 = Map("OTP" -> "Otopeni", "SFO" -> "San Fran")
 
-    val target = wrapIndex("spark-streaming-test-scala-basic-write/data")
+    val target = wrapIndex(resource("spark-streaming-test-scala-basic-write", "data"))
 
     val batch = sc.makeRDD(Seq(doc1, doc2))
 
@@ -144,7 +144,7 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
     val doc1 = Map("one" -> null, "two" -> Set("2"), "three" ->(".", "..", "..."))
     val doc2 = Map("OTP" -> "Otopeni", "SFO" -> "San Fran")
 
-    val target = wrapIndex("spark-streaming-test-scala-בְּדִיקָה-write/data")
+    val target = wrapIndex(resource("spark-streaming-test-scala-בְּדִיקָה-write", "data"))
 
     val batch = sc.makeRDD(Seq(doc1, doc2))
 
@@ -160,7 +160,7 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
     val expected = ExpectingToThrow(classOf[SparkException]).from(ssc)
     val doc = Map("itemId" -> "1", "map" -> Map("lat" -> 1.23, "lon" -> -70.12), "list" -> ("A", "B", "C"), "unknown" -> new Garbage(5))
     val batch = sc.makeRDD(Seq(doc))
-    runStream(batch)(_.saveToEs(wrapIndex("spark-streaming-test-nested-map/data"), cfg))
+    runStream(batch)(_.saveToEs(wrapIndex(resource("spark-streaming-test-nested-map", "data")), cfg))
     expected.assertExceptionFound()
   }
 
@@ -172,7 +172,7 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
 
     val vals = ReflectionUtils.caseClassValues(caseClass2)
 
-    val target = wrapIndex("spark-streaming-test-scala-basic-write-objects/data")
+    val target = wrapIndex(resource("spark-streaming-test-scala-basic-write-objects", "data"))
 
     val batch = sc.makeRDD(Seq(javaBean, caseClass1))
     runStreamRecoverably(batch)(_.saveToEs(target, cfg))
@@ -190,14 +190,15 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
     val doc1 = Map("one" -> null, "two" -> Set("2"), "three" -> (".", "..", "..."), "number" -> 1)
     val doc2 = Map("OTP" -> "Otopeni", "SFO" -> "San Fran", "number" -> 2)
 
-    val target = wrapIndex("spark-streaming-test-scala-id-write/data")
+    val target = wrapIndex(resource("spark-streaming-test-scala-id-write", "data"))
+    val docEndpoint = wrapIndex(docPath("spark-streaming-test-scala-id-write", "data"))
 
     val batch = sc.makeRDD(Seq(doc1, doc2))
     runStream(batch)(_.saveToEs(target, Map(ES_MAPPING_ID -> "number")))
 
     assertEquals(2, EsSpark.esRDD(sc, target).count())
-    assertTrue(RestUtils.exists(target + "/1"))
-    assertTrue(RestUtils.exists(target + "/2"))
+    assertTrue(RestUtils.exists(docEndpoint + "/1"))
+    assertTrue(RestUtils.exists(docEndpoint + "/2"))
 
     assertThat(RestUtils.get(target + "/_search?"), containsString("SFO"))
   }
@@ -207,7 +208,8 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
     val doc1 = Map("one" -> null, "two" -> Set("2"), "three" -> (".", "..", "..."), "number" -> 1)
     val doc2 = Map("OTP" -> "Otopeni", "SFO" -> "San Fran", "number" -> 2)
 
-    val target = wrapIndex("spark-streaming-test-scala-dyn-id-write/data")
+    val target = wrapIndex(resource("spark-streaming-test-scala-dyn-id-write", "data"))
+    val docEndpoint = wrapIndex(docPath("spark-streaming-test-scala-dyn-id-write", "data"))
 
     val pairRDD = sc.makeRDD(Seq((3, doc1), (4, doc2)))
     runStream(pairRDD)(_.saveToEsWithMeta(target, cfg))
@@ -215,8 +217,8 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
     println(RestUtils.get(target + "/_search?"))
 
     assertEquals(2, EsSpark.esRDD(sc, target).count())
-    assertTrue(RestUtils.exists(target + "/3"))
-    assertTrue(RestUtils.exists(target + "/4"))
+    assertTrue(RestUtils.exists(docEndpoint + "/3"))
+    assertTrue(RestUtils.exists(docEndpoint + "/4"))
 
     assertThat(RestUtils.get(target + "/_search?"), containsString("SFO"))
   }
@@ -226,7 +228,8 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
     val doc1 = Map("one" -> null, "two" -> Set("2"), "three" -> (".", "..", "..."), "number" -> 1)
     val doc2 = Map("OTP" -> "Otopeni", "SFO" -> "San Fran", "number" -> 2)
 
-    val target = wrapIndex("spark-streaming-test-scala-dyn-id-write-map/data")
+    val target = wrapIndex(resource("spark-streaming-test-scala-dyn-id-write-map", "data"))
+    val docEndpoint = wrapIndex(docPath("spark-streaming-test-scala-dyn-id-write-map", "data"))
 
     val metadata1 = Map(ID -> 5)
     val metadata2 = Map(ID -> 6, VERSION -> "23")
@@ -238,8 +241,8 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
 
     runStream(pairRDD)(_.saveToEsWithMeta(target, cfg))
 
-    assertTrue(RestUtils.exists(target + "/5"))
-    assertTrue(RestUtils.exists(target + "/6"))
+    assertTrue(RestUtils.exists(docEndpoint + "/5"))
+    assertTrue(RestUtils.exists(docEndpoint + "/6"))
 
     assertThat(RestUtils.get(target + "/_search?"), containsString("SFO"))
   }
@@ -249,7 +252,7 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
     val trip1 = Map("reason" -> "business", "airport" -> "SFO")
     val trip2 = Map("participants" -> 5, "airport" -> "OTP")
 
-    val target = wrapIndex("spark-streaming-test-scala-write-exclude/data")
+    val target = wrapIndex(resource("spark-streaming-test-scala-write-exclude", "data"))
 
     val batch = sc.makeRDD(Seq(trip1, trip2))
     runStream(batch)(_.saveToEs(target, Map(ES_MAPPING_EXCLUDE -> "airport")))
@@ -273,7 +276,7 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
     val doc1 = Map("one" -> null, "two" -> Set("2"), "three" -> (".", "..", "..."))
     val doc2 = Map("OTP" -> "Otopeni", "SFO" -> "San Fran")
 
-    val target = wrapIndex("spark-streaming-test-scala-ingest-write/data")
+    val target = wrapIndex(resource("spark-streaming-test-scala-ingest-write", "data"))
 
     val ingestCfg = cfg + (ConfigurationOptions.ES_INGEST_PIPELINE -> pipelineName) + (ConfigurationOptions.ES_NODES_INGEST_ONLY -> "true")
 
@@ -291,15 +294,15 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
     val trip1 = Map("reason" -> "business", "airport" -> "sfo")
     val trip2 = Map("participants" -> 5, "airport" -> "otp")
 
-    val target = wrapIndex("spark-streaming-test-trip-{airport}/data")
+    val target = wrapIndex(resource("spark-streaming-test-trip-{airport}", "data"))
     val batch = sc.makeRDD(Seq(trip1, trip2))
     runStream(batch)(_.saveToEs(target, cfg))
 
-    assertTrue(RestUtils.exists(wrapIndex("spark-streaming-test-trip-otp/data")))
-    assertTrue(RestUtils.exists(wrapIndex("spark-streaming-test-trip-sfo/data")))
+    assertTrue(RestUtils.exists(wrapIndex(resource("spark-streaming-test-trip-otp", "data"))))
+    assertTrue(RestUtils.exists(wrapIndex(resource("spark-streaming-test-trip-sfo", "data"))))
 
-    assertThat(RestUtils.get(wrapIndex("spark-streaming-test-trip-sfo/data/_search?")), containsString("business"))
-    assertThat(RestUtils.get(wrapIndex("spark-streaming-test-trip-otp/data/_search?")), containsString("participants"))
+    assertThat(RestUtils.get(wrapIndex(resource("spark-streaming-test-trip-sfo", "data") + "/_search?")), containsString("business"))
+    assertThat(RestUtils.get(wrapIndex(resource("spark-streaming-test-trip-otp", "data") + "/_search?")), containsString("participants"))
   }
 
   @Test
@@ -308,22 +311,22 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
     val json2 = "{\"participants\" : 5,\"airport\" : \"otp\"}"
 
     val batch = sc.makeRDD(Seq(json1, json2))
-    runStreamRecoverably(batch)(_.saveJsonToEs(wrapIndex("spark-streaming-test-json-{airport}/data"), cfg))
+    runStreamRecoverably(batch)(_.saveJsonToEs(wrapIndex(resource("spark-streaming-test-json-{airport}", "data")), cfg))
 
     val json1BA = json1.getBytes()
     val json2BA = json2.getBytes()
 
     val batch2 = sc.makeRDD(Seq(json1BA, json2BA))
-    runStream(batch2)(_.saveJsonToEs(wrapIndex("spark-streaming-test-json-ba-{airport}/data"), cfg))
+    runStream(batch2)(_.saveJsonToEs(wrapIndex(resource("spark-streaming-test-json-ba-{airport}", "data")), cfg))
 
-    assertTrue(RestUtils.exists(wrapIndex("spark-streaming-test-json-sfo/data")))
-    assertTrue(RestUtils.exists(wrapIndex("spark-streaming-test-json-otp/data")))
+    assertTrue(RestUtils.exists(wrapIndex(resource("spark-streaming-test-json-sfo", "data"))))
+    assertTrue(RestUtils.exists(wrapIndex(resource("spark-streaming-test-json-otp", "data"))))
 
-    assertTrue(RestUtils.exists(wrapIndex("spark-streaming-test-json-ba-sfo/data")))
-    assertTrue(RestUtils.exists(wrapIndex("spark-streaming-test-json-ba-otp/data")))
+    assertTrue(RestUtils.exists(wrapIndex(resource("spark-streaming-test-json-ba-sfo", "data"))))
+    assertTrue(RestUtils.exists(wrapIndex(resource("spark-streaming-test-json-ba-otp", "data"))))
 
-    assertThat(RestUtils.get(wrapIndex("spark-streaming-test-json-sfo/data/_search?")), containsString("business"))
-    assertThat(RestUtils.get(wrapIndex("spark-streaming-test-json-otp/data/_search?")), containsString("participants"))
+    assertThat(RestUtils.get(wrapIndex(resource("spark-streaming-test-json-sfo", "data") + "/_search?")), containsString("business"))
+    assertThat(RestUtils.get(wrapIndex(resource("spark-streaming-test-json-otp", "data") + "/_search?")), containsString("participants"))
   }
 
   @Test
@@ -348,11 +351,8 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
 
     val index = "spark-streaming-test-contact"
     val typed = "data"
-    val (target, docEndpoint) = if (version.onOrAfter(EsMajorVersion.V_7_X)) {
-      (index, s"$index/_doc")
-    } else {
-      (s"$index/$typed", s"$index/$typed")
-    }
+    val target = resource(index, typed)
+    val docEndpoint = docPath(index, typed)
     RestUtils.touch(index)
     RestUtils.putMapping(index, typed, mapping.getBytes(StringUtils.UTF_8))
     RestUtils.postData(s"$docEndpoint/1", """{ "id" : "1", "note": "First", "address": [] }""".getBytes(StringUtils.UTF_8))
@@ -402,7 +402,7 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
       Map("field2" -> "bar"),
       Map("field1" -> 0.0, "field2" -> "baz")
     )
-    val target = wrapIndex("spark-streaming-test-nullasempty/data")
+    val target = wrapIndex(resource("spark-streaming-test-nullasempty", "data"))
     val batch = sc.makeRDD(data)
 
     runStream(batch)(_.saveToEs(target))
@@ -415,6 +415,22 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
       typelessMapping
     } else {
       s"""{"$typeName":$typelessMapping}"""
+    }
+  }
+
+  def resource(index: String, typeName: String): String = {
+    if (version.onOrAfter(EsMajorVersion.V_7_X)) {
+      index
+    } else {
+      s"$index/$typeName"
+    }
+  }
+
+  def docPath(index: String, typeName: String): String = {
+    if (version.onOrAfter(EsMajorVersion.V_7_X)) {
+      s"$index/_doc"
+    } else {
+      s"$index/$typeName"
     }
   }
 

--- a/spark/sql-13/src/itest/scala/org/elasticsearch/spark/integration/AbstractScalaEsScalaSparkStreaming.scala
+++ b/spark/sql-13/src/itest/scala/org/elasticsearch/spark/integration/AbstractScalaEsScalaSparkStreaming.scala
@@ -32,6 +32,8 @@ import org.elasticsearch.hadoop.cfg.ConfigurationOptions._
 import org.elasticsearch.hadoop.mr.EsAssume
 import org.elasticsearch.hadoop.mr.RestUtils
 import org.elasticsearch.hadoop.util.TestUtils
+import org.elasticsearch.hadoop.util.TestUtils.resource
+import org.elasticsearch.hadoop.util.TestUtils.docEndpoint
 import org.elasticsearch.hadoop.util.{EsMajorVersion, StringUtils, TestSettings}
 import org.elasticsearch.spark.rdd.EsSpark
 import org.elasticsearch.spark.rdd.Metadata._
@@ -114,7 +116,7 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
     val doc1 = Map("one" -> null, "two" -> Set("2"), "three" -> (".", "..", "..."))
     val doc2 = Map("OTP" -> "Otopeni", "SFO" -> "San Fran")
 
-    val target = wrapIndex(resource("spark-test-nonexisting", "scala-basic-write"))
+    val target = wrapIndex(resource("spark-test-nonexisting", "scala-basic-write", version))
 
     val batch = sc.makeRDD(Seq(doc1, doc2))
     runStream(batch)(_.saveToEs(target, cfg + (ES_INDEX_AUTO_CREATE -> "no")))
@@ -128,7 +130,7 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
     val doc1 = Map("one" -> null, "two" -> Set("2"), "three" ->(".", "..", "..."))
     val doc2 = Map("OTP" -> "Otopeni", "SFO" -> "San Fran")
 
-    val target = wrapIndex(resource("spark-streaming-test-scala-basic-write", "data"))
+    val target = wrapIndex(resource("spark-streaming-test-scala-basic-write", "data", version))
 
     val batch = sc.makeRDD(Seq(doc1, doc2))
 
@@ -144,7 +146,7 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
     val doc1 = Map("one" -> null, "two" -> Set("2"), "three" ->(".", "..", "..."))
     val doc2 = Map("OTP" -> "Otopeni", "SFO" -> "San Fran")
 
-    val target = wrapIndex(resource("spark-streaming-test-scala-בְּדִיקָה-write", "data"))
+    val target = wrapIndex(resource("spark-streaming-test-scala-בְּדִיקָה-write", "data", version))
 
     val batch = sc.makeRDD(Seq(doc1, doc2))
 
@@ -160,7 +162,7 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
     val expected = ExpectingToThrow(classOf[SparkException]).from(ssc)
     val doc = Map("itemId" -> "1", "map" -> Map("lat" -> 1.23, "lon" -> -70.12), "list" -> ("A", "B", "C"), "unknown" -> new Garbage(5))
     val batch = sc.makeRDD(Seq(doc))
-    runStream(batch)(_.saveToEs(wrapIndex(resource("spark-streaming-test-nested-map", "data")), cfg))
+    runStream(batch)(_.saveToEs(wrapIndex(resource("spark-streaming-test-nested-map", "data", version)), cfg))
     expected.assertExceptionFound()
   }
 
@@ -172,7 +174,7 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
 
     val vals = ReflectionUtils.caseClassValues(caseClass2)
 
-    val target = wrapIndex(resource("spark-streaming-test-scala-basic-write-objects", "data"))
+    val target = wrapIndex(resource("spark-streaming-test-scala-basic-write-objects", "data", version))
 
     val batch = sc.makeRDD(Seq(javaBean, caseClass1))
     runStreamRecoverably(batch)(_.saveToEs(target, cfg))
@@ -190,15 +192,15 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
     val doc1 = Map("one" -> null, "two" -> Set("2"), "three" -> (".", "..", "..."), "number" -> 1)
     val doc2 = Map("OTP" -> "Otopeni", "SFO" -> "San Fran", "number" -> 2)
 
-    val target = wrapIndex(resource("spark-streaming-test-scala-id-write", "data"))
-    val docEndpoint = wrapIndex(docPath("spark-streaming-test-scala-id-write", "data"))
+    val target = wrapIndex(resource("spark-streaming-test-scala-id-write", "data", version))
+    val docPath = wrapIndex(docEndpoint("spark-streaming-test-scala-id-write", "data", version))
 
     val batch = sc.makeRDD(Seq(doc1, doc2))
     runStream(batch)(_.saveToEs(target, Map(ES_MAPPING_ID -> "number")))
 
     assertEquals(2, EsSpark.esRDD(sc, target).count())
-    assertTrue(RestUtils.exists(docEndpoint + "/1"))
-    assertTrue(RestUtils.exists(docEndpoint + "/2"))
+    assertTrue(RestUtils.exists(docPath + "/1"))
+    assertTrue(RestUtils.exists(docPath + "/2"))
 
     assertThat(RestUtils.get(target + "/_search?"), containsString("SFO"))
   }
@@ -208,8 +210,8 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
     val doc1 = Map("one" -> null, "two" -> Set("2"), "three" -> (".", "..", "..."), "number" -> 1)
     val doc2 = Map("OTP" -> "Otopeni", "SFO" -> "San Fran", "number" -> 2)
 
-    val target = wrapIndex(resource("spark-streaming-test-scala-dyn-id-write", "data"))
-    val docEndpoint = wrapIndex(docPath("spark-streaming-test-scala-dyn-id-write", "data"))
+    val target = wrapIndex(resource("spark-streaming-test-scala-dyn-id-write", "data", version))
+    val docPath = wrapIndex(docEndpoint("spark-streaming-test-scala-dyn-id-write", "data", version))
 
     val pairRDD = sc.makeRDD(Seq((3, doc1), (4, doc2)))
     runStream(pairRDD)(_.saveToEsWithMeta(target, cfg))
@@ -217,8 +219,8 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
     println(RestUtils.get(target + "/_search?"))
 
     assertEquals(2, EsSpark.esRDD(sc, target).count())
-    assertTrue(RestUtils.exists(docEndpoint + "/3"))
-    assertTrue(RestUtils.exists(docEndpoint + "/4"))
+    assertTrue(RestUtils.exists(docPath + "/3"))
+    assertTrue(RestUtils.exists(docPath + "/4"))
 
     assertThat(RestUtils.get(target + "/_search?"), containsString("SFO"))
   }
@@ -228,8 +230,8 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
     val doc1 = Map("one" -> null, "two" -> Set("2"), "three" -> (".", "..", "..."), "number" -> 1)
     val doc2 = Map("OTP" -> "Otopeni", "SFO" -> "San Fran", "number" -> 2)
 
-    val target = wrapIndex(resource("spark-streaming-test-scala-dyn-id-write-map", "data"))
-    val docEndpoint = wrapIndex(docPath("spark-streaming-test-scala-dyn-id-write-map", "data"))
+    val target = wrapIndex(resource("spark-streaming-test-scala-dyn-id-write-map", "data", version))
+    val docPath = wrapIndex(docEndpoint("spark-streaming-test-scala-dyn-id-write-map", "data", version))
 
     val metadata1 = Map(ID -> 5)
     val metadata2 = Map(ID -> 6, VERSION -> "23")
@@ -241,8 +243,8 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
 
     runStream(pairRDD)(_.saveToEsWithMeta(target, cfg))
 
-    assertTrue(RestUtils.exists(docEndpoint + "/5"))
-    assertTrue(RestUtils.exists(docEndpoint + "/6"))
+    assertTrue(RestUtils.exists(docPath + "/5"))
+    assertTrue(RestUtils.exists(docPath + "/6"))
 
     assertThat(RestUtils.get(target + "/_search?"), containsString("SFO"))
   }
@@ -252,7 +254,7 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
     val trip1 = Map("reason" -> "business", "airport" -> "SFO")
     val trip2 = Map("participants" -> 5, "airport" -> "OTP")
 
-    val target = wrapIndex(resource("spark-streaming-test-scala-write-exclude", "data"))
+    val target = wrapIndex(resource("spark-streaming-test-scala-write-exclude", "data", version))
 
     val batch = sc.makeRDD(Seq(trip1, trip2))
     runStream(batch)(_.saveToEs(target, Map(ES_MAPPING_EXCLUDE -> "airport")))
@@ -276,7 +278,7 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
     val doc1 = Map("one" -> null, "two" -> Set("2"), "three" -> (".", "..", "..."))
     val doc2 = Map("OTP" -> "Otopeni", "SFO" -> "San Fran")
 
-    val target = wrapIndex(resource("spark-streaming-test-scala-ingest-write", "data"))
+    val target = wrapIndex(resource("spark-streaming-test-scala-ingest-write", "data", version))
 
     val ingestCfg = cfg + (ConfigurationOptions.ES_INGEST_PIPELINE -> pipelineName) + (ConfigurationOptions.ES_NODES_INGEST_ONLY -> "true")
 
@@ -294,15 +296,15 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
     val trip1 = Map("reason" -> "business", "airport" -> "sfo")
     val trip2 = Map("participants" -> 5, "airport" -> "otp")
 
-    val target = wrapIndex(resource("spark-streaming-test-trip-{airport}", "data"))
+    val target = wrapIndex(resource("spark-streaming-test-trip-{airport}", "data", version))
     val batch = sc.makeRDD(Seq(trip1, trip2))
     runStream(batch)(_.saveToEs(target, cfg))
 
-    assertTrue(RestUtils.exists(wrapIndex(resource("spark-streaming-test-trip-otp", "data"))))
-    assertTrue(RestUtils.exists(wrapIndex(resource("spark-streaming-test-trip-sfo", "data"))))
+    assertTrue(RestUtils.exists(wrapIndex(resource("spark-streaming-test-trip-otp", "data", version))))
+    assertTrue(RestUtils.exists(wrapIndex(resource("spark-streaming-test-trip-sfo", "data", version))))
 
-    assertThat(RestUtils.get(wrapIndex(resource("spark-streaming-test-trip-sfo", "data") + "/_search?")), containsString("business"))
-    assertThat(RestUtils.get(wrapIndex(resource("spark-streaming-test-trip-otp", "data") + "/_search?")), containsString("participants"))
+    assertThat(RestUtils.get(wrapIndex(resource("spark-streaming-test-trip-sfo", "data", version) + "/_search?")), containsString("business"))
+    assertThat(RestUtils.get(wrapIndex(resource("spark-streaming-test-trip-otp", "data", version) + "/_search?")), containsString("participants"))
   }
 
   @Test
@@ -311,22 +313,22 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
     val json2 = "{\"participants\" : 5,\"airport\" : \"otp\"}"
 
     val batch = sc.makeRDD(Seq(json1, json2))
-    runStreamRecoverably(batch)(_.saveJsonToEs(wrapIndex(resource("spark-streaming-test-json-{airport}", "data")), cfg))
+    runStreamRecoverably(batch)(_.saveJsonToEs(wrapIndex(resource("spark-streaming-test-json-{airport}", "data", version)), cfg))
 
     val json1BA = json1.getBytes()
     val json2BA = json2.getBytes()
 
     val batch2 = sc.makeRDD(Seq(json1BA, json2BA))
-    runStream(batch2)(_.saveJsonToEs(wrapIndex(resource("spark-streaming-test-json-ba-{airport}", "data")), cfg))
+    runStream(batch2)(_.saveJsonToEs(wrapIndex(resource("spark-streaming-test-json-ba-{airport}", "data", version)), cfg))
 
-    assertTrue(RestUtils.exists(wrapIndex(resource("spark-streaming-test-json-sfo", "data"))))
-    assertTrue(RestUtils.exists(wrapIndex(resource("spark-streaming-test-json-otp", "data"))))
+    assertTrue(RestUtils.exists(wrapIndex(resource("spark-streaming-test-json-sfo", "data", version))))
+    assertTrue(RestUtils.exists(wrapIndex(resource("spark-streaming-test-json-otp", "data", version))))
 
-    assertTrue(RestUtils.exists(wrapIndex(resource("spark-streaming-test-json-ba-sfo", "data"))))
-    assertTrue(RestUtils.exists(wrapIndex(resource("spark-streaming-test-json-ba-otp", "data"))))
+    assertTrue(RestUtils.exists(wrapIndex(resource("spark-streaming-test-json-ba-sfo", "data", version))))
+    assertTrue(RestUtils.exists(wrapIndex(resource("spark-streaming-test-json-ba-otp", "data", version))))
 
-    assertThat(RestUtils.get(wrapIndex(resource("spark-streaming-test-json-sfo", "data") + "/_search?")), containsString("business"))
-    assertThat(RestUtils.get(wrapIndex(resource("spark-streaming-test-json-otp", "data") + "/_search?")), containsString("participants"))
+    assertThat(RestUtils.get(wrapIndex(resource("spark-streaming-test-json-sfo", "data", version) + "/_search?")), containsString("business"))
+    assertThat(RestUtils.get(wrapIndex(resource("spark-streaming-test-json-otp", "data", version) + "/_search?")), containsString("participants"))
   }
 
   @Test
@@ -351,12 +353,12 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
 
     val index = "spark-streaming-test-contact"
     val typed = "data"
-    val target = resource(index, typed)
-    val docEndpoint = docPath(index, typed)
+    val target = resource(index, typed, version)
+    val docPath = docEndpoint(index, typed, version)
     RestUtils.touch(index)
     RestUtils.putMapping(index, typed, mapping.getBytes(StringUtils.UTF_8))
-    RestUtils.postData(s"$docEndpoint/1", """{ "id" : "1", "note": "First", "address": [] }""".getBytes(StringUtils.UTF_8))
-    RestUtils.postData(s"$docEndpoint/2", """{ "id" : "2", "note": "First", "address": [] }""".getBytes(StringUtils.UTF_8))
+    RestUtils.postData(s"$docPath/1", """{ "id" : "1", "note": "First", "address": [] }""".getBytes(StringUtils.UTF_8))
+    RestUtils.postData(s"$docPath/2", """{ "id" : "2", "note": "First", "address": [] }""".getBytes(StringUtils.UTF_8))
 
     val lang = if (version.onOrAfter(EsMajorVersion.V_5_X)) "painless" else "groovy"
     val props = Map("es.write.operation" -> "upsert",
@@ -388,11 +390,11 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
 
     runStream(notes)(_.saveToEs(target, props + ("es.update.script.params" -> note_up_params) + ("es.update.script" -> note_up_script)))
 
-    assertTrue(RestUtils.exists(s"$docEndpoint/1"))
-    assertThat(RestUtils.get(s"$docEndpoint/1"), both(containsString(""""zipcode":"12345"""")).and(containsString(""""note":"First"""")))
+    assertTrue(RestUtils.exists(s"$docPath/1"))
+    assertThat(RestUtils.get(s"$docPath/1"), both(containsString(""""zipcode":"12345"""")).and(containsString(""""note":"First"""")))
 
-    assertTrue(RestUtils.exists(s"$docEndpoint/2"))
-    assertThat(RestUtils.get(s"$docEndpoint/2"), both(not(containsString(""""zipcode":"12345""""))).and(containsString(""""note":"Second"""")))
+    assertTrue(RestUtils.exists(s"$docPath/2"))
+    assertThat(RestUtils.get(s"$docPath/2"), both(not(containsString(""""zipcode":"12345""""))).and(containsString(""""note":"Second"""")))
   }
 
   @Test
@@ -402,7 +404,7 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
       Map("field2" -> "bar"),
       Map("field1" -> 0.0, "field2" -> "baz")
     )
-    val target = wrapIndex(resource("spark-streaming-test-nullasempty", "data"))
+    val target = wrapIndex(resource("spark-streaming-test-nullasempty", "data", version))
     val batch = sc.makeRDD(data)
 
     runStream(batch)(_.saveToEs(target))
@@ -415,22 +417,6 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
       typelessMapping
     } else {
       s"""{"$typeName":$typelessMapping}"""
-    }
-  }
-
-  def resource(index: String, typeName: String): String = {
-    if (TestUtils.isTypelessVersion(version)) {
-      index
-    } else {
-      s"$index/$typeName"
-    }
-  }
-
-  def docPath(index: String, typeName: String): String = {
-    if (TestUtils.isTypelessVersion(version)) {
-      s"$index/_doc"
-    } else {
-      s"$index/$typeName"
     }
   }
 

--- a/spark/sql-13/src/itest/scala/org/elasticsearch/spark/integration/AbstractScalaEsScalaSparkStreaming.scala
+++ b/spark/sql-13/src/itest/scala/org/elasticsearch/spark/integration/AbstractScalaEsScalaSparkStreaming.scala
@@ -411,7 +411,7 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
   }
 
   def wrapMapping(typeName: String, typelessMapping: String): String = {
-    if (version.onOrAfter(EsMajorVersion.V_7_X)) {
+    if (TestUtils.isTypelessVersion(version)) {
       typelessMapping
     } else {
       s"""{"$typeName":$typelessMapping}"""
@@ -419,7 +419,7 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
   }
 
   def resource(index: String, typeName: String): String = {
-    if (version.onOrAfter(EsMajorVersion.V_7_X)) {
+    if (TestUtils.isTypelessVersion(version)) {
       index
     } else {
       s"$index/$typeName"
@@ -427,7 +427,7 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
   }
 
   def docPath(index: String, typeName: String): String = {
-    if (version.onOrAfter(EsMajorVersion.V_7_X)) {
+    if (TestUtils.isTypelessVersion(version)) {
       s"$index/_doc"
     } else {
       s"$index/$typeName"

--- a/spark/sql-13/src/itest/scala/org/elasticsearch/spark/integration/AbstractScalaEsSparkSQL.scala
+++ b/spark/sql-13/src/itest/scala/org/elasticsearch/spark/integration/AbstractScalaEsSparkSQL.scala
@@ -1265,7 +1265,7 @@ class AbstractScalaEsScalaSparkSQL(prefix: String, readMetadata: jl.Boolean, pus
     val (target, docEndpoint) = makeTargets(index, typename)
     RestUtils.delete(index)
     RestUtils.touch(index)
-    if (version.onOrAfter(EsMajorVersion.V_7_X)) {
+    if (TestUtils.isTypelessVersion(version)) {
       RestUtils.putMapping(index, typename, "data/join/mapping/typeless.json")
     } else {
       RestUtils.putMapping(index, typename, "data/join/mapping/typed.json")
@@ -1557,7 +1557,7 @@ class AbstractScalaEsScalaSparkSQL(prefix: String, readMetadata: jl.Boolean, pus
       val index = wrapIndex("sparksql-test-scala-write-join-separate")
       val typename = "join"
       val (target, docEndpoint) = makeTargets(index, typename)
-      if (version.onOrAfter(EsMajorVersion.V_7_X)) {
+      if (TestUtils.isTypelessVersion(version)) {
         RestUtils.putMapping(index, typename, "data/join/mapping/typeless.json")
       } else {
         RestUtils.putMapping(index, typename, "data/join/mapping/typed.json")
@@ -1592,7 +1592,7 @@ class AbstractScalaEsScalaSparkSQL(prefix: String, readMetadata: jl.Boolean, pus
       val index = wrapIndex("sparksql-test-scala-write-join-combined")
       val typename = "join"
       val (target, docEndpoint) = makeTargets(index, typename)
-      if (version.onOrAfter(EsMajorVersion.V_7_X)) {
+      if (TestUtils.isTypelessVersion(version)) {
         RestUtils.putMapping(index, typename, "data/join/mapping/typeless.json")
       } else {
         RestUtils.putMapping(index, typename, "data/join/mapping/typed.json")
@@ -2237,18 +2237,18 @@ class AbstractScalaEsScalaSparkSQL(prefix: String, readMetadata: jl.Boolean, pus
   }
 
   def wrapMapping(typeName: String, typelessMapping: String): String = {
-    if (version.onOrBefore(EsMajorVersion.V_6_X)) {
-      s"""{"$typeName":$typelessMapping}"""
-    } else {
+    if (TestUtils.isTypelessVersion(version)) {
       typelessMapping
+    } else {
+      s"""{"$typeName":$typelessMapping}"""
     }
   }
 
   def makeTargets(index: String, typeName: String): (String, String) = {
-    if (version.onOrBefore(EsMajorVersion.V_6_X)) {
-      (s"$index/$typeName", s"$index/$typeName")
-    } else {
+    if (TestUtils.isTypelessVersion(version)) {
       (index, s"$index/_doc")
+    } else {
+      (s"$index/$typeName", s"$index/$typeName")
     }
   }
 

--- a/spark/sql-20/src/itest/java/org/elasticsearch/spark/integration/AbstractJavaEsSparkSQLTest.java
+++ b/spark/sql-20/src/itest/java/org/elasticsearch/spark/integration/AbstractJavaEsSparkSQLTest.java
@@ -41,6 +41,7 @@ import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 import org.elasticsearch.hadoop.mr.RestUtils;
+import org.elasticsearch.hadoop.util.EsMajorVersion;
 import org.elasticsearch.hadoop.util.TestSettings;
 import org.elasticsearch.hadoop.util.TestUtils;
 import org.elasticsearch.spark.sql.api.java.JavaEsSparkSQL;
@@ -69,6 +70,7 @@ public class AbstractJavaEsSparkSQLTest implements Serializable {
 	
 	private static transient JavaSparkContext sc = null;
 	private static transient SQLContext sqc = null;
+	private transient EsMajorVersion version = TestUtils.getEsClusterInfo().getMajorVersion();
 
 	@BeforeClass
 	public static void setup() {
@@ -100,7 +102,7 @@ public class AbstractJavaEsSparkSQLTest implements Serializable {
     public void testEsDataset1Write() throws Exception {
         Dataset<Row> dataset = artistsAsDataset();
 
-		String target = "sparksql-test-scala-basic-write/data";
+		String target = resource("sparksql-test-scala-basic-write", "data");
         JavaEsSparkSQL.saveToEs(dataset, target);
 		assertTrue(RestUtils.exists(target));
 		assertThat(RestUtils.get(target + "/_search?"), containsString("345"));
@@ -110,19 +112,21 @@ public class AbstractJavaEsSparkSQLTest implements Serializable {
     public void testEsDataset1WriteWithId() throws Exception {
         Dataset<Row> dataset = artistsAsDataset();
 
-		String target = "sparksql-test-scala-basic-write-id-mapping/data";
+		String target = resource("sparksql-test-scala-basic-write-id-mapping", "data");
+		String docEndpoint = docPath("sparksql-test-scala-basic-write-id-mapping", "data");
+
         JavaEsSparkSQL.saveToEs(dataset, target,
 				ImmutableMap.of(ES_MAPPING_ID, "id"));
 		assertTrue(RestUtils.exists(target));
 		assertThat(RestUtils.get(target + "/_search?"), containsString("345"));
-		assertThat(RestUtils.exists(target + "/1"), is(true));
+		assertThat(RestUtils.exists(docEndpoint + "/1"), is(true));
 	}
 
     @Test
     public void testEsSchemaRDD1WriteWithMappingExclude() throws Exception {
         Dataset<Row> dataset = artistsAsDataset();
 
-        String target = "sparksql-test-scala-basic-write-exclude-mapping/data";
+        String target = resource("sparksql-test-scala-basic-write-exclude-mapping", "data");
         JavaEsSparkSQL.saveToEs(dataset, target,
                 ImmutableMap.of(ES_MAPPING_EXCLUDE, "url"));
         assertTrue(RestUtils.exists(target));
@@ -131,7 +135,7 @@ public class AbstractJavaEsSparkSQLTest implements Serializable {
     
 	@Test
     public void testEsDataset2Read() throws Exception {
-		String target = "sparksql-test-scala-basic-write/data";
+		String target = resource("sparksql-test-scala-basic-write", "data");
 
         // Dataset<Row> dataset = JavaEsSparkSQL.esDF(sqc, target);
         Dataset<Row> dataset = sqc.read().format("es").load(target);
@@ -154,7 +158,7 @@ public class AbstractJavaEsSparkSQLTest implements Serializable {
 
 	@Test
 	public void testEsDatasetReadMetadata() throws Exception {
-		String target = "sparksql-test-scala-basic-write/data";
+		String target = resource("sparksql-test-scala-basic-write", "data");
 
 		Dataset<Row> dataset = sqc.read().format("es").option("es.read.metadata", "true").load(target).where("id = 1");
 
@@ -196,5 +200,21 @@ public class AbstractJavaEsSparkSQLTest implements Serializable {
 		});
 
         return sqc.createDataFrame(rowData, schema);
+	}
+
+	private String resource(String index, String type) {
+		if (version.onOrAfter(EsMajorVersion.V_8_X)) {
+			return index;
+		} else {
+			return index + "/" + type;
+		}
+	}
+
+	private String docPath(String index, String type) {
+		if (version.onOrAfter(EsMajorVersion.V_8_X)) {
+			return index + "/_doc";
+		} else {
+			return index + "/" + type;
+		}
 	}
 }

--- a/spark/sql-20/src/itest/java/org/elasticsearch/spark/integration/AbstractJavaEsSparkSQLTest.java
+++ b/spark/sql-20/src/itest/java/org/elasticsearch/spark/integration/AbstractJavaEsSparkSQLTest.java
@@ -203,7 +203,7 @@ public class AbstractJavaEsSparkSQLTest implements Serializable {
 	}
 
 	private String resource(String index, String type) {
-		if (version.onOrAfter(EsMajorVersion.V_8_X)) {
+		if (TestUtils.isTypelessVersion(version)) {
 			return index;
 		} else {
 			return index + "/" + type;
@@ -211,7 +211,7 @@ public class AbstractJavaEsSparkSQLTest implements Serializable {
 	}
 
 	private String docPath(String index, String type) {
-		if (version.onOrAfter(EsMajorVersion.V_8_X)) {
+		if (TestUtils.isTypelessVersion(version)) {
 			return index + "/_doc";
 		} else {
 			return index + "/" + type;

--- a/spark/sql-20/src/itest/java/org/elasticsearch/spark/integration/AbstractJavaEsSparkSQLTest.java
+++ b/spark/sql-20/src/itest/java/org/elasticsearch/spark/integration/AbstractJavaEsSparkSQLTest.java
@@ -53,6 +53,8 @@ import org.junit.runners.MethodSorters;
 
 import com.google.common.collect.ImmutableMap;
 
+import static org.elasticsearch.hadoop.util.TestUtils.docEndpoint;
+import static org.elasticsearch.hadoop.util.TestUtils.resource;
 import static org.junit.Assert.*;
 
 import static org.elasticsearch.hadoop.cfg.ConfigurationOptions.*;
@@ -102,7 +104,7 @@ public class AbstractJavaEsSparkSQLTest implements Serializable {
     public void testEsDataset1Write() throws Exception {
         Dataset<Row> dataset = artistsAsDataset();
 
-		String target = resource("sparksql-test-scala-basic-write", "data");
+		String target = resource("sparksql-test-scala-basic-write", "data", version);
         JavaEsSparkSQL.saveToEs(dataset, target);
 		assertTrue(RestUtils.exists(target));
 		assertThat(RestUtils.get(target + "/_search?"), containsString("345"));
@@ -112,8 +114,8 @@ public class AbstractJavaEsSparkSQLTest implements Serializable {
     public void testEsDataset1WriteWithId() throws Exception {
         Dataset<Row> dataset = artistsAsDataset();
 
-		String target = resource("sparksql-test-scala-basic-write-id-mapping", "data");
-		String docEndpoint = docPath("sparksql-test-scala-basic-write-id-mapping", "data");
+		String target = resource("sparksql-test-scala-basic-write-id-mapping", "data", version);
+		String docEndpoint = docEndpoint("sparksql-test-scala-basic-write-id-mapping", "data", version);
 
         JavaEsSparkSQL.saveToEs(dataset, target,
 				ImmutableMap.of(ES_MAPPING_ID, "id"));
@@ -126,7 +128,7 @@ public class AbstractJavaEsSparkSQLTest implements Serializable {
     public void testEsSchemaRDD1WriteWithMappingExclude() throws Exception {
         Dataset<Row> dataset = artistsAsDataset();
 
-        String target = resource("sparksql-test-scala-basic-write-exclude-mapping", "data");
+        String target = resource("sparksql-test-scala-basic-write-exclude-mapping", "data", version);
         JavaEsSparkSQL.saveToEs(dataset, target,
                 ImmutableMap.of(ES_MAPPING_EXCLUDE, "url"));
         assertTrue(RestUtils.exists(target));
@@ -135,7 +137,7 @@ public class AbstractJavaEsSparkSQLTest implements Serializable {
     
 	@Test
     public void testEsDataset2Read() throws Exception {
-		String target = resource("sparksql-test-scala-basic-write", "data");
+		String target = resource("sparksql-test-scala-basic-write", "data", version);
 
         // Dataset<Row> dataset = JavaEsSparkSQL.esDF(sqc, target);
         Dataset<Row> dataset = sqc.read().format("es").load(target);
@@ -158,7 +160,7 @@ public class AbstractJavaEsSparkSQLTest implements Serializable {
 
 	@Test
 	public void testEsDatasetReadMetadata() throws Exception {
-		String target = resource("sparksql-test-scala-basic-write", "data");
+		String target = resource("sparksql-test-scala-basic-write", "data", version);
 
 		Dataset<Row> dataset = sqc.read().format("es").option("es.read.metadata", "true").load(target).where("id = 1");
 
@@ -200,21 +202,5 @@ public class AbstractJavaEsSparkSQLTest implements Serializable {
 		});
 
         return sqc.createDataFrame(rowData, schema);
-	}
-
-	private String resource(String index, String type) {
-		if (TestUtils.isTypelessVersion(version)) {
-			return index;
-		} else {
-			return index + "/" + type;
-		}
-	}
-
-	private String docPath(String index, String type) {
-		if (TestUtils.isTypelessVersion(version)) {
-			return index + "/_doc";
-		} else {
-			return index + "/" + type;
-		}
 	}
 }

--- a/spark/sql-20/src/itest/java/org/elasticsearch/spark/integration/AbstractJavaEsSparkStreamingTest.java
+++ b/spark/sql-20/src/itest/java/org/elasticsearch/spark/integration/AbstractJavaEsSparkStreamingTest.java
@@ -154,7 +154,7 @@ public class AbstractJavaEsSparkStreamingTest implements Serializable {
         docs.add(doc1);
         docs.add(doc2);
 
-        String target = wrapIndex("spark-test-nonexisting/scala-basic-write");
+        String target = wrapIndex(resource("spark-test-nonexisting-scala-basic-write", "data"));
 
         Map<String, String> localConf = new HashMap<>(cfg);
         localConf.put(ES_INDEX_AUTO_CREATE, "no");
@@ -190,7 +190,7 @@ public class AbstractJavaEsSparkStreamingTest implements Serializable {
         docs.add(doc1);
         docs.add(doc2);
 
-        String target = wrapIndex("spark-streaming-test-scala-basic-write/data");
+        String target = wrapIndex(resource("spark-streaming-test-scala-basic-write", "data"));
 
         JavaRDD<Map<String, Object>> batch = sc.parallelize(docs);
         Queue<JavaRDD<Map<String, Object>>> rddQueue = new LinkedList<>();
@@ -228,7 +228,8 @@ public class AbstractJavaEsSparkStreamingTest implements Serializable {
         Map<String, String> localConf = new HashMap<>(cfg);
         localConf.put("es.mapping.id", "number");
 
-        String target = wrapIndex("spark-streaming-test-scala-id-write/data");
+        String target = wrapIndex(resource("spark-streaming-test-scala-id-write", "data"));
+        String docEndpoint = wrapIndex(docPath("spark-streaming-test-scala-id-write", "data"));
 
         JavaRDD<Map<String,Object>> batch = sc.parallelize(docs);
         Queue<JavaRDD<Map<String, Object>>> rddQueue = new LinkedList<>();
@@ -240,8 +241,8 @@ public class AbstractJavaEsSparkStreamingTest implements Serializable {
         ssc.stop(false, true);
 
         assertEquals(2, JavaEsSpark.esRDD(sc, target).count());
-        assertTrue(RestUtils.exists(target + "/1"));
-        assertTrue(RestUtils.exists(target + "/2"));
+        assertTrue(RestUtils.exists(docEndpoint + "/1"));
+        assertTrue(RestUtils.exists(docEndpoint + "/2"));
 
         assertThat(RestUtils.get(target + "/_search?"), containsString("SFO"));
     }
@@ -265,7 +266,8 @@ public class AbstractJavaEsSparkStreamingTest implements Serializable {
         docs.add(doc1);
         docs.add(doc2);
 
-        String target = wrapIndex("spark-streaming-test-scala-dyn-id-write/data");
+        String target = wrapIndex(resource("spark-streaming-test-scala-dyn-id-write", "data"));
+        String docEndpoint = wrapIndex(docPath("spark-streaming-test-scala-dyn-id-write", "data"));
 
         JavaRDD<Map<String,Object>> batch = sc.parallelize(docs);
         Queue<JavaRDD<Map<String, Object>>> rddQueue = new LinkedList<>();
@@ -280,8 +282,8 @@ public class AbstractJavaEsSparkStreamingTest implements Serializable {
         ssc.stop(false, true);
 
         assertEquals(2, JavaEsSpark.esRDD(sc, target).count());
-        assertTrue(RestUtils.exists(target + "/3"));
-        assertTrue(RestUtils.exists(target + "/4"));
+        assertTrue(RestUtils.exists(docEndpoint + "/3"));
+        assertTrue(RestUtils.exists(docEndpoint + "/4"));
 
         assertThat(RestUtils.get(target + "/_search?"), containsString("SFO"));
     }
@@ -315,7 +317,8 @@ public class AbstractJavaEsSparkStreamingTest implements Serializable {
         docs.add(doc1);
         docs.add(doc2);
 
-        String target = wrapIndex("spark-streaming-test-scala-dyn-id-write-map/data");
+        String target = wrapIndex(resource("spark-streaming-test-scala-dyn-id-write-map", "data"));
+        String docEndpoint = wrapIndex(docPath("spark-streaming-test-scala-dyn-id-write-map", "data"));
 
         JavaRDD<Map<String,Object>> batch = sc.parallelize(docs);
         Queue<JavaRDD<Map<String, Object>>> rddQueue = new LinkedList<>();
@@ -330,8 +333,8 @@ public class AbstractJavaEsSparkStreamingTest implements Serializable {
         ssc.stop(false, true);
 
         assertEquals(2, JavaEsSpark.esRDD(sc, target).count());
-        assertTrue(RestUtils.exists(target + "/5"));
-        assertTrue(RestUtils.exists(target + "/6"));
+        assertTrue(RestUtils.exists(docEndpoint + "/5"));
+        assertTrue(RestUtils.exists(docEndpoint + "/6"));
 
         assertThat(RestUtils.get(target + "/_search?"), containsString("SFO"));
     }
@@ -362,7 +365,7 @@ public class AbstractJavaEsSparkStreamingTest implements Serializable {
         docs.add(trip1);
         docs.add(trip2);
 
-        String target = wrapIndex("spark-streaming-test-scala-write-exclude/data");
+        String target = wrapIndex(resource("spark-streaming-test-scala-write-exclude", "data"));
 
         Map<String, String> localConf = new HashMap<>(cfg);
         localConf.put(ES_MAPPING_EXCLUDE, "airport");
@@ -407,7 +410,7 @@ public class AbstractJavaEsSparkStreamingTest implements Serializable {
         docs.add(doc1);
         docs.add(doc2);
 
-        String target = wrapIndex("spark-streaming-test-scala-ingest-write/data");
+        String target = wrapIndex(resource("spark-streaming-test-scala-ingest-write", "data"));
 
         Map<String, String> localConf = new HashMap<>(cfg);
         localConf.put(ES_INGEST_PIPELINE, pipelineName);
@@ -440,7 +443,7 @@ public class AbstractJavaEsSparkStreamingTest implements Serializable {
         docs.add(trip1);
         docs.add(trip2);
 
-        String target = wrapIndex("spark-streaming-test-trip-{airport}/data");
+        String target = wrapIndex(resource("spark-streaming-test-trip-{airport}", "data"));
 
         JavaRDD<Map<String, Object>> batch = sc.parallelize(docs);
         Queue<JavaRDD<Map<String, Object>>> rddQueue = new LinkedList<>();
@@ -451,11 +454,11 @@ public class AbstractJavaEsSparkStreamingTest implements Serializable {
         TimeUnit.SECONDS.sleep(2);
         ssc.stop(false, true);
 
-        assertTrue(RestUtils.exists(wrapIndex("spark-streaming-test-trip-otp/data")));
-        assertTrue(RestUtils.exists(wrapIndex("spark-streaming-test-trip-sfo/data")));
+        assertTrue(RestUtils.exists(wrapIndex(resource("spark-streaming-test-trip-otp", "data"))));
+        assertTrue(RestUtils.exists(wrapIndex(resource("spark-streaming-test-trip-sfo", "data"))));
 
-        assertThat(RestUtils.get(wrapIndex("spark-streaming-test-trip-sfo/data/_search?")), containsString("business"));
-        assertThat(RestUtils.get(wrapIndex("spark-streaming-test-trip-otp/data/_search?")), containsString("participants"));
+        assertThat(RestUtils.get(wrapIndex(resource("spark-streaming-test-trip-sfo", "data") + "/_search?")), containsString("business"));
+        assertThat(RestUtils.get(wrapIndex(resource("spark-streaming-test-trip-otp", "data") + "/_search?")), containsString("participants"));
     }
 
     @Test
@@ -467,7 +470,7 @@ public class AbstractJavaEsSparkStreamingTest implements Serializable {
         docs.add(json1);
         docs.add(json2);
 
-        String jsonTarget = wrapIndex("spark-streaming-test-json-{airport}/data");
+        String jsonTarget = wrapIndex(resource("spark-streaming-test-json-{airport}", "data"));
 
         JavaRDD<String> batch1 = sc.parallelize(docs);
         Queue<JavaRDD<String>> rddQueue1 = new LinkedList<>();
@@ -486,7 +489,7 @@ public class AbstractJavaEsSparkStreamingTest implements Serializable {
         byteDocs.add(json1BA);
         byteDocs.add(json2BA);
 
-        String jsonBATarget = wrapIndex("spark-streaming-test-json-ba-{airport}/data");
+        String jsonBATarget = wrapIndex(resource("spark-streaming-test-json-ba-{airport}", "data"));
 
         JavaRDD<byte[]> batch2 = sc.parallelize(byteDocs);
         Queue<JavaRDD<byte[]>> rddQueue2 = new LinkedList<>();
@@ -497,14 +500,14 @@ public class AbstractJavaEsSparkStreamingTest implements Serializable {
         TimeUnit.SECONDS.sleep(2);
         ssc.stop(false, true);
 
-        assertTrue(RestUtils.exists(wrapIndex("spark-streaming-test-json-sfo/data")));
-        assertTrue(RestUtils.exists(wrapIndex("spark-streaming-test-json-otp/data")));
+        assertTrue(RestUtils.exists(wrapIndex(resource("spark-streaming-test-json-sfo", "data"))));
+        assertTrue(RestUtils.exists(wrapIndex(resource("spark-streaming-test-json-otp", "data"))));
 
-        assertTrue(RestUtils.exists(wrapIndex("spark-streaming-test-json-ba-sfo/data")));
-        assertTrue(RestUtils.exists(wrapIndex("spark-streaming-test-json-ba-otp/data")));
+        assertTrue(RestUtils.exists(wrapIndex(resource("spark-streaming-test-json-ba-sfo", "data"))));
+        assertTrue(RestUtils.exists(wrapIndex(resource("spark-streaming-test-json-ba-otp", "data"))));
 
-        assertThat(RestUtils.get(wrapIndex("spark-streaming-test-json-sfo/data/_search?")), containsString("business"));
-        assertThat(RestUtils.get(wrapIndex("spark-streaming-test-json-otp/data/_search?")), containsString("participants"));
+        assertThat(RestUtils.get(wrapIndex(resource("spark-streaming-test-json-sfo", "data") + "/_search?")), containsString("business"));
+        assertThat(RestUtils.get(wrapIndex(resource("spark-streaming-test-json-otp", "data") + "/_search?")), containsString("participants"));
     }
 
     @Test
@@ -520,12 +523,8 @@ public class AbstractJavaEsSparkStreamingTest implements Serializable {
         }
         String index = wrapIndex("spark-streaming-test-contact");
         String type = "data";
-        String target = index + "/" + type;
-        String docEndpoint = target;
-        if (version.onOrAfter(EsMajorVersion.V_7_X)) {
-            target = index;
-            docEndpoint = index + "/_doc";
-        }
+        String target = resource(index, type);
+        String docEndpoint = docPath(index, type);
 
         RestUtils.touch(index);
         RestUtils.putMapping(index, type, mapping.getBytes());
@@ -596,6 +595,22 @@ public class AbstractJavaEsSparkStreamingTest implements Serializable {
 
         assertTrue(RestUtils.exists(docEndpoint + "/2"));
         assertThat(RestUtils.get(docEndpoint + "/2"), both(not(containsString("\"zipcode\":\"12345\""))).and(containsString("\"note\":\"Second\"")));
+    }
+
+    private String resource(String index, String type) {
+        if (version.onOrAfter(EsMajorVersion.V_8_X)) {
+            return index;
+        } else {
+            return index + "/" + type;
+        }
+    }
+
+    private String docPath(String index, String type) {
+        if (version.onOrAfter(EsMajorVersion.V_8_X)) {
+            return index + "/_doc";
+        } else {
+            return index + "/" + type;
+        }
     }
 
     private String wrapIndex(String index) {

--- a/spark/sql-20/src/itest/java/org/elasticsearch/spark/integration/AbstractJavaEsSparkStreamingTest.java
+++ b/spark/sql-20/src/itest/java/org/elasticsearch/spark/integration/AbstractJavaEsSparkStreamingTest.java
@@ -518,7 +518,7 @@ public class AbstractJavaEsSparkStreamingTest implements Serializable {
         }
 
         String mapping = "{\"properties\":{\"id\":{\"type\":\""+keyword+"\"},\"note\":{\"type\":\""+keyword+"\"},\"address\":{\"type\":\"nested\",\"properties\":{\"id\":{\"type\":\""+keyword+"\"},\"zipcode\":{\"type\":\""+keyword+"\"}}}}}";
-        if (version.onOrBefore(EsMajorVersion.V_6_X)) {
+        if (!TestUtils.isTypelessVersion(version)) {
             mapping = "{\"data\":"+mapping+"}";
         }
         String index = wrapIndex("spark-streaming-test-contact");
@@ -598,7 +598,7 @@ public class AbstractJavaEsSparkStreamingTest implements Serializable {
     }
 
     private String resource(String index, String type) {
-        if (version.onOrAfter(EsMajorVersion.V_8_X)) {
+        if (TestUtils.isTypelessVersion(version)) {
             return index;
         } else {
             return index + "/" + type;
@@ -606,7 +606,7 @@ public class AbstractJavaEsSparkStreamingTest implements Serializable {
     }
 
     private String docPath(String index, String type) {
-        if (version.onOrAfter(EsMajorVersion.V_8_X)) {
+        if (TestUtils.isTypelessVersion(version)) {
             return index + "/_doc";
         } else {
             return index + "/" + type;

--- a/spark/sql-20/src/itest/java/org/elasticsearch/spark/integration/AbstractJavaEsSparkStreamingTest.java
+++ b/spark/sql-20/src/itest/java/org/elasticsearch/spark/integration/AbstractJavaEsSparkStreamingTest.java
@@ -51,11 +51,9 @@ import org.elasticsearch.spark.streaming.api.java.JavaEsSparkStreaming;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
-import org.junit.Assume;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.FixMethodOrder;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.MethodSorters;
@@ -76,6 +74,8 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import static org.elasticsearch.hadoop.cfg.ConfigurationOptions.*;
+import static org.elasticsearch.hadoop.util.TestUtils.docEndpoint;
+import static org.elasticsearch.hadoop.util.TestUtils.resource;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 import static scala.collection.JavaConversions.propertiesAsScalaMap;
@@ -154,7 +154,7 @@ public class AbstractJavaEsSparkStreamingTest implements Serializable {
         docs.add(doc1);
         docs.add(doc2);
 
-        String target = wrapIndex(resource("spark-test-nonexisting-scala-basic-write", "data"));
+        String target = wrapIndex(resource("spark-test-nonexisting-scala-basic-write", "data", version));
 
         Map<String, String> localConf = new HashMap<>(cfg);
         localConf.put(ES_INDEX_AUTO_CREATE, "no");
@@ -190,7 +190,7 @@ public class AbstractJavaEsSparkStreamingTest implements Serializable {
         docs.add(doc1);
         docs.add(doc2);
 
-        String target = wrapIndex(resource("spark-streaming-test-scala-basic-write", "data"));
+        String target = wrapIndex(resource("spark-streaming-test-scala-basic-write", "data", version));
 
         JavaRDD<Map<String, Object>> batch = sc.parallelize(docs);
         Queue<JavaRDD<Map<String, Object>>> rddQueue = new LinkedList<>();
@@ -228,8 +228,8 @@ public class AbstractJavaEsSparkStreamingTest implements Serializable {
         Map<String, String> localConf = new HashMap<>(cfg);
         localConf.put("es.mapping.id", "number");
 
-        String target = wrapIndex(resource("spark-streaming-test-scala-id-write", "data"));
-        String docEndpoint = wrapIndex(docPath("spark-streaming-test-scala-id-write", "data"));
+        String target = wrapIndex(resource("spark-streaming-test-scala-id-write", "data", version));
+        String docEndpoint = wrapIndex(docEndpoint("spark-streaming-test-scala-id-write", "data", version));
 
         JavaRDD<Map<String,Object>> batch = sc.parallelize(docs);
         Queue<JavaRDD<Map<String, Object>>> rddQueue = new LinkedList<>();
@@ -266,8 +266,8 @@ public class AbstractJavaEsSparkStreamingTest implements Serializable {
         docs.add(doc1);
         docs.add(doc2);
 
-        String target = wrapIndex(resource("spark-streaming-test-scala-dyn-id-write", "data"));
-        String docEndpoint = wrapIndex(docPath("spark-streaming-test-scala-dyn-id-write", "data"));
+        String target = wrapIndex(resource("spark-streaming-test-scala-dyn-id-write", "data", version));
+        String docEndpoint = wrapIndex(docEndpoint("spark-streaming-test-scala-dyn-id-write", "data", version));
 
         JavaRDD<Map<String,Object>> batch = sc.parallelize(docs);
         Queue<JavaRDD<Map<String, Object>>> rddQueue = new LinkedList<>();
@@ -317,8 +317,8 @@ public class AbstractJavaEsSparkStreamingTest implements Serializable {
         docs.add(doc1);
         docs.add(doc2);
 
-        String target = wrapIndex(resource("spark-streaming-test-scala-dyn-id-write-map", "data"));
-        String docEndpoint = wrapIndex(docPath("spark-streaming-test-scala-dyn-id-write-map", "data"));
+        String target = wrapIndex(resource("spark-streaming-test-scala-dyn-id-write-map", "data", version));
+        String docEndpoint = wrapIndex(docEndpoint("spark-streaming-test-scala-dyn-id-write-map", "data", version));
 
         JavaRDD<Map<String,Object>> batch = sc.parallelize(docs);
         Queue<JavaRDD<Map<String, Object>>> rddQueue = new LinkedList<>();
@@ -365,7 +365,7 @@ public class AbstractJavaEsSparkStreamingTest implements Serializable {
         docs.add(trip1);
         docs.add(trip2);
 
-        String target = wrapIndex(resource("spark-streaming-test-scala-write-exclude", "data"));
+        String target = wrapIndex(resource("spark-streaming-test-scala-write-exclude", "data", version));
 
         Map<String, String> localConf = new HashMap<>(cfg);
         localConf.put(ES_MAPPING_EXCLUDE, "airport");
@@ -410,7 +410,7 @@ public class AbstractJavaEsSparkStreamingTest implements Serializable {
         docs.add(doc1);
         docs.add(doc2);
 
-        String target = wrapIndex(resource("spark-streaming-test-scala-ingest-write", "data"));
+        String target = wrapIndex(resource("spark-streaming-test-scala-ingest-write", "data", version));
 
         Map<String, String> localConf = new HashMap<>(cfg);
         localConf.put(ES_INGEST_PIPELINE, pipelineName);
@@ -443,7 +443,7 @@ public class AbstractJavaEsSparkStreamingTest implements Serializable {
         docs.add(trip1);
         docs.add(trip2);
 
-        String target = wrapIndex(resource("spark-streaming-test-trip-{airport}", "data"));
+        String target = wrapIndex(resource("spark-streaming-test-trip-{airport}", "data", version));
 
         JavaRDD<Map<String, Object>> batch = sc.parallelize(docs);
         Queue<JavaRDD<Map<String, Object>>> rddQueue = new LinkedList<>();
@@ -454,11 +454,11 @@ public class AbstractJavaEsSparkStreamingTest implements Serializable {
         TimeUnit.SECONDS.sleep(2);
         ssc.stop(false, true);
 
-        assertTrue(RestUtils.exists(wrapIndex(resource("spark-streaming-test-trip-otp", "data"))));
-        assertTrue(RestUtils.exists(wrapIndex(resource("spark-streaming-test-trip-sfo", "data"))));
+        assertTrue(RestUtils.exists(wrapIndex(resource("spark-streaming-test-trip-otp", "data", version))));
+        assertTrue(RestUtils.exists(wrapIndex(resource("spark-streaming-test-trip-sfo", "data", version))));
 
-        assertThat(RestUtils.get(wrapIndex(resource("spark-streaming-test-trip-sfo", "data") + "/_search?")), containsString("business"));
-        assertThat(RestUtils.get(wrapIndex(resource("spark-streaming-test-trip-otp", "data") + "/_search?")), containsString("participants"));
+        assertThat(RestUtils.get(wrapIndex(resource("spark-streaming-test-trip-sfo", "data", version) + "/_search?")), containsString("business"));
+        assertThat(RestUtils.get(wrapIndex(resource("spark-streaming-test-trip-otp", "data", version) + "/_search?")), containsString("participants"));
     }
 
     @Test
@@ -470,7 +470,7 @@ public class AbstractJavaEsSparkStreamingTest implements Serializable {
         docs.add(json1);
         docs.add(json2);
 
-        String jsonTarget = wrapIndex(resource("spark-streaming-test-json-{airport}", "data"));
+        String jsonTarget = wrapIndex(resource("spark-streaming-test-json-{airport}", "data", version));
 
         JavaRDD<String> batch1 = sc.parallelize(docs);
         Queue<JavaRDD<String>> rddQueue1 = new LinkedList<>();
@@ -489,7 +489,7 @@ public class AbstractJavaEsSparkStreamingTest implements Serializable {
         byteDocs.add(json1BA);
         byteDocs.add(json2BA);
 
-        String jsonBATarget = wrapIndex(resource("spark-streaming-test-json-ba-{airport}", "data"));
+        String jsonBATarget = wrapIndex(resource("spark-streaming-test-json-ba-{airport}", "data", version));
 
         JavaRDD<byte[]> batch2 = sc.parallelize(byteDocs);
         Queue<JavaRDD<byte[]>> rddQueue2 = new LinkedList<>();
@@ -500,14 +500,14 @@ public class AbstractJavaEsSparkStreamingTest implements Serializable {
         TimeUnit.SECONDS.sleep(2);
         ssc.stop(false, true);
 
-        assertTrue(RestUtils.exists(wrapIndex(resource("spark-streaming-test-json-sfo", "data"))));
-        assertTrue(RestUtils.exists(wrapIndex(resource("spark-streaming-test-json-otp", "data"))));
+        assertTrue(RestUtils.exists(wrapIndex(resource("spark-streaming-test-json-sfo", "data", version))));
+        assertTrue(RestUtils.exists(wrapIndex(resource("spark-streaming-test-json-otp", "data", version))));
 
-        assertTrue(RestUtils.exists(wrapIndex(resource("spark-streaming-test-json-ba-sfo", "data"))));
-        assertTrue(RestUtils.exists(wrapIndex(resource("spark-streaming-test-json-ba-otp", "data"))));
+        assertTrue(RestUtils.exists(wrapIndex(resource("spark-streaming-test-json-ba-sfo", "data", version))));
+        assertTrue(RestUtils.exists(wrapIndex(resource("spark-streaming-test-json-ba-otp", "data", version))));
 
-        assertThat(RestUtils.get(wrapIndex(resource("spark-streaming-test-json-sfo", "data") + "/_search?")), containsString("business"));
-        assertThat(RestUtils.get(wrapIndex(resource("spark-streaming-test-json-otp", "data") + "/_search?")), containsString("participants"));
+        assertThat(RestUtils.get(wrapIndex(resource("spark-streaming-test-json-sfo", "data", version) + "/_search?")), containsString("business"));
+        assertThat(RestUtils.get(wrapIndex(resource("spark-streaming-test-json-otp", "data", version) + "/_search?")), containsString("participants"));
     }
 
     @Test
@@ -523,8 +523,8 @@ public class AbstractJavaEsSparkStreamingTest implements Serializable {
         }
         String index = wrapIndex("spark-streaming-test-contact");
         String type = "data";
-        String target = resource(index, type);
-        String docEndpoint = docPath(index, type);
+        String target = resource(index, type, version);
+        String docEndpoint = docEndpoint(index, type, version);
 
         RestUtils.touch(index);
         RestUtils.putMapping(index, type, mapping.getBytes());
@@ -595,22 +595,6 @@ public class AbstractJavaEsSparkStreamingTest implements Serializable {
 
         assertTrue(RestUtils.exists(docEndpoint + "/2"));
         assertThat(RestUtils.get(docEndpoint + "/2"), both(not(containsString("\"zipcode\":\"12345\""))).and(containsString("\"note\":\"Second\"")));
-    }
-
-    private String resource(String index, String type) {
-        if (TestUtils.isTypelessVersion(version)) {
-            return index;
-        } else {
-            return index + "/" + type;
-        }
-    }
-
-    private String docPath(String index, String type) {
-        if (TestUtils.isTypelessVersion(version)) {
-            return index + "/_doc";
-        } else {
-            return index + "/" + type;
-        }
     }
 
     private String wrapIndex(String index) {

--- a/spark/sql-20/src/itest/scala/org/elasticsearch/spark/integration/AbstractJavaEsSparkStructuredStreamingTest.java
+++ b/spark/sql-20/src/itest/scala/org/elasticsearch/spark/integration/AbstractJavaEsSparkStructuredStreamingTest.java
@@ -92,6 +92,22 @@ public class AbstractJavaEsSparkStructuredStreamingTest {
         this.commitLogDir = logDir.getAbsolutePath();
     }
 
+    private String resource(String index, String type) {
+        if (version.onOrAfter(EsMajorVersion.V_8_X)) {
+            return index;
+        } else {
+            return index + "/" + type;
+        }
+    }
+
+    private String docPath(String index, String type) {
+        if (version.onOrAfter(EsMajorVersion.V_8_X)) {
+            return index + "/_doc";
+        } else {
+            return index + "/" + type;
+        }
+    }
+
     private String wrapIndex(String index) {
         return prefix + index;
     }
@@ -126,7 +142,7 @@ public class AbstractJavaEsSparkStructuredStreamingTest {
 
     @Test(expected = EsHadoopIllegalArgumentException.class)
     public void test0FailOnIndexCreationDisabled() throws Exception {
-        String target = wrapIndex("test-nonexisting/data");
+        String target = wrapIndex(resource("test-nonexisting", "data"));
         JavaStreamingQueryTestHarness<RecordBean> test = new JavaStreamingQueryTestHarness<>(spark, Encoders.bean(RecordBean.class));
 
         RecordBean doc1 = new RecordBean();
@@ -161,7 +177,7 @@ public class AbstractJavaEsSparkStructuredStreamingTest {
 
     @Test
     public void test1BasicWrite() throws Exception {
-        String target = wrapIndex("test-write/data");
+        String target = wrapIndex(resource("test-write", "data"));
         JavaStreamingQueryTestHarness<RecordBean> test = new JavaStreamingQueryTestHarness<>(spark, Encoders.bean(RecordBean.class));
 
         RecordBean doc1 = new RecordBean();
@@ -197,7 +213,8 @@ public class AbstractJavaEsSparkStructuredStreamingTest {
 
     @Test
     public void test1WriteWithMappingId() throws Exception {
-        String target = wrapIndex("test-write-id/data");
+        String target = wrapIndex(resource("test-write-id", "data"));
+        String docEndpoint = wrapIndex(docPath("test-write-id", "data"));
         JavaStreamingQueryTestHarness<RecordBean> test = new JavaStreamingQueryTestHarness<>(spark, Encoders.bean(RecordBean.class));
 
         RecordBean doc1 = new RecordBean();
@@ -227,16 +244,16 @@ public class AbstractJavaEsSparkStructuredStreamingTest {
         );
 
         assertEquals(3, JavaEsSpark.esRDD(new JavaSparkContext(spark.sparkContext()), target).count());
-        assertTrue(RestUtils.exists(target + "/1"));
-        assertTrue(RestUtils.exists(target + "/2"));
-        assertTrue(RestUtils.exists(target + "/3"));
+        assertTrue(RestUtils.exists(docEndpoint + "/1"));
+        assertTrue(RestUtils.exists(docEndpoint + "/2"));
+        assertTrue(RestUtils.exists(docEndpoint + "/3"));
 
         assertThat(RestUtils.get(target + "/_search?"), containsString("Spark"));
     }
 
     @Test
     public void test1WriteWithMappingExclude() throws Exception {
-        String target = wrapIndex("test-mapping-exclude/data");
+        String target = wrapIndex(resource("test-mapping-exclude", "data"));
         JavaStreamingQueryTestHarness<RecordBean> test = new JavaStreamingQueryTestHarness<>(spark, Encoders.bean(RecordBean.class));
 
         RecordBean doc1 = new RecordBean();
@@ -279,7 +296,7 @@ public class AbstractJavaEsSparkStructuredStreamingTest {
         String pipeline = "{\"description\":\"Test Pipeline\",\"processors\":[{\"set\":{\"field\":\"pipeTEST\",\"value\":true,\"override\":true}}]}";
         RestUtils.put("/_ingest/pipeline/" + pipelineName, StringUtils.toUTF(pipeline));
 
-        String target = wrapIndex("test-write-ingest/data");
+        String target = wrapIndex(resource("test-write-ingest", "data"));
         JavaStreamingQueryTestHarness<RecordBean> test = new JavaStreamingQueryTestHarness<>(spark, Encoders.bean(RecordBean.class));
 
         RecordBean doc1 = new RecordBean();
@@ -315,7 +332,7 @@ public class AbstractJavaEsSparkStructuredStreamingTest {
 
     @Test
     public void test1MultiIndexWrite() throws Exception {
-        String target = wrapIndex("test-write-tech-{name}/data");
+        String target = wrapIndex(resource("test-write-tech-{name}", "data"));
         JavaStreamingQueryTestHarness<RecordBean> test = new JavaStreamingQueryTestHarness<>(spark, Encoders.bean(RecordBean.class));
 
         RecordBean doc1 = new RecordBean();
@@ -338,11 +355,11 @@ public class AbstractJavaEsSparkStructuredStreamingTest {
                 target
         );
 
-        assertTrue(RestUtils.exists(wrapIndex("test-write-tech-spark/data")));
-        assertTrue(RestUtils.exists(wrapIndex("test-write-tech-hadoop/data")));
+        assertTrue(RestUtils.exists(wrapIndex(resource("test-write-tech-spark", "data"))));
+        assertTrue(RestUtils.exists(wrapIndex(resource("test-write-tech-hadoop", "data"))));
 
-        assertThat(RestUtils.get(wrapIndex("test-write-tech-spark/data/_search?")), containsString("\"name\":\"spark\""));
-        assertThat(RestUtils.get(wrapIndex("test-write-tech-hadoop/data/_search?")), containsString("\"name\":\"hadoop\""));
+        assertThat(RestUtils.get(wrapIndex(resource("test-write-tech-spark", "data") + "/_search?")), containsString("\"name\":\"spark\""));
+        assertThat(RestUtils.get(wrapIndex(resource("test-write-tech-hadoop", "data") + "/_search?")), containsString("\"name\":\"hadoop\""));
     }
 
     public static class ContactBean implements Serializable {
@@ -411,12 +428,13 @@ public class AbstractJavaEsSparkStructuredStreamingTest {
         String mapping = "{\"data\":{\"properties\":{\"id\":{\"type\":\""+keyword+"\"},\"note\":{\"type\":\""+keyword+"\"},\"address\":{\"type\":\"nested\",\"properties\":{\"id\":{\"type\":\""+keyword+"\"},\"zipcode\":{\"type\":\""+keyword+"\"}}}}}}";
         String index = wrapIndex("test-script-upsert");
         String type = "data";
-        String target = index + "/" + type;
+        String target = resource(index, type);
+        String docEndpoint = docPath(index, type);
 
         RestUtils.touch(index);
         RestUtils.putMapping(index, type, mapping.getBytes());
-        RestUtils.postData(target+"/1", "{\"id\":\"1\",\"note\":\"First\",\"address\":[]}".getBytes());
-        RestUtils.postData(target+"/2", "{\"id\":\"2\",\"note\":\"First\",\"address\":[]}".getBytes());
+        RestUtils.postData(docEndpoint+"/1", "{\"id\":\"1\",\"note\":\"First\",\"address\":[]}".getBytes());
+        RestUtils.postData(docEndpoint+"/2", "{\"id\":\"2\",\"note\":\"First\",\"address\":[]}".getBytes());
 
         // Common configurations
         Map<String, String> updateProperties = new HashMap<>();
@@ -488,10 +506,10 @@ public class AbstractJavaEsSparkStructuredStreamingTest {
             );
 
         // Validate
-        assertTrue(RestUtils.exists(target + "/1"));
-        assertThat(RestUtils.get(target + "/1"), both(containsString("\"zipcode\":\"12345\"")).and(containsString("\"note\":\"First\"")));
+        assertTrue(RestUtils.exists(docEndpoint + "/1"));
+        assertThat(RestUtils.get(docEndpoint + "/1"), both(containsString("\"zipcode\":\"12345\"")).and(containsString("\"note\":\"First\"")));
 
-        assertTrue(RestUtils.exists(target + "/2"));
-        assertThat(RestUtils.get(target + "/2"), both(not(containsString("\"zipcode\":\"12345\""))).and(containsString("\"note\":\"Second\"")));
+        assertTrue(RestUtils.exists(docEndpoint + "/2"));
+        assertThat(RestUtils.get(docEndpoint + "/2"), both(not(containsString("\"zipcode\":\"12345\""))).and(containsString("\"note\":\"Second\"")));
     }
 }

--- a/spark/sql-20/src/itest/scala/org/elasticsearch/spark/integration/AbstractJavaEsSparkStructuredStreamingTest.java
+++ b/spark/sql-20/src/itest/scala/org/elasticsearch/spark/integration/AbstractJavaEsSparkStructuredStreamingTest.java
@@ -93,7 +93,7 @@ public class AbstractJavaEsSparkStructuredStreamingTest {
     }
 
     private String resource(String index, String type) {
-        if (version.onOrAfter(EsMajorVersion.V_8_X)) {
+        if (TestUtils.isTypelessVersion(version)) {
             return index;
         } else {
             return index + "/" + type;
@@ -101,7 +101,7 @@ public class AbstractJavaEsSparkStructuredStreamingTest {
     }
 
     private String docPath(String index, String type) {
-        if (version.onOrAfter(EsMajorVersion.V_8_X)) {
+        if (TestUtils.isTypelessVersion(version)) {
             return index + "/_doc";
         } else {
             return index + "/" + type;

--- a/spark/sql-20/src/itest/scala/org/elasticsearch/spark/integration/AbstractJavaEsSparkStructuredStreamingTest.java
+++ b/spark/sql-20/src/itest/scala/org/elasticsearch/spark/integration/AbstractJavaEsSparkStructuredStreamingTest.java
@@ -214,7 +214,7 @@ public class AbstractJavaEsSparkStructuredStreamingTest {
     @Test
     public void test1WriteWithMappingId() throws Exception {
         String target = wrapIndex(resource("test-write-id", "data"));
-        String docEndpoint = wrapIndex(docPath("test-write-id", "data"));
+        String docPath = wrapIndex(docPath("test-write-id", "data"));
         JavaStreamingQueryTestHarness<RecordBean> test = new JavaStreamingQueryTestHarness<>(spark, Encoders.bean(RecordBean.class));
 
         RecordBean doc1 = new RecordBean();
@@ -244,9 +244,9 @@ public class AbstractJavaEsSparkStructuredStreamingTest {
         );
 
         assertEquals(3, JavaEsSpark.esRDD(new JavaSparkContext(spark.sparkContext()), target).count());
-        assertTrue(RestUtils.exists(docEndpoint + "/1"));
-        assertTrue(RestUtils.exists(docEndpoint + "/2"));
-        assertTrue(RestUtils.exists(docEndpoint + "/3"));
+        assertTrue(RestUtils.exists(docPath + "/1"));
+        assertTrue(RestUtils.exists(docPath + "/2"));
+        assertTrue(RestUtils.exists(docPath + "/3"));
 
         assertThat(RestUtils.get(target + "/_search?"), containsString("Spark"));
     }
@@ -429,12 +429,12 @@ public class AbstractJavaEsSparkStructuredStreamingTest {
         String index = wrapIndex("test-script-upsert");
         String type = "data";
         String target = resource(index, type);
-        String docEndpoint = docPath(index, type);
+        String docPath = docPath(index, type);
 
         RestUtils.touch(index);
         RestUtils.putMapping(index, type, mapping.getBytes());
-        RestUtils.postData(docEndpoint+"/1", "{\"id\":\"1\",\"note\":\"First\",\"address\":[]}".getBytes());
-        RestUtils.postData(docEndpoint+"/2", "{\"id\":\"2\",\"note\":\"First\",\"address\":[]}".getBytes());
+        RestUtils.postData(docPath+"/1", "{\"id\":\"1\",\"note\":\"First\",\"address\":[]}".getBytes());
+        RestUtils.postData(docPath+"/2", "{\"id\":\"2\",\"note\":\"First\",\"address\":[]}".getBytes());
 
         // Common configurations
         Map<String, String> updateProperties = new HashMap<>();
@@ -506,10 +506,10 @@ public class AbstractJavaEsSparkStructuredStreamingTest {
             );
 
         // Validate
-        assertTrue(RestUtils.exists(docEndpoint + "/1"));
-        assertThat(RestUtils.get(docEndpoint + "/1"), both(containsString("\"zipcode\":\"12345\"")).and(containsString("\"note\":\"First\"")));
+        assertTrue(RestUtils.exists(docPath + "/1"));
+        assertThat(RestUtils.get(docPath + "/1"), both(containsString("\"zipcode\":\"12345\"")).and(containsString("\"note\":\"First\"")));
 
-        assertTrue(RestUtils.exists(docEndpoint + "/2"));
-        assertThat(RestUtils.get(docEndpoint + "/2"), both(not(containsString("\"zipcode\":\"12345\""))).and(containsString("\"note\":\"Second\"")));
+        assertTrue(RestUtils.exists(docPath + "/2"));
+        assertThat(RestUtils.get(docPath + "/2"), both(not(containsString("\"zipcode\":\"12345\""))).and(containsString("\"note\":\"Second\"")));
     }
 }

--- a/spark/sql-20/src/itest/scala/org/elasticsearch/spark/integration/AbstractScalaEsScalaSparkStreaming.scala
+++ b/spark/sql-20/src/itest/scala/org/elasticsearch/spark/integration/AbstractScalaEsScalaSparkStreaming.scala
@@ -415,7 +415,7 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
   }
 
   def resource(index: String, typeName: String): String = {
-    if (version.onOrAfter(EsMajorVersion.V_8_X)) {
+    if (TestUtils.isTypelessVersion(version)) {
       index
     } else {
       s"$index/$typeName"
@@ -423,7 +423,7 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
   }
 
   def docPath(index: String, typeName: String): String = {
-    if (version.onOrAfter(EsMajorVersion.V_8_X)) {
+    if (TestUtils.isTypelessVersion(version)) {
       s"$index/_doc"
     } else {
       s"$index/$typeName"
@@ -435,7 +435,7 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
   }
 
   def wrapMapping(typename: String, mapping: String): String = {
-    if (version.onOrAfter(EsMajorVersion.V_7_X)) {
+    if (TestUtils.isTypelessVersion(version)) {
       mapping
     } else {
       s"""{"$typename":$mapping}"""

--- a/spark/sql-20/src/itest/scala/org/elasticsearch/spark/integration/AbstractScalaEsScalaSparkStreaming.scala
+++ b/spark/sql-20/src/itest/scala/org/elasticsearch/spark/integration/AbstractScalaEsScalaSparkStreaming.scala
@@ -32,6 +32,8 @@ import org.elasticsearch.hadoop.cfg.ConfigurationOptions._
 import org.elasticsearch.hadoop.mr.EsAssume
 import org.elasticsearch.hadoop.mr.RestUtils
 import org.elasticsearch.hadoop.util.TestUtils
+import org.elasticsearch.hadoop.util.TestUtils.resource
+import org.elasticsearch.hadoop.util.TestUtils.docEndpoint
 import org.elasticsearch.hadoop.util.{EsMajorVersion, StringUtils, TestSettings}
 import org.elasticsearch.spark.rdd.EsSpark
 import org.elasticsearch.spark.rdd.Metadata._
@@ -111,7 +113,7 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
     val doc1 = Map("one" -> null, "two" -> Set("2"), "three" -> (".", "..", "..."))
     val doc2 = Map("OTP" -> "Otopeni", "SFO" -> "San Fran")
 
-    val target = wrapIndex(resource("spark-test-nonexisting-scala-basic-write", "data"))
+    val target = wrapIndex(resource("spark-test-nonexisting-scala-basic-write", "data", version))
 
     val batch = sc.makeRDD(Seq(doc1, doc2))
     runStream(batch)(_.saveToEs(target, cfg + (ES_INDEX_AUTO_CREATE -> "no")))
@@ -125,7 +127,7 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
     val doc1 = Map("one" -> null, "two" -> Set("2"), "three" ->(".", "..", "..."))
     val doc2 = Map("OTP" -> "Otopeni", "SFO" -> "San Fran")
 
-    val target = wrapIndex(resource("spark-streaming-test-scala-basic-write", "data"))
+    val target = wrapIndex(resource("spark-streaming-test-scala-basic-write", "data", version))
 
     val batch = sc.makeRDD(Seq(doc1, doc2))
 
@@ -141,7 +143,7 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
     val expected = ExpectingToThrow(classOf[SparkException]).from(ssc)
     val doc = Map("itemId" -> "1", "map" -> Map("lat" -> 1.23, "lon" -> -70.12), "list" -> ("A", "B", "C"), "unknown" -> new Garbage(0))
     val batch = sc.makeRDD(Seq(doc))
-    runStream(batch)(_.saveToEs(wrapIndex(resource("spark-streaming-test-nested-map", "data")), cfg))
+    runStream(batch)(_.saveToEs(wrapIndex(resource("spark-streaming-test-nested-map", "data", version)), cfg))
     expected.assertExceptionFound()
   }
 
@@ -153,7 +155,7 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
 
     val vals = ReflectionUtils.caseClassValues(caseClass2)
 
-    val target = wrapIndex(resource("spark-streaming-test-scala-basic-write-objects", "data"))
+    val target = wrapIndex(resource("spark-streaming-test-scala-basic-write-objects", "data", version))
 
     val batch = sc.makeRDD(Seq(javaBean, caseClass1))
     runStreamRecoverably(batch)(_.saveToEs(target, cfg))
@@ -171,15 +173,15 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
     val doc1 = Map("one" -> null, "two" -> Set("2"), "three" -> (".", "..", "..."), "number" -> 1)
     val doc2 = Map("OTP" -> "Otopeni", "SFO" -> "San Fran", "number" -> 2)
 
-    val target = wrapIndex(resource("spark-streaming-test-scala-id-write", "data"))
-    val docEndpoint = wrapIndex(docPath("spark-streaming-test-scala-id-write", "data"))
+    val target = wrapIndex(resource("spark-streaming-test-scala-id-write", "data", version))
+    val docPath = wrapIndex(docEndpoint("spark-streaming-test-scala-id-write", "data", version))
 
     val batch = sc.makeRDD(Seq(doc1, doc2))
     runStream(batch)(_.saveToEs(target, Map(ES_MAPPING_ID -> "number")))
 
     assertEquals(2, EsSpark.esRDD(sc, target).count())
-    assertTrue(RestUtils.exists(docEndpoint + "/1"))
-    assertTrue(RestUtils.exists(docEndpoint + "/2"))
+    assertTrue(RestUtils.exists(docPath + "/1"))
+    assertTrue(RestUtils.exists(docPath + "/2"))
 
     assertThat(RestUtils.get(target + "/_search?"), containsString("SFO"))
   }
@@ -189,8 +191,8 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
     val doc1 = Map("one" -> null, "two" -> Set("2"), "three" -> (".", "..", "..."), "number" -> 1)
     val doc2 = Map("OTP" -> "Otopeni", "SFO" -> "San Fran", "number" -> 2)
 
-    val target = wrapIndex(resource("spark-streaming-test-scala-dyn-id-write", "data"))
-    val docEndpoint = wrapIndex(docPath("spark-streaming-test-scala-dyn-id-write", "data"))
+    val target = wrapIndex(resource("spark-streaming-test-scala-dyn-id-write", "data", version))
+    val docPath = wrapIndex(docEndpoint("spark-streaming-test-scala-dyn-id-write", "data", version))
 
     val pairRDD = sc.makeRDD(Seq((3, doc1), (4, doc2)))
     runStream(pairRDD)(_.saveToEsWithMeta(target, cfg))
@@ -198,8 +200,8 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
     println(RestUtils.get(target + "/_search?"))
 
     assertEquals(2, EsSpark.esRDD(sc, target).count())
-    assertTrue(RestUtils.exists(docEndpoint + "/3"))
-    assertTrue(RestUtils.exists(docEndpoint + "/4"))
+    assertTrue(RestUtils.exists(docPath + "/3"))
+    assertTrue(RestUtils.exists(docPath + "/4"))
 
     assertThat(RestUtils.get(target + "/_search?"), containsString("SFO"))
   }
@@ -209,8 +211,8 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
     val doc1 = Map("one" -> null, "two" -> Set("2"), "three" -> (".", "..", "..."), "number" -> 1)
     val doc2 = Map("OTP" -> "Otopeni", "SFO" -> "San Fran", "number" -> 2)
 
-    val target = wrapIndex(resource("spark-streaming-test-scala-dyn-id-write-map", "data"))
-    val docEndpoint = wrapIndex(docPath("spark-streaming-test-scala-dyn-id-write-map", "data"))
+    val target = wrapIndex(resource("spark-streaming-test-scala-dyn-id-write-map", "data", version))
+    val docPath = wrapIndex(docEndpoint("spark-streaming-test-scala-dyn-id-write-map", "data", version))
 
     val metadata1 = Map(ID -> 5)
     val metadata2 = Map(ID -> 6, VERSION -> "23")
@@ -222,8 +224,8 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
 
     runStream(pairRDD)(_.saveToEsWithMeta(target, cfg))
 
-    assertTrue(RestUtils.exists(docEndpoint + "/5"))
-    assertTrue(RestUtils.exists(docEndpoint + "/6"))
+    assertTrue(RestUtils.exists(docPath + "/5"))
+    assertTrue(RestUtils.exists(docPath + "/6"))
 
     assertThat(RestUtils.get(target + "/_search?"), containsString("SFO"))
   }
@@ -233,7 +235,7 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
     val trip1 = Map("reason" -> "business", "airport" -> "SFO")
     val trip2 = Map("participants" -> 5, "airport" -> "OTP")
 
-    val target = wrapIndex(resource("spark-streaming-test-scala-write-exclude", "data"))
+    val target = wrapIndex(resource("spark-streaming-test-scala-write-exclude", "data", version))
 
     val batch = sc.makeRDD(Seq(trip1, trip2))
     runStream(batch)(_.saveToEs(target, Map(ES_MAPPING_EXCLUDE -> "airport")))
@@ -257,7 +259,7 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
     val doc1 = Map("one" -> null, "two" -> Set("2"), "three" -> (".", "..", "..."))
     val doc2 = Map("OTP" -> "Otopeni", "SFO" -> "San Fran")
 
-    val target = wrapIndex(resource("spark-streaming-test-scala-ingest-write", "data"))
+    val target = wrapIndex(resource("spark-streaming-test-scala-ingest-write", "data", version))
 
     val ingestCfg = cfg + (ConfigurationOptions.ES_INGEST_PIPELINE -> pipelineName) + (ConfigurationOptions.ES_NODES_INGEST_ONLY -> "true")
 
@@ -274,15 +276,15 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
     val trip1 = Map("reason" -> "business", "airport" -> "sfo")
     val trip2 = Map("participants" -> 5, "airport" -> "otp")
 
-    val target = wrapIndex(resource("spark-streaming-test-trip-{airport}", "data"))
+    val target = wrapIndex(resource("spark-streaming-test-trip-{airport}", "data", version))
     val batch = sc.makeRDD(Seq(trip1, trip2))
     runStream(batch)(_.saveToEs(target, cfg))
 
-    assertTrue(RestUtils.exists(wrapIndex(resource("spark-streaming-test-trip-otp", "data"))))
-    assertTrue(RestUtils.exists(wrapIndex(resource("spark-streaming-test-trip-sfo", "data"))))
+    assertTrue(RestUtils.exists(wrapIndex(resource("spark-streaming-test-trip-otp", "data", version))))
+    assertTrue(RestUtils.exists(wrapIndex(resource("spark-streaming-test-trip-sfo", "data", version))))
 
-    assertThat(RestUtils.get(wrapIndex(resource("spark-streaming-test-trip-sfo", "data") + "/_search?")), containsString("business"))
-    assertThat(RestUtils.get(wrapIndex(resource("spark-streaming-test-trip-otp", "data") + "/_search?")), containsString("participants"))
+    assertThat(RestUtils.get(wrapIndex(resource("spark-streaming-test-trip-sfo", "data", version) + "/_search?")), containsString("business"))
+    assertThat(RestUtils.get(wrapIndex(resource("spark-streaming-test-trip-otp", "data", version) + "/_search?")), containsString("participants"))
   }
 
   @Test
@@ -291,22 +293,22 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
     val json2 = "{\"participants\" : 5,\"airport\" : \"otp\"}"
 
     val batch = sc.makeRDD(Seq(json1, json2))
-    runStreamRecoverably(batch)(_.saveJsonToEs(wrapIndex(resource("spark-streaming-test-json-{airport}", "data")), cfg))
+    runStreamRecoverably(batch)(_.saveJsonToEs(wrapIndex(resource("spark-streaming-test-json-{airport}", "data", version)), cfg))
 
     val json1BA = json1.getBytes()
     val json2BA = json2.getBytes()
 
     val batch2 = sc.makeRDD(Seq(json1BA, json2BA))
-    runStream(batch2)(_.saveJsonToEs(wrapIndex(resource("spark-streaming-test-json-ba-{airport}", "data")), cfg))
+    runStream(batch2)(_.saveJsonToEs(wrapIndex(resource("spark-streaming-test-json-ba-{airport}", "data", version)), cfg))
 
-    assertTrue(RestUtils.exists(wrapIndex(resource("spark-streaming-test-json-sfo", "data"))))
-    assertTrue(RestUtils.exists(wrapIndex(resource("spark-streaming-test-json-otp", "data"))))
+    assertTrue(RestUtils.exists(wrapIndex(resource("spark-streaming-test-json-sfo", "data", version))))
+    assertTrue(RestUtils.exists(wrapIndex(resource("spark-streaming-test-json-otp", "data", version))))
 
-    assertTrue(RestUtils.exists(wrapIndex(resource("spark-streaming-test-json-ba-sfo", "data"))))
-    assertTrue(RestUtils.exists(wrapIndex(resource("spark-streaming-test-json-ba-otp", "data"))))
+    assertTrue(RestUtils.exists(wrapIndex(resource("spark-streaming-test-json-ba-sfo", "data", version))))
+    assertTrue(RestUtils.exists(wrapIndex(resource("spark-streaming-test-json-ba-otp", "data", version))))
 
-    assertThat(RestUtils.get(wrapIndex(resource("spark-streaming-test-json-sfo", "data") + "/_search?")), containsString("business"))
-    assertThat(RestUtils.get(wrapIndex(resource("spark-streaming-test-json-otp", "data") + "/_search?")), containsString("participants"))
+    assertThat(RestUtils.get(wrapIndex(resource("spark-streaming-test-json-sfo", "data", version) + "/_search?")), containsString("business"))
+    assertThat(RestUtils.get(wrapIndex(resource("spark-streaming-test-json-otp", "data", version) + "/_search?")), containsString("participants"))
   }
 
   @Test
@@ -331,13 +333,13 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
 
     val index = "spark-streaming-test-contact"
     val typed = "data"
-    val target = resource(index, typed)
-    val docEndpoint = docPath(index, typed)
+    val target = resource(index, typed, version)
+    val docPath = docEndpoint(index, typed, version)
 
     RestUtils.touch(index)
     RestUtils.putMapping(index, typed, mapping.getBytes(StringUtils.UTF_8))
-    RestUtils.postData(s"$docEndpoint/1", """{ "id" : "1", "note": "First", "address": [] }""".getBytes(StringUtils.UTF_8))
-    RestUtils.postData(s"$docEndpoint/2", """{ "id" : "2", "note": "First", "address": [] }""".getBytes(StringUtils.UTF_8))
+    RestUtils.postData(s"$docPath/1", """{ "id" : "1", "note": "First", "address": [] }""".getBytes(StringUtils.UTF_8))
+    RestUtils.postData(s"$docPath/2", """{ "id" : "2", "note": "First", "address": [] }""".getBytes(StringUtils.UTF_8))
 
     val lang = if (version.onOrAfter(EsMajorVersion.V_5_X)) "painless" else "groovy"
     val props = Map("es.write.operation" -> "upsert",
@@ -366,11 +368,11 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
     }
     runStream(notes)(_.saveToEs(target, props + ("es.update.script.params" -> note_up_params) + ("es.update.script" -> note_up_script)))
 
-    assertTrue(RestUtils.exists(s"$docEndpoint/1"))
-    assertThat(RestUtils.get(s"$docEndpoint/1"), both(containsString(""""zipcode":"12345"""")).and(containsString(""""note":"First"""")))
+    assertTrue(RestUtils.exists(s"$docPath/1"))
+    assertThat(RestUtils.get(s"$docPath/1"), both(containsString(""""zipcode":"12345"""")).and(containsString(""""note":"First"""")))
 
-    assertTrue(RestUtils.exists(s"$docEndpoint/2"))
-    assertThat(RestUtils.get(s"$docEndpoint/2"), both(not(containsString(""""zipcode":"12345""""))).and(containsString(""""note":"Second"""")))
+    assertTrue(RestUtils.exists(s"$docPath/2"))
+    assertThat(RestUtils.get(s"$docPath/2"), both(not(containsString(""""zipcode":"12345""""))).and(containsString(""""note":"Second"""")))
   }
 
   @Test
@@ -380,7 +382,7 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
       Map("field2" -> "bar"),
       Map("field1" -> 0.0, "field2" -> "baz")
     )
-    val target = wrapIndex(resource("spark-streaming-test-nullasempty", "data"))
+    val target = wrapIndex(resource("spark-streaming-test-nullasempty", "data", version))
     val batch = sc.makeRDD(data)
 
     runStream(batch)(_.saveToEs(target))
@@ -412,22 +414,6 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
     TimeUnit.SECONDS.sleep(2) // Let the stream processing happen
     ssc.stop(stopSparkContext = false, stopGracefully = true)
     ssc = new StreamingContext(sc, Seconds(1))
-  }
-
-  def resource(index: String, typeName: String): String = {
-    if (TestUtils.isTypelessVersion(version)) {
-      index
-    } else {
-      s"$index/$typeName"
-    }
-  }
-
-  def docPath(index: String, typeName: String): String = {
-    if (TestUtils.isTypelessVersion(version)) {
-      s"$index/_doc"
-    } else {
-      s"$index/$typeName"
-    }
   }
 
   def wrapIndex(index: String) = {

--- a/spark/sql-20/src/itest/scala/org/elasticsearch/spark/integration/AbstractScalaEsScalaSparkStreaming.scala
+++ b/spark/sql-20/src/itest/scala/org/elasticsearch/spark/integration/AbstractScalaEsScalaSparkStreaming.scala
@@ -111,7 +111,7 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
     val doc1 = Map("one" -> null, "two" -> Set("2"), "three" -> (".", "..", "..."))
     val doc2 = Map("OTP" -> "Otopeni", "SFO" -> "San Fran")
 
-    val target = wrapIndex("spark-test-nonexisting/scala-basic-write")
+    val target = wrapIndex(resource("spark-test-nonexisting-scala-basic-write", "data"))
 
     val batch = sc.makeRDD(Seq(doc1, doc2))
     runStream(batch)(_.saveToEs(target, cfg + (ES_INDEX_AUTO_CREATE -> "no")))
@@ -125,7 +125,7 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
     val doc1 = Map("one" -> null, "two" -> Set("2"), "three" ->(".", "..", "..."))
     val doc2 = Map("OTP" -> "Otopeni", "SFO" -> "San Fran")
 
-    val target = wrapIndex("spark-streaming-test-scala-basic-write/data")
+    val target = wrapIndex(resource("spark-streaming-test-scala-basic-write", "data"))
 
     val batch = sc.makeRDD(Seq(doc1, doc2))
 
@@ -141,7 +141,7 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
     val expected = ExpectingToThrow(classOf[SparkException]).from(ssc)
     val doc = Map("itemId" -> "1", "map" -> Map("lat" -> 1.23, "lon" -> -70.12), "list" -> ("A", "B", "C"), "unknown" -> new Garbage(0))
     val batch = sc.makeRDD(Seq(doc))
-    runStream(batch)(_.saveToEs(wrapIndex("spark-streaming-test-nested-map/data"), cfg))
+    runStream(batch)(_.saveToEs(wrapIndex(resource("spark-streaming-test-nested-map", "data")), cfg))
     expected.assertExceptionFound()
   }
 
@@ -153,7 +153,7 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
 
     val vals = ReflectionUtils.caseClassValues(caseClass2)
 
-    val target = wrapIndex("spark-streaming-test-scala-basic-write-objects/data")
+    val target = wrapIndex(resource("spark-streaming-test-scala-basic-write-objects", "data"))
 
     val batch = sc.makeRDD(Seq(javaBean, caseClass1))
     runStreamRecoverably(batch)(_.saveToEs(target, cfg))
@@ -171,14 +171,15 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
     val doc1 = Map("one" -> null, "two" -> Set("2"), "three" -> (".", "..", "..."), "number" -> 1)
     val doc2 = Map("OTP" -> "Otopeni", "SFO" -> "San Fran", "number" -> 2)
 
-    val target = wrapIndex("spark-streaming-test-scala-id-write/data")
+    val target = wrapIndex(resource("spark-streaming-test-scala-id-write", "data"))
+    val docEndpoint = wrapIndex(docPath("spark-streaming-test-scala-id-write", "data"))
 
     val batch = sc.makeRDD(Seq(doc1, doc2))
     runStream(batch)(_.saveToEs(target, Map(ES_MAPPING_ID -> "number")))
 
     assertEquals(2, EsSpark.esRDD(sc, target).count())
-    assertTrue(RestUtils.exists(target + "/1"))
-    assertTrue(RestUtils.exists(target + "/2"))
+    assertTrue(RestUtils.exists(docEndpoint + "/1"))
+    assertTrue(RestUtils.exists(docEndpoint + "/2"))
 
     assertThat(RestUtils.get(target + "/_search?"), containsString("SFO"))
   }
@@ -188,7 +189,8 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
     val doc1 = Map("one" -> null, "two" -> Set("2"), "three" -> (".", "..", "..."), "number" -> 1)
     val doc2 = Map("OTP" -> "Otopeni", "SFO" -> "San Fran", "number" -> 2)
 
-    val target = wrapIndex("spark-streaming-test-scala-dyn-id-write/data")
+    val target = wrapIndex(resource("spark-streaming-test-scala-dyn-id-write", "data"))
+    val docEndpoint = wrapIndex(docPath("spark-streaming-test-scala-dyn-id-write", "data"))
 
     val pairRDD = sc.makeRDD(Seq((3, doc1), (4, doc2)))
     runStream(pairRDD)(_.saveToEsWithMeta(target, cfg))
@@ -196,8 +198,8 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
     println(RestUtils.get(target + "/_search?"))
 
     assertEquals(2, EsSpark.esRDD(sc, target).count())
-    assertTrue(RestUtils.exists(target + "/3"))
-    assertTrue(RestUtils.exists(target + "/4"))
+    assertTrue(RestUtils.exists(docEndpoint + "/3"))
+    assertTrue(RestUtils.exists(docEndpoint + "/4"))
 
     assertThat(RestUtils.get(target + "/_search?"), containsString("SFO"))
   }
@@ -207,7 +209,8 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
     val doc1 = Map("one" -> null, "two" -> Set("2"), "three" -> (".", "..", "..."), "number" -> 1)
     val doc2 = Map("OTP" -> "Otopeni", "SFO" -> "San Fran", "number" -> 2)
 
-    val target = wrapIndex("spark-streaming-test-scala-dyn-id-write-map/data")
+    val target = wrapIndex(resource("spark-streaming-test-scala-dyn-id-write-map", "data"))
+    val docEndpoint = wrapIndex(docPath("spark-streaming-test-scala-dyn-id-write-map", "data"))
 
     val metadata1 = Map(ID -> 5)
     val metadata2 = Map(ID -> 6, VERSION -> "23")
@@ -219,8 +222,8 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
 
     runStream(pairRDD)(_.saveToEsWithMeta(target, cfg))
 
-    assertTrue(RestUtils.exists(target + "/5"))
-    assertTrue(RestUtils.exists(target + "/6"))
+    assertTrue(RestUtils.exists(docEndpoint + "/5"))
+    assertTrue(RestUtils.exists(docEndpoint + "/6"))
 
     assertThat(RestUtils.get(target + "/_search?"), containsString("SFO"))
   }
@@ -230,7 +233,7 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
     val trip1 = Map("reason" -> "business", "airport" -> "SFO")
     val trip2 = Map("participants" -> 5, "airport" -> "OTP")
 
-    val target = wrapIndex("spark-streaming-test-scala-write-exclude/data")
+    val target = wrapIndex(resource("spark-streaming-test-scala-write-exclude", "data"))
 
     val batch = sc.makeRDD(Seq(trip1, trip2))
     runStream(batch)(_.saveToEs(target, Map(ES_MAPPING_EXCLUDE -> "airport")))
@@ -254,7 +257,7 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
     val doc1 = Map("one" -> null, "two" -> Set("2"), "three" -> (".", "..", "..."))
     val doc2 = Map("OTP" -> "Otopeni", "SFO" -> "San Fran")
 
-    val target = wrapIndex("spark-streaming-test-scala-ingest-write/data")
+    val target = wrapIndex(resource("spark-streaming-test-scala-ingest-write", "data"))
 
     val ingestCfg = cfg + (ConfigurationOptions.ES_INGEST_PIPELINE -> pipelineName) + (ConfigurationOptions.ES_NODES_INGEST_ONLY -> "true")
 
@@ -271,15 +274,15 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
     val trip1 = Map("reason" -> "business", "airport" -> "sfo")
     val trip2 = Map("participants" -> 5, "airport" -> "otp")
 
-    val target = wrapIndex("spark-streaming-test-trip-{airport}/data")
+    val target = wrapIndex(resource("spark-streaming-test-trip-{airport}", "data"))
     val batch = sc.makeRDD(Seq(trip1, trip2))
     runStream(batch)(_.saveToEs(target, cfg))
 
-    assertTrue(RestUtils.exists(wrapIndex("spark-streaming-test-trip-otp/data")))
-    assertTrue(RestUtils.exists(wrapIndex("spark-streaming-test-trip-sfo/data")))
+    assertTrue(RestUtils.exists(wrapIndex(resource("spark-streaming-test-trip-otp", "data"))))
+    assertTrue(RestUtils.exists(wrapIndex(resource("spark-streaming-test-trip-sfo", "data"))))
 
-    assertThat(RestUtils.get(wrapIndex("spark-streaming-test-trip-sfo/data/_search?")), containsString("business"))
-    assertThat(RestUtils.get(wrapIndex("spark-streaming-test-trip-otp/data/_search?")), containsString("participants"))
+    assertThat(RestUtils.get(wrapIndex(resource("spark-streaming-test-trip-sfo", "data") + "/_search?")), containsString("business"))
+    assertThat(RestUtils.get(wrapIndex(resource("spark-streaming-test-trip-otp", "data") + "/_search?")), containsString("participants"))
   }
 
   @Test
@@ -288,22 +291,22 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
     val json2 = "{\"participants\" : 5,\"airport\" : \"otp\"}"
 
     val batch = sc.makeRDD(Seq(json1, json2))
-    runStreamRecoverably(batch)(_.saveJsonToEs(wrapIndex("spark-streaming-test-json-{airport}/data"), cfg))
+    runStreamRecoverably(batch)(_.saveJsonToEs(wrapIndex(resource("spark-streaming-test-json-{airport}", "data")), cfg))
 
     val json1BA = json1.getBytes()
     val json2BA = json2.getBytes()
 
     val batch2 = sc.makeRDD(Seq(json1BA, json2BA))
-    runStream(batch2)(_.saveJsonToEs(wrapIndex("spark-streaming-test-json-ba-{airport}/data"), cfg))
+    runStream(batch2)(_.saveJsonToEs(wrapIndex(resource("spark-streaming-test-json-ba-{airport}", "data")), cfg))
 
-    assertTrue(RestUtils.exists(wrapIndex("spark-streaming-test-json-sfo/data")))
-    assertTrue(RestUtils.exists(wrapIndex("spark-streaming-test-json-otp/data")))
+    assertTrue(RestUtils.exists(wrapIndex(resource("spark-streaming-test-json-sfo", "data"))))
+    assertTrue(RestUtils.exists(wrapIndex(resource("spark-streaming-test-json-otp", "data"))))
 
-    assertTrue(RestUtils.exists(wrapIndex("spark-streaming-test-json-ba-sfo/data")))
-    assertTrue(RestUtils.exists(wrapIndex("spark-streaming-test-json-ba-otp/data")))
+    assertTrue(RestUtils.exists(wrapIndex(resource("spark-streaming-test-json-ba-sfo", "data"))))
+    assertTrue(RestUtils.exists(wrapIndex(resource("spark-streaming-test-json-ba-otp", "data"))))
 
-    assertThat(RestUtils.get(wrapIndex("spark-streaming-test-json-sfo/data/_search?")), containsString("business"))
-    assertThat(RestUtils.get(wrapIndex("spark-streaming-test-json-otp/data/_search?")), containsString("participants"))
+    assertThat(RestUtils.get(wrapIndex(resource("spark-streaming-test-json-sfo", "data") + "/_search?")), containsString("business"))
+    assertThat(RestUtils.get(wrapIndex(resource("spark-streaming-test-json-otp", "data") + "/_search?")), containsString("participants"))
   }
 
   @Test
@@ -328,11 +331,9 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
 
     val index = "spark-streaming-test-contact"
     val typed = "data"
-    val (target, docEndpoint) = if (version.onOrAfter(EsMajorVersion.V_7_X)) {
-      (index, s"$index/_doc")
-    } else {
-      (s"$index/$typed", s"$index/$typed")
-    }
+    val target = resource(index, typed)
+    val docEndpoint = docPath(index, typed)
+
     RestUtils.touch(index)
     RestUtils.putMapping(index, typed, mapping.getBytes(StringUtils.UTF_8))
     RestUtils.postData(s"$docEndpoint/1", """{ "id" : "1", "note": "First", "address": [] }""".getBytes(StringUtils.UTF_8))
@@ -379,7 +380,7 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
       Map("field2" -> "bar"),
       Map("field1" -> 0.0, "field2" -> "baz")
     )
-    val target = wrapIndex("spark-streaming-test-nullasempty/data")
+    val target = wrapIndex(resource("spark-streaming-test-nullasempty", "data"))
     val batch = sc.makeRDD(data)
 
     runStream(batch)(_.saveToEs(target))
@@ -411,6 +412,22 @@ class AbstractScalaEsScalaSparkStreaming(val prefix: String, readMetadata: jl.Bo
     TimeUnit.SECONDS.sleep(2) // Let the stream processing happen
     ssc.stop(stopSparkContext = false, stopGracefully = true)
     ssc = new StreamingContext(sc, Seconds(1))
+  }
+
+  def resource(index: String, typeName: String): String = {
+    if (version.onOrAfter(EsMajorVersion.V_8_X)) {
+      index
+    } else {
+      s"$index/$typeName"
+    }
+  }
+
+  def docPath(index: String, typeName: String): String = {
+    if (version.onOrAfter(EsMajorVersion.V_8_X)) {
+      s"$index/_doc"
+    } else {
+      s"$index/$typeName"
+    }
   }
 
   def wrapIndex(index: String) = {

--- a/spark/sql-20/src/itest/scala/org/elasticsearch/spark/integration/AbstractScalaEsSparkSQL.scala
+++ b/spark/sql-20/src/itest/scala/org/elasticsearch/spark/integration/AbstractScalaEsSparkSQL.scala
@@ -1318,7 +1318,7 @@ class AbstractScalaEsScalaSparkSQL(prefix: String, readMetadata: jl.Boolean, pus
     val (target, docEndpoint) = makeTargets(index, typename)
     RestUtils.delete(index)
     RestUtils.touch(index)
-    if (version.onOrAfter(EsMajorVersion.V_7_X)) {
+    if (TestUtils.isTypelessVersion(version)) {
       RestUtils.putMapping(index, typename, "data/join/mapping/typeless.json")
     } else {
       RestUtils.putMapping(index, typename, "data/join/mapping/typed.json")
@@ -1615,7 +1615,7 @@ class AbstractScalaEsScalaSparkSQL(prefix: String, readMetadata: jl.Boolean, pus
       val index = wrapIndex("sparksql-test-scala-write-join-separate")
       val typename = "join"
       val (target, docEndpoint) = makeTargets(index, typename)
-      if (version.onOrAfter(EsMajorVersion.V_7_X)) {
+      if (TestUtils.isTypelessVersion(version)) {
         RestUtils.putMapping(index, typename, "data/join/mapping/typeless.json")
       } else {
         RestUtils.putMapping(index, typename, "data/join/mapping/typed.json")
@@ -1650,7 +1650,7 @@ class AbstractScalaEsScalaSparkSQL(prefix: String, readMetadata: jl.Boolean, pus
       val index = wrapIndex("sparksql-test-scala-write-join-combined")
       val typename = "join"
       val (target, docEndpoint) = makeTargets(index, typename)
-      if (version.onOrAfter(EsMajorVersion.V_7_X)) {
+      if (TestUtils.isTypelessVersion(version)) {
         RestUtils.putMapping(index, typename, "data/join/mapping/typeless.json")
       } else {
         RestUtils.putMapping(index, typename, "data/join/mapping/typed.json")
@@ -2311,7 +2311,7 @@ class AbstractScalaEsScalaSparkSQL(prefix: String, readMetadata: jl.Boolean, pus
   }
 
   def resource(index: String, typeName: String): String = {
-    if (version.onOrAfter(EsMajorVersion.V_8_X)) {
+    if (TestUtils.isTypelessVersion(version)) {
       index
     } else {
       s"$index/$typeName"
@@ -2319,7 +2319,7 @@ class AbstractScalaEsScalaSparkSQL(prefix: String, readMetadata: jl.Boolean, pus
   }
 
   def docPath(index: String, typeName: String): String = {
-    if (version.onOrAfter(EsMajorVersion.V_8_X)) {
+    if (TestUtils.isTypelessVersion(version)) {
       s"$index/_doc"
     } else {
       s"$index/$typeName"
@@ -2331,7 +2331,7 @@ class AbstractScalaEsScalaSparkSQL(prefix: String, readMetadata: jl.Boolean, pus
   }
 
   def wrapMapping(typename: String, mapping: String): String = {
-    if (version.onOrAfter(EsMajorVersion.V_7_X)) {
+    if (TestUtils.isTypelessVersion(version)) {
       mapping
     } else {
       s"""{"$typename":$mapping}"""
@@ -2339,10 +2339,10 @@ class AbstractScalaEsScalaSparkSQL(prefix: String, readMetadata: jl.Boolean, pus
   }
 
   def makeTargets(index: String, typeName: String): (String, String) = {
-    if (version.onOrBefore(EsMajorVersion.V_6_X)) {
-      (s"$index/$typeName", s"$index/$typeName")
-    } else {
+    if (TestUtils.isTypelessVersion(version)) {
       (index, s"$index/_doc")
+    } else {
+      (s"$index/$typeName", s"$index/$typeName")
     }
   }
 

--- a/spark/sql-20/src/itest/scala/org/elasticsearch/spark/integration/AbstractScalaEsSparkSQL.scala
+++ b/spark/sql-20/src/itest/scala/org/elasticsearch/spark/integration/AbstractScalaEsSparkSQL.scala
@@ -56,6 +56,8 @@ import org.elasticsearch.hadoop.mr.RestUtils
 import org.elasticsearch.hadoop.util.StringUtils
 import org.elasticsearch.hadoop.util.TestSettings
 import org.elasticsearch.hadoop.util.TestUtils
+import org.elasticsearch.hadoop.util.TestUtils.resource
+import org.elasticsearch.hadoop.util.TestUtils.docEndpoint
 import org.elasticsearch.spark.cfg.SparkSettingsManager
 import org.elasticsearch.spark.sparkRDDFunctions
 import org.elasticsearch.spark.sparkStringJsonRDDFunctions
@@ -265,14 +267,14 @@ class AbstractScalaEsScalaSparkSQL(prefix: String, readMetadata: jl.Boolean, pus
 
     val index = wrapIndex("sparksql-test-array-mapping-top-level")
     val typename = "data"
-    val (target, docEndpoint) = makeTargets(index, typename)
+    val (target, docPath) = makeTargets(index, typename)
     RestUtils.touch(index)
     RestUtils.putMapping(index, typename, mapping.getBytes(StringUtils.UTF_8))
 
     // add some data
     val doc1 = """{"arr" : [{"one" : "1", "two" : "2"}, {"one" : "unu", "two" : "doi"}], "top-level" : "root" }""".stripMargin
 
-    RestUtils.postData(docEndpoint, doc1.getBytes(StringUtils.UTF_8))
+    RestUtils.postData(docPath, doc1.getBytes(StringUtils.UTF_8))
     RestUtils.refresh(index)
 
     val newCfg = collection.mutable.Map(cfg.toSeq: _*) += (ES_READ_FIELD_AS_ARRAY_INCLUDE -> "arr")
@@ -306,7 +308,7 @@ class AbstractScalaEsScalaSparkSQL(prefix: String, readMetadata: jl.Boolean, pus
   @Test
   def testMultiFieldsWithSameName {
     val index = wrapIndex("sparksql-test-array-mapping-nested")
-    val (target, docEndpoint) = makeTargets(index, "data")
+    val (target, docPath) = makeTargets(index, "data")
     RestUtils.touch(index)
 
     // add some data
@@ -331,7 +333,7 @@ class AbstractScalaEsScalaSparkSQL(prefix: String, readMetadata: jl.Boolean, pus
     |  "level1" : "$text"
     |}
     """.stripMargin
-    RestUtils.postData(docEndpoint, jsonDoc.getBytes(StringUtils.UTF_8))
+    RestUtils.postData(docPath, jsonDoc.getBytes(StringUtils.UTF_8))
     RestUtils.refresh(index)
 
     val newCfg = collection.mutable.Map(cfg.toSeq: _*) += (ES_READ_FIELD_AS_ARRAY_INCLUDE -> "bar.bar.bar", "es.resource" -> target)
@@ -447,7 +449,7 @@ class AbstractScalaEsScalaSparkSQL(prefix: String, readMetadata: jl.Boolean, pus
   @Test
   def test1ReadFieldNameWithPercentage() {
     val index = wrapIndex("spark-test-scala-sql-field-with-percentage")
-    val (target, docEndpoint) = makeTargets(index, "data")
+    val (target, docPath) = makeTargets(index, "data")
     sqc.esDF(target).count()
   }
 
@@ -476,20 +478,20 @@ class AbstractScalaEsScalaSparkSQL(prefix: String, readMetadata: jl.Boolean, pus
     val dataFrame = artistsAsDataFrame
 
     val index = wrapIndex("sparksql-test-scala-basic-write-id-mapping")
-    val (target, docEndpoint) = makeTargets(index, "data")
+    val (target, docPath) = makeTargets(index, "data")
     val newCfg = collection.mutable.Map(cfg.toSeq: _*) += (ES_MAPPING_ID -> "id", ES_MAPPING_EXCLUDE -> "url")
 
     dataFrame.saveToEs(target, newCfg)
     assertTrue(RestUtils.exists(target))
     assertThat(RestUtils.get(target + "/_search?"), containsString("345"))
-    assertThat(RestUtils.exists(docEndpoint + "/1"), is(true))
+    assertThat(RestUtils.exists(docPath + "/1"), is(true))
     assertThat(RestUtils.get(target + "/_search?"), not(containsString("url")))
   }
 
   @Test
   def testEsDataFrame1WriteNullValue() {
     val index = wrapIndex("spark-test-null-data-test-0")
-    val (target, docEndpoint) = makeTargets(index, "data")
+    val (target, docPath) = makeTargets(index, "data")
 
     val docs = Seq(
       """{"id":"1","name":{"first":"Robert","last":"Downey","suffix":"Jr"}}""",
@@ -501,8 +503,8 @@ class AbstractScalaEsScalaSparkSQL(prefix: String, readMetadata: jl.Boolean, pus
     val jsonDF = sqc.read.json(rdd).toDF.select("id", "name")
     jsonDF.saveToEs(target, conf)
     RestUtils.refresh(index)
-    val hit1 = RestUtils.get(s"$docEndpoint/1/_source")
-    val hit2 = RestUtils.get(s"$docEndpoint/2/_source")
+    val hit1 = RestUtils.get(s"$docPath/1/_source")
+    val hit2 = RestUtils.get(s"$docPath/2/_source")
 
     assertThat(hit1, containsString("suffix"))
     assertThat(hit2, not(containsString("suffix")))
@@ -511,7 +513,7 @@ class AbstractScalaEsScalaSparkSQL(prefix: String, readMetadata: jl.Boolean, pus
   @Test
   def testEsDataFrame12CheckYesWriteNullValue() {
     val index = wrapIndex("spark-test-null-data-test-1")
-    val (target, docEndpoint) = makeTargets(index, "data")
+    val (target, docPath) = makeTargets(index, "data")
 
     val docs = Seq(
       """{"id":"1","name":{"first":"Robert","last":"Downey","suffix":"Jr"}}""",
@@ -523,8 +525,8 @@ class AbstractScalaEsScalaSparkSQL(prefix: String, readMetadata: jl.Boolean, pus
     val jsonDF = sqc.read.json(rdd).toDF.select("id", "name")
     jsonDF.saveToEs(target, conf)
     RestUtils.refresh(index)
-    val hit1 = RestUtils.get(s"$docEndpoint/1/_source")
-    val hit2 = RestUtils.get(s"$docEndpoint/2/_source")
+    val hit1 = RestUtils.get(s"$docPath/1/_source")
+    val hit2 = RestUtils.get(s"$docPath/2/_source")
 
     assertThat(hit1, containsString("suffix"))
     assertThat(hit2, containsString("suffix"))
@@ -534,7 +536,7 @@ class AbstractScalaEsScalaSparkSQL(prefix: String, readMetadata: jl.Boolean, pus
   @Test
   def testEsDataFrame11CheckNoWriteNullValueFromRows() {
     val index = wrapIndex("spark-test-null-data-test-2")
-    val (target, docEndpoint) = makeTargets(index, "data")
+    val (target, docPath) = makeTargets(index, "data")
 
     val data = Seq(
       Row("1", "Robert", "Downey", "Jr"),
@@ -552,8 +554,8 @@ class AbstractScalaEsScalaSparkSQL(prefix: String, readMetadata: jl.Boolean, pus
     val df = sqc.createDataFrame(rdd, schema)
     df.saveToEs(target, conf)
     RestUtils.refresh(index)
-    val hit1 = RestUtils.get(s"$docEndpoint/1/_source")
-    val hit2 = RestUtils.get(s"$docEndpoint/2/_source")
+    val hit1 = RestUtils.get(s"$docPath/1/_source")
+    val hit2 = RestUtils.get(s"$docPath/2/_source")
 
     assertThat(hit1, containsString("suffix"))
     assertThat(hit2, not(containsString("suffix")))
@@ -562,7 +564,7 @@ class AbstractScalaEsScalaSparkSQL(prefix: String, readMetadata: jl.Boolean, pus
   @Test
   def testEsDataFrame12CheckYesWriteNullValueFromRows() {
     val index = wrapIndex("spark-test-null-data-test-3")
-    val (target, docEndpoint) = makeTargets(index, "data")
+    val (target, docPath) = makeTargets(index, "data")
     val data = Seq(
       Row("1", "Robert", "Downey", "Jr"),
       Row("2", "Chris", "Evans", null)
@@ -579,8 +581,8 @@ class AbstractScalaEsScalaSparkSQL(prefix: String, readMetadata: jl.Boolean, pus
     val df = sqc.createDataFrame(rdd, schema)
     df.saveToEs(target, conf)
     RestUtils.refresh(index)
-    val hit1 = RestUtils.get(s"$docEndpoint/1/_source")
-    val hit2 = RestUtils.get(s"$docEndpoint/2/_source")
+    val hit1 = RestUtils.get(s"$docPath/1/_source")
+    val hit2 = RestUtils.get(s"$docPath/2/_source")
 
     assertThat(hit1, containsString("suffix"))
     assertThat(hit2, containsString("suffix"))
@@ -719,11 +721,11 @@ class AbstractScalaEsScalaSparkSQL(prefix: String, readMetadata: jl.Boolean, pus
     val dataFrame = sqc.createDataFrame(rowRDD, schema)
 
     val index = wrapIndex("sparksql-test-scala-basic-write-rich-mapping-id-mapping")
-    val (target, docEndpoint) = makeTargets(index, "data")
+    val (target, docPath) = makeTargets(index, "data")
     dataFrame.saveToEs(target, Map(ES_MAPPING_ID -> "id"))
     assertTrue(RestUtils.exists(target))
     assertThat(RestUtils.get(target + "/_search?"), containsString("345"))
-    assertThat(RestUtils.exists(docEndpoint + "/1"), is(true))
+    assertThat(RestUtils.exists(docPath + "/1"), is(true))
   }
 
   @Test(expected = classOf[SparkException])
@@ -838,7 +840,7 @@ class AbstractScalaEsScalaSparkSQL(prefix: String, readMetadata: jl.Boolean, pus
   @Test
   def testScrollLimitWithEmptyPartition(): Unit = {
     val index = wrapIndex("scroll-limit")
-    val (target, docEndpoint) = makeTargets(index, "data")
+    val (target, docPath) = makeTargets(index, "data")
 
     // Make index with two shards
     RestUtils.delete(index)
@@ -1173,7 +1175,7 @@ class AbstractScalaEsScalaSparkSQL(prefix: String, readMetadata: jl.Boolean, pus
     println(input.schema.simpleString)
 
     val index = wrapIndex("spark-test-json-file")
-    val (target, docEndpoint) = makeTargets(index, "data")
+    val (target, docPath) = makeTargets(index, "data")
     input.saveToEs(target, cfg)
 
     val basic = sqc.read.json(readAsRDD(this.getClass.getResource("/basic.json").toURI()))
@@ -1191,7 +1193,7 @@ class AbstractScalaEsScalaSparkSQL(prefix: String, readMetadata: jl.Boolean, pus
     val sample = input.take(1)(0).toString()
 
     val index = wrapIndex("spark-test-json-file-schema")
-    val (target, docEndpoint) = makeTargets(index, "data")
+    val (target, docPath) = makeTargets(index, "data")
     input.saveToEs(target, cfg)
 
     val dsCfg = collection.mutable.Map(cfg.toSeq: _*) += ("path" -> target)
@@ -1315,7 +1317,7 @@ class AbstractScalaEsScalaSparkSQL(prefix: String, readMetadata: jl.Boolean, pus
 
     val index = wrapIndex("sparksql-test-scala-overwrite-join")
     val typename = "join"
-    val (target, docEndpoint) = makeTargets(index, typename)
+    val (target, docPath) = makeTargets(index, typename)
     RestUtils.delete(index)
     RestUtils.touch(index)
     if (TestUtils.isTypelessVersion(version)) {
@@ -1330,8 +1332,8 @@ class AbstractScalaEsScalaSparkSQL(prefix: String, readMetadata: jl.Boolean, pus
       .options(Map(ES_MAPPING_ID -> "id", ES_MAPPING_JOIN -> "joiner"))
       .save(target)
 
-    assertThat(RestUtils.get(docEndpoint + "/10?routing=1"), containsString("kimchy"))
-    assertThat(RestUtils.get(docEndpoint + "/10?routing=1"), containsString(""""_routing":"1""""))
+    assertThat(RestUtils.get(docPath + "/10?routing=1"), containsString("kimchy"))
+    assertThat(RestUtils.get(docPath + "/10?routing=1"), containsString(""""_routing":"1""""))
 
     // Overwrite the data using a new dataset:
     val newChildren = Seq(
@@ -1348,9 +1350,9 @@ class AbstractScalaEsScalaSparkSQL(prefix: String, readMetadata: jl.Boolean, pus
       .mode(SaveMode.Overwrite)
       .save(target)
 
-    assertFalse(RestUtils.exists(docEndpoint + "/10?routing=1"))
-    assertThat(RestUtils.get(docEndpoint + "/110?routing=1"), containsString("costinl"))
-    assertThat(RestUtils.get(docEndpoint + "/110?routing=1"), containsString(""""_routing":"1""""))
+    assertFalse(RestUtils.exists(docPath + "/10?routing=1"))
+    assertThat(RestUtils.get(docPath + "/110?routing=1"), containsString("costinl"))
+    assertThat(RestUtils.get(docPath + "/110?routing=1"), containsString(""""_routing":"1""""))
   }
 
   @Test
@@ -1456,7 +1458,7 @@ class AbstractScalaEsScalaSparkSQL(prefix: String, readMetadata: jl.Boolean, pus
   def testEsDataFrame60DataSourceSaveModeIgnore() {
     val srcFrame = artistsJsonAsDataFrame
     val index = wrapIndex("sparksql-test-savemode_ignore")
-    val (target, docEndpoint) = makeTargets(index, "data")
+    val (target, docPath) = makeTargets(index, "data")
     val table = wrapIndex("save_mode_ignore")
 
     srcFrame.write.format("org.elasticsearch.spark.sql").mode(SaveMode.Ignore).save(target)
@@ -1614,7 +1616,7 @@ class AbstractScalaEsScalaSparkSQL(prefix: String, readMetadata: jl.Boolean, pus
     {
       val index = wrapIndex("sparksql-test-scala-write-join-separate")
       val typename = "join"
-      val (target, docEndpoint) = makeTargets(index, typename)
+      val (target, docPath) = makeTargets(index, typename)
       if (TestUtils.isTypelessVersion(version)) {
         RestUtils.putMapping(index, typename, "data/join/mapping/typeless.json")
       } else {
@@ -1624,8 +1626,8 @@ class AbstractScalaEsScalaSparkSQL(prefix: String, readMetadata: jl.Boolean, pus
       sc.makeRDD(parents).saveToEs(target, Map(ES_MAPPING_ID -> "id", ES_MAPPING_JOIN -> "joiner"))
       sc.makeRDD(children).saveToEs(target, Map(ES_MAPPING_ID -> "id", ES_MAPPING_JOIN -> "joiner"))
 
-      assertThat(RestUtils.get(docEndpoint + "/10?routing=1"), containsString("kimchy"))
-      assertThat(RestUtils.get(docEndpoint + "/10?routing=1"), containsString(""""_routing":"1""""))
+      assertThat(RestUtils.get(docPath + "/10?routing=1"), containsString("kimchy"))
+      assertThat(RestUtils.get(docPath + "/10?routing=1"), containsString(""""_routing":"1""""))
 
       val df = sqc.read.format("es").load(target)
       val data = df.where(df("id").equalTo("1").or(df("id").equalTo("10"))).sort(df("id")).collect()
@@ -1649,7 +1651,7 @@ class AbstractScalaEsScalaSparkSQL(prefix: String, readMetadata: jl.Boolean, pus
     {
       val index = wrapIndex("sparksql-test-scala-write-join-combined")
       val typename = "join"
-      val (target, docEndpoint) = makeTargets(index, typename)
+      val (target, docPath) = makeTargets(index, typename)
       if (TestUtils.isTypelessVersion(version)) {
         RestUtils.putMapping(index, typename, "data/join/mapping/typeless.json")
       } else {
@@ -1658,8 +1660,8 @@ class AbstractScalaEsScalaSparkSQL(prefix: String, readMetadata: jl.Boolean, pus
 
       sc.makeRDD(docs).saveToEs(target, Map(ES_MAPPING_ID -> "id", ES_MAPPING_JOIN -> "joiner"))
 
-      assertThat(RestUtils.get(docEndpoint + "/10?routing=1"), containsString("kimchy"))
-      assertThat(RestUtils.get(docEndpoint + "/10?routing=1"), containsString(""""_routing":"1""""))
+      assertThat(RestUtils.get(docPath + "/10?routing=1"), containsString("kimchy"))
+      assertThat(RestUtils.get(docPath + "/10?routing=1"), containsString(""""_routing":"1""""))
 
       val df = sqc.read.format("es").load(target)
       val data = df.where(df("id").equalTo("1").or(df("id").equalTo("10"))).sort(df("id")).collect()
@@ -1703,7 +1705,7 @@ class AbstractScalaEsScalaSparkSQL(prefix: String, readMetadata: jl.Boolean, pus
     
     val index = wrapIndex("sparksql-test-geopoint-latlonstring-geopoint")
     val typed = "data"
-    val (target, docEndpoint) = makeTargets(index, typed)
+    val (target, docPath) = makeTargets(index, typed)
     RestUtils.touch(index)
     RestUtils.putMapping(index, typed, mapping.getBytes(StringUtils.UTF_8))
 
@@ -2310,22 +2312,6 @@ class AbstractScalaEsScalaSparkSQL(prefix: String, readMetadata: jl.Boolean, pus
     RestUtils.delete("_all")
   }
 
-  def resource(index: String, typeName: String): String = {
-    if (TestUtils.isTypelessVersion(version)) {
-      index
-    } else {
-      s"$index/$typeName"
-    }
-  }
-
-  def docPath(index: String, typeName: String): String = {
-    if (TestUtils.isTypelessVersion(version)) {
-      s"$index/_doc"
-    } else {
-      s"$index/$typeName"
-    }
-  }
-
   def wrapIndex(index: String) = {
     prefix + index
   }
@@ -2339,11 +2325,7 @@ class AbstractScalaEsScalaSparkSQL(prefix: String, readMetadata: jl.Boolean, pus
   }
 
   def makeTargets(index: String, typeName: String): (String, String) = {
-    if (TestUtils.isTypelessVersion(version)) {
-      (index, s"$index/_doc")
-    } else {
-      (s"$index/$typeName", s"$index/$typeName")
-    }
+    (resource(index, typeName, version), docEndpoint(index, typeName, version))
   }
 
   /**

--- a/spark/sql-20/src/itest/scala/org/elasticsearch/spark/integration/AbstractScalaEsSparkSQL.scala
+++ b/spark/sql-20/src/itest/scala/org/elasticsearch/spark/integration/AbstractScalaEsSparkSQL.scala
@@ -1394,7 +1394,7 @@ class AbstractScalaEsScalaSparkSQL(prefix: String, readMetadata: jl.Boolean, pus
   @Test
   def testEsDataFrame60DataSourceSaveModeError() {
     val srcFrame = artistsJsonAsDataFrame
-    val index = wrapIndex("sparksql-test-savemode_error/data")
+    val index = wrapIndex("sparksql-test-savemode_error")
     val (target, _) = makeTargets(index, "data")
     val table = wrapIndex("save_mode_error")
 
@@ -2308,6 +2308,22 @@ class AbstractScalaEsScalaSparkSQL(prefix: String, readMetadata: jl.Boolean, pus
   def zzzz_clearEnvironment() {
     // Nuke the whole environment after the tests run.
     RestUtils.delete("_all")
+  }
+
+  def resource(index: String, typeName: String): String = {
+    if (version.onOrAfter(EsMajorVersion.V_8_X)) {
+      index
+    } else {
+      s"$index/$typeName"
+    }
+  }
+
+  def docPath(index: String, typeName: String): String = {
+    if (version.onOrAfter(EsMajorVersion.V_8_X)) {
+      s"$index/_doc"
+    } else {
+      s"$index/$typeName"
+    }
   }
 
   def wrapIndex(index: String) = {

--- a/spark/sql-20/src/itest/scala/org/elasticsearch/spark/integration/AbstractScalaEsSparkStructuredStreaming.scala
+++ b/spark/sql-20/src/itest/scala/org/elasticsearch/spark/integration/AbstractScalaEsSparkStructuredStreaming.scala
@@ -27,6 +27,8 @@ import org.elasticsearch.hadoop.util.EsMajorVersion
 import org.elasticsearch.hadoop.util.StringUtils
 import org.elasticsearch.hadoop.util.TestSettings
 import org.elasticsearch.hadoop.util.TestUtils
+import org.elasticsearch.hadoop.util.TestUtils.resource
+import org.elasticsearch.hadoop.util.TestUtils.docEndpoint
 import org.elasticsearch.spark.sql.streaming.SparkSqlStreamingConfigs
 import org.elasticsearch.spark.sql.streaming.StreamingQueryTestHarness
 import org.hamcrest.Matchers.containsString
@@ -128,22 +130,6 @@ class AbstractScalaEsSparkStructuredStreaming(prefix: String, something: Boolean
   import org.elasticsearch.spark.integration.Products._
   import spark.implicits._
 
-  def resource(index: String, typeName: String): String = {
-    if (TestUtils.isTypelessVersion(version)) {
-      index
-    } else {
-      s"$index/$typeName"
-    }
-  }
-
-  def docPath(index: String, typeName: String): String = {
-    if (TestUtils.isTypelessVersion(version)) {
-      s"$index/_doc"
-    } else {
-      s"$index/$typeName"
-    }
-  }
-
   def wrapIndex(name: String): String = {
     prefix + "-spark-struct-stream-" + name
   }
@@ -191,7 +177,7 @@ class AbstractScalaEsSparkStructuredStreaming(prefix: String, something: Boolean
   @Test(expected = classOf[EsHadoopIllegalArgumentException])
   def test1FailOnIncorrectSaveCall(): Unit = {
     import org.elasticsearch.spark.sql._
-    val target = wrapIndex(resource("failed-on-save-call", "data"))
+    val target = wrapIndex(resource("failed-on-save-call", "data", version))
     val test = new StreamingQueryTestHarness[Record](spark)
 
     test.stream.saveToEs(target)
@@ -201,7 +187,7 @@ class AbstractScalaEsSparkStructuredStreaming(prefix: String, something: Boolean
 
   @Test(expected = classOf[EsHadoopIllegalArgumentException])
   def test1FailOnCompleteMode(): Unit = {
-    val target = wrapIndex(resource("failed-on-complete-mode", "data"))
+    val target = wrapIndex(resource("failed-on-complete-mode", "data", version))
     val test = new StreamingQueryTestHarness[Record](spark)
 
     test.withInput(Record(1, "Spark"))
@@ -220,7 +206,7 @@ class AbstractScalaEsSparkStructuredStreaming(prefix: String, something: Boolean
 
   @Test(expected = classOf[EsHadoopIllegalArgumentException])
   def test1FailOnPartitions(): Unit = {
-    val target = wrapIndex(resource("failed-on-partitions", "data"))
+    val target = wrapIndex(resource("failed-on-partitions", "data", version))
     val test = new StreamingQueryTestHarness[Record](spark)
 
     test.withInput(Record(1, "Spark"))
@@ -238,7 +224,7 @@ class AbstractScalaEsSparkStructuredStreaming(prefix: String, something: Boolean
 
   @Test
   def test2BasicWriteWithoutCommitLog(): Unit = {
-    val target = wrapIndex(resource("test-basic-write-no-commit", "data"))
+    val target = wrapIndex(resource("test-basic-write-no-commit", "data", version))
     val test = new StreamingQueryTestHarness[Record](spark)
 
     test.withInput(Record(1, "Spark"))
@@ -264,7 +250,7 @@ class AbstractScalaEsSparkStructuredStreaming(prefix: String, something: Boolean
 
   @Test
   def test2BasicWrite(): Unit = {
-    val target = wrapIndex(resource("test-basic-write", "data"))
+    val target = wrapIndex(resource("test-basic-write", "data", version))
     val test = new StreamingQueryTestHarness[Record](spark)
 
     test.withInput(Record(1, "Spark"))
@@ -293,7 +279,7 @@ class AbstractScalaEsSparkStructuredStreaming(prefix: String, something: Boolean
       val check = s"${AbstractScalaEsSparkStructuredStreaming.commitLogDir}/session1"
       spark.conf.set(SQLConf.CHECKPOINT_LOCATION.key, check)
 
-      val target = wrapIndex(resource("test-basic-write", "data"))
+      val target = wrapIndex(resource("test-basic-write", "data", version))
       val test = new StreamingQueryTestHarness[Record](spark)
 
       test.withInput(Record(1, "Spark"))
@@ -327,7 +313,7 @@ class AbstractScalaEsSparkStructuredStreaming(prefix: String, something: Boolean
       val check = s"${AbstractScalaEsSparkStructuredStreaming.commitLogDir}/session2"
       spark.conf.set(SQLConf.CHECKPOINT_LOCATION.key, check)
 
-      val target = wrapIndex(resource("test-basic-write", "data"))
+      val target = wrapIndex(resource("test-basic-write", "data", version))
       val test = new StreamingQueryTestHarness[Record](spark)
 
       test.withInput(Record(1, "Spark"))
@@ -357,7 +343,7 @@ class AbstractScalaEsSparkStructuredStreaming(prefix: String, something: Boolean
 
   @Test(expected = classOf[EsHadoopIllegalArgumentException])
   def test1FailOnIndexCreationDisabled(): Unit = {
-    val target = wrapIndex(resource("test-write-index-create-disabled", "data"))
+    val target = wrapIndex(resource("test-write-index-create-disabled", "data", version))
     val test = new StreamingQueryTestHarness[Record](spark)
 
     test.withInput(Record(1, "Spark"))
@@ -378,8 +364,8 @@ class AbstractScalaEsSparkStructuredStreaming(prefix: String, something: Boolean
 
   @Test
   def test2WriteWithMappingId(): Unit = {
-    val target = wrapIndex(resource("test-write-with-id", "data"))
-    val docEndpoint = wrapIndex(docPath("test-write-with-id", "data"))
+    val target = wrapIndex(resource("test-write-with-id", "data", version))
+    val docPath = wrapIndex(docEndpoint("test-write-with-id", "data", version))
     val test = new StreamingQueryTestHarness[Record](spark)
 
     test.withInput(Record(1, "Spark"))
@@ -395,9 +381,9 @@ class AbstractScalaEsSparkStructuredStreaming(prefix: String, something: Boolean
       }
 
     assertTrue(RestUtils.exists(target))
-    assertTrue(RestUtils.exists(docEndpoint + "/1"))
-    assertTrue(RestUtils.exists(docEndpoint + "/2"))
-    assertTrue(RestUtils.exists(docEndpoint + "/3"))
+    assertTrue(RestUtils.exists(docPath + "/1"))
+    assertTrue(RestUtils.exists(docPath + "/2"))
+    assertTrue(RestUtils.exists(docPath + "/3"))
     val searchResult = RestUtils.get(target + "/_search?")
     assertThat(searchResult, containsString("Spark"))
     assertThat(searchResult, containsString("Hadoop"))
@@ -406,7 +392,7 @@ class AbstractScalaEsSparkStructuredStreaming(prefix: String, something: Boolean
 
   @Test
   def test2WriteWithMappingExclude(): Unit = {
-    val target = wrapIndex(resource("test-write-with-exclude", "data"))
+    val target = wrapIndex(resource("test-write-with-exclude", "data", version))
     val test = new StreamingQueryTestHarness[Record](spark)
 
     test.withInput(Record(1, "Spark"))
@@ -437,7 +423,7 @@ class AbstractScalaEsSparkStructuredStreaming(prefix: String, something: Boolean
     val pipeline: String = """{"description":"Test Pipeline","processors":[{"set":{"field":"pipeTEST","value":true,"override":true}}]}"""
     RestUtils.put("/_ingest/pipeline/" + pipelineName, StringUtils.toUTF(pipeline))
 
-    val target = wrapIndex(resource("test-write-ingest", "data"))
+    val target = wrapIndex(resource("test-write-ingest", "data", version))
     val test = new StreamingQueryTestHarness[Record](spark)
 
     test.withInput(Record(1, "Spark"))
@@ -462,7 +448,7 @@ class AbstractScalaEsSparkStructuredStreaming(prefix: String, something: Boolean
 
   @Test
   def test2MultiIndexWrite(): Unit = {
-    val target = wrapIndex(resource("test-tech-{name}", "data"))
+    val target = wrapIndex(resource("test-tech-{name}", "data", version))
     val test = new StreamingQueryTestHarness[Record](spark)
 
     test.withInput(Record(1, "spark"))
@@ -475,16 +461,16 @@ class AbstractScalaEsSparkStructuredStreaming(prefix: String, something: Boolean
           .start(target)
       }
 
-    assertTrue(RestUtils.exists(wrapIndex(resource("test-tech-spark", "data"))))
-    assertTrue(RestUtils.exists(wrapIndex(resource("test-tech-hadoop", "data"))))
-    assertThat(wrapIndex(resource("test-tech-spark", "data") + "/_search?"), containsString("spark"))
-    assertThat(wrapIndex(resource("test-tech-hadoop", "data") + "/_search?"), containsString("hadoop"))
+    assertTrue(RestUtils.exists(wrapIndex(resource("test-tech-spark", "data", version))))
+    assertTrue(RestUtils.exists(wrapIndex(resource("test-tech-hadoop", "data", version))))
+    assertThat(wrapIndex(resource("test-tech-spark", "data", version) + "/_search?"), containsString("spark"))
+    assertThat(wrapIndex(resource("test-tech-hadoop", "data", version) + "/_search?"), containsString("hadoop"))
   }
 
   @Test
   def test2NullValueIgnored() {
-    val target = wrapIndex(resource("test-null-data-absent", "data"))
-    val docEndpoint = wrapIndex(docPath("test-null-data-absent", "data"))
+    val target = wrapIndex(resource("test-null-data-absent", "data", version))
+    val docPath = wrapIndex(docEndpoint("test-null-data-absent", "data", version))
     val test = new StreamingQueryTestHarness[Record](spark)
 
     test.withInput(Record(1, "Spark"))
@@ -499,14 +485,14 @@ class AbstractScalaEsSparkStructuredStreaming(prefix: String, something: Boolean
       }
 
     assertTrue(RestUtils.exists(target))
-    assertThat(RestUtils.get(docEndpoint + "/1"), containsString("name"))
-    assertThat(RestUtils.get(docEndpoint + "/2"), not(containsString("name")))
+    assertThat(RestUtils.get(docPath + "/1"), containsString("name"))
+    assertThat(RestUtils.get(docPath + "/2"), not(containsString("name")))
   }
 
   @Test
   def test2NullValueWritten() {
-    val target = wrapIndex(resource("test-null-data-null", "data"))
-    val docEndpoint = wrapIndex(docPath("test-null-data-null", "data"))
+    val target = wrapIndex(resource("test-null-data-null", "data", version))
+    val docPath = wrapIndex(docEndpoint("test-null-data-null", "data", version))
     val test = new StreamingQueryTestHarness[Record](spark)
 
     test.withInput(Record(1, "Spark"))
@@ -522,14 +508,14 @@ class AbstractScalaEsSparkStructuredStreaming(prefix: String, something: Boolean
       }
 
     assertTrue(RestUtils.exists(target))
-    assertThat(RestUtils.get(docEndpoint + "/1"), containsString("name"))
-    assertThat(RestUtils.get(docEndpoint + "/2"), containsString("name"))
+    assertThat(RestUtils.get(docPath + "/1"), containsString("name"))
+    assertThat(RestUtils.get(docPath + "/2"), containsString("name"))
   }
 
   @Test
   def test2WriteWithRichMapping() {
-    val target = wrapIndex(resource("test-basic-write-rich-mapping-id", "data"))
-    val docEndpoint = wrapIndex(docPath("test-basic-write-rich-mapping-id", "data"))
+    val target = wrapIndex(resource("test-basic-write-rich-mapping-id", "data", version))
+    val docPath = wrapIndex(docEndpoint("test-basic-write-rich-mapping-id", "data", version))
     val test = new StreamingQueryTestHarness[Text](spark)
 
     Source.fromURI(TestUtils.sampleArtistsDatUri())(Codec.ISO8859).getLines().foreach(s => test.withInput(Text(s)))
@@ -555,12 +541,12 @@ class AbstractScalaEsSparkStructuredStreaming(prefix: String, something: Boolean
 
     assertTrue(RestUtils.exists(target))
     assertThat(RestUtils.get(target + "/_search?"), containsString("345"))
-    assertThat(RestUtils.exists(docEndpoint+"/1"), is(true))
+    assertThat(RestUtils.exists(docPath+"/1"), is(true))
   }
 
   @Test
   def test1FailOnDecimalType() {
-    val target = wrapIndex(resource("test-decimal-exception", "data"))
+    val target = wrapIndex(resource("test-decimal-exception", "data", version))
     val test = new StreamingQueryTestHarness[DecimalData](spark)
 
     test.withInput(DecimalData(Decimal(10)))

--- a/spark/sql-20/src/itest/scala/org/elasticsearch/spark/integration/AbstractScalaEsSparkStructuredStreaming.scala
+++ b/spark/sql-20/src/itest/scala/org/elasticsearch/spark/integration/AbstractScalaEsSparkStructuredStreaming.scala
@@ -129,7 +129,7 @@ class AbstractScalaEsSparkStructuredStreaming(prefix: String, something: Boolean
   import spark.implicits._
 
   def resource(index: String, typeName: String): String = {
-    if (version.onOrAfter(EsMajorVersion.V_8_X)) {
+    if (TestUtils.isTypelessVersion(version)) {
       index
     } else {
       s"$index/$typeName"
@@ -137,7 +137,7 @@ class AbstractScalaEsSparkStructuredStreaming(prefix: String, something: Boolean
   }
 
   def docPath(index: String, typeName: String): String = {
-    if (version.onOrAfter(EsMajorVersion.V_8_X)) {
+    if (TestUtils.isTypelessVersion(version)) {
       s"$index/_doc"
     } else {
       s"$index/$typeName"


### PR DESCRIPTION
In the 7.0 line there are changes to ensure that 7.0 respects the deprecation of the usage of Elasticsearch types in requests. This change ensures that the existing test code that depends on typeless API's continues to function in a manner that is backwards compatible with older versions for testing purposes.

The plan at the moment is to remove the types completely in the 8.0 line with a later PR. The backwards compatibility sensitive changes are in this PR for the benefit of running 7.x tests against 6.x clusters.