### PR TITLE
[DOCS] Adds tagged region for notable breaking changes

### DIFF
--- a/docs/src/reference/asciidoc/appendix/breaking.adoc
+++ b/docs/src/reference/asciidoc/appendix/breaking.adoc
@@ -10,6 +10,12 @@ versions (e.g. 5.x to 6.y).
 For clarity, we always list any breaking changes at the top of the
 <<release-notes,release notes>> for each version.
 
+//NOTE: The notable-breaking-changes tagged regions are re-used in the
+//Installation and Upgrade Guide
+// tag::notable-v8-breaking-changes[]
+
+// end::notable-v8-breaking-changes[]
+
 [[breaking-changes-7.0]]
 === Breaking Changes in 7.0
 


### PR DESCRIPTION
This PR adds a tagged region in the Elasticsearch Hadoop Breaking changes page (https://www.elastic.co/guide/en/elasticsearch/hadoop/master/breaking-changes.html), such that content can be re-used in the Installation and Upgrade Guide (https://www.elastic.co/guide/en/elastic-stack/master/elastic-stack-breaking-changes.html).

At least one tagged region must exist to prevent build errors in the Installation and Upgrade Guide, though as is the case now for V8.0.0 it can be an empty tagged region.

At this time, the Installation and Upgrade Guide for version X only lists the breaking changes specific to that version. Since this Elasticsearch Hadoop page contains information about multiple versions, I've made the tagged regions version-specific (i.e. tag::notable-v8-breaking-changes[]). 

Related to https://github.com/elastic/docs/pull/789 and https://github.com/elastic/stack-docs/pull/268