### PR TITLE
[DOCS] Adds shared attributes

### DIFF
--- a/docs/src/reference/asciidoc/index.adoc
+++ b/docs/src/reference/asciidoc/index.adoc
@@ -2,9 +2,7 @@
 
 :icons:
 :ehtm: 	Elasticsearch for Apache Hadoop
-:esh: 	ES-Hadoop
 :eh: 	elasticsearch-hadoop
-:es: 	Elasticsearch
 :mr: 	Map/Reduce
 :sp:	Apache Spark
 :st:	Apache Storm
@@ -21,7 +19,7 @@
 :hv-v:	1.2.1
 :cs-v:	2.6.3
 
-
+include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
 [[float]]
 [preface]


### PR DESCRIPTION
This PR adds the use of the shared attributes file: https://github.com/elastic/docs/blob/master/shared/attributes.asciidoc

... and removes redundant definitions from https://github.com/elastic/elasticsearch-hadoop/blob/master/docs/src/reference/asciidoc/index.adoc

If there are any other attributes that are used in the Breaking changes (https://www.elastic.co/guide/en/elasticsearch/hadoop/master/breaking-changes.html), they must also be added to the shared attributes file.  Otherwise, they will not work when the content is pulled into the Installation and Upgrade Guide
(https://www.elastic.co/guide/en/elastic-stack/master/elasticsearch-hadoop-breaking-changes.html)
