### PR TITLE
Fix missing service files in ES-Hadoop jars

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/BuildPlugin.groovy
@@ -645,7 +645,7 @@ class BuildPlugin implements Plugin<Project>  {
     private static String gitHash(File gitHead) {
         String rev = "unknown"
 
-        if (gitHead.exists()) {
+        if (gitHead != null && gitHead.exists()) {
             rev = gitHead.text.trim()
         }
         return rev

--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/IntegrationBuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/IntegrationBuildPlugin.groovy
@@ -42,7 +42,8 @@ class IntegrationBuildPlugin implements Plugin<Project> {
             Jar rootJar = project.rootProject.getTasks().getByName('jar') as Jar
             rootJar.dependsOn(project.tasks.jar)
             rootJar.from(project.zipTree(project.tasks.jar.archivePath)) {
-                exclude "META-INF/**"
+                exclude "META-INF/*"
+                include "META-INF/services"
                 include "**/*"
             }
 

--- a/hive/build.gradle
+++ b/hive/build.gradle
@@ -17,6 +17,7 @@ jar {
     from(zipTree(project(":elasticsearch-hadoop-mr").jar.archivePath)) {
         include "org/elasticsearch/hadoop/**"
         include "esh-build.properties"
+        include "META-INF/services/*"
     }
 }
 

--- a/pig/build.gradle
+++ b/pig/build.gradle
@@ -17,6 +17,7 @@ jar {
     from(zipTree(project(":elasticsearch-hadoop-mr").jar.archivePath)) {
         include "org/elasticsearch/hadoop/**"
         include "esh-build.properties"
+        include "META-INF/services/*"
     }
 }
 

--- a/spark/sql-13/build.gradle
+++ b/spark/sql-13/build.gradle
@@ -106,6 +106,7 @@ jar {
     from(zipTree(project(":elasticsearch-hadoop-mr").jar.archivePath)) {
         include "org/elasticsearch/hadoop/**"
         include "esh-build.properties"
+        include "META-INF/services/*"
     }
 }
 

--- a/spark/sql-20/build.gradle
+++ b/spark/sql-20/build.gradle
@@ -119,6 +119,7 @@ jar {
     from(zipTree(project(":elasticsearch-hadoop-mr").jar.archivePath)) {
         include "org/elasticsearch/hadoop/**"
         include "esh-build.properties"
+        include "META-INF/services/*"
     }
 }
 

--- a/storm/build.gradle
+++ b/storm/build.gradle
@@ -17,6 +17,7 @@ jar {
     from(zipTree(project(":elasticsearch-hadoop-mr").jar.archivePath)) {
         include "org/elasticsearch/hadoop/**"
         include "esh-build.properties"
+        include "META-INF/services/*"
     }
 }
 


### PR DESCRIPTION
When creating the jar files for ES-Hadoop, each integration copies the contents of the MR jar into itself since the MR jar contains all the core code. Once each jar is built, they all contribute their contents to the top level elasticsearch-hadoop jar (ignoring duplicate code files). A problem occurs during these jar transitions: The contents of META-INF/services are not copied along. This previously would manifest as not being able to create a Spark SQL dataframe using the short name `"es"` when using the `elasticsearch-hadoop-x.x.x.jar`. Creating the dataframe using the short name would work fine when using the `elasticsearch-spark-yy_zz-x.x.x.jar` because it contains the appropriate service file, which is never copied up to the root jar.

Now that we have Kerberos integrated, there are several items in different projects services directories that all need to be copied around in order for different Kerberos features in Hadoop and Spark to function normally. 

We did not encounter these problems because we make use of a separate hadoop testing jar, which is created directly from the sources of the projects instead of from the jar files, and which includes all the test and integration test sources.

This PR ensures that the contents of the `mr` project's `META-INF/services` directory are copied into the hive, pig, spark, and storm jars, and that the contents of all of integrations `META-INF/services` directories are copied into the root elasticsearch-hadoop jar.