### PR TITLE
Revert build-tools to older version

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -7,11 +7,13 @@ apply plugin: 'groovy'
  */
 
 boolean localRepo = project.getProperties().containsKey("localRepo")
+localRepo = false // TODO: Remove this once we can safely depend on build-tools again.
 
 Properties props = new Properties()
 props.load(project.file('esh-version.properties').newDataInputStream())
 String eshVersion = props.getProperty('eshadoop')
 String esVersion = props.getProperty('elasticsearch')
+String buildToolsVersion = "7.0.0" // TODO: Remove this once we can safely depend on build-tools again.
 
 // determine if we're building a prerelease or candidate (alphaX/betaX/rcX)
 String qualifier = System.getProperty("build.version_qualifier", "")
@@ -58,9 +60,9 @@ dependencies {
     compile 'org.springframework.build.gradle:propdeps-plugin:0.0.7'
 
     if (localRepo) {
-        compile name: "build-tools-${esVersion}"
+        compile name: "build-tools-${buildToolsVersion}"
     } else {
-        compile group: 'org.elasticsearch.gradle', name: 'build-tools', version: esVersion
+        compile group: 'org.elasticsearch.gradle', name: 'build-tools', version: buildToolsVersion
     }
 }
 

--- a/buildSrc/esh-version.properties
+++ b/buildSrc/esh-version.properties
@@ -1,2 +1,3 @@
 eshadoop        = 8.0.0
 elasticsearch   = 8.0.0
+lucene          = 8.1.0-snapshot-e460356abe

--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/BuildPlugin.groovy
@@ -1,6 +1,7 @@
 package org.elasticsearch.hadoop.gradle
 
 import org.apache.tools.ant.taskdefs.condition.Os
+import org.elasticsearch.gradle.VersionProperties
 import org.elasticsearch.gradle.precommit.LicenseHeadersTask
 import org.gradle.api.GradleException
 import org.gradle.api.JavaVersion
@@ -13,7 +14,6 @@ import org.gradle.api.artifacts.DependencySubstitutions
 import org.gradle.api.artifacts.ResolutionStrategy
 import org.gradle.api.artifacts.maven.MavenPom
 import org.gradle.api.artifacts.maven.MavenResolver
-import org.gradle.api.artifacts.repositories.IvyArtifactRepository
 import org.gradle.api.file.CopySpec
 import org.gradle.api.java.archives.Manifest
 import org.gradle.api.plugins.JavaPlugin
@@ -93,13 +93,13 @@ class BuildPlugin implements Plugin<Project>  {
      */
     private static void configureVersions(Project project) {
         if (!project.rootProject.ext.has('versionsConfigured')) {
-            project.rootProject.version = VersionProperties.ESHADOOP_VERSION
+            project.rootProject.version = EshVersionProperties.ESHADOOP_VERSION
             println "Building version [${project.rootProject.version}]"
 
-            project.rootProject.ext.eshadoopVersion = VersionProperties.ESHADOOP_VERSION
-            project.rootProject.ext.elasticsearchVersion = VersionProperties.ELASTICSEARCH_VERSION
-            project.rootProject.ext.luceneVersion = org.elasticsearch.gradle.VersionProperties.lucene
-            project.rootProject.ext.versions = VersionProperties.VERSIONS
+            project.rootProject.ext.eshadoopVersion = EshVersionProperties.ESHADOOP_VERSION
+            project.rootProject.ext.elasticsearchVersion = EshVersionProperties.ELASTICSEARCH_VERSION
+            project.rootProject.ext.luceneVersion = VersionProperties.lucene
+            project.rootProject.ext.versions = EshVersionProperties.VERSIONS
             project.rootProject.ext.versionsConfigured = true
 
             println "Testing against Elasticsearch [${project.rootProject.ext.elasticsearchVersion}] with Lucene [${project.rootProject.ext.luceneVersion}]"

--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/BuildPlugin.groovy
@@ -1,7 +1,6 @@
 package org.elasticsearch.hadoop.gradle
 
 import org.apache.tools.ant.taskdefs.condition.Os
-import org.elasticsearch.gradle.VersionProperties
 import org.elasticsearch.gradle.precommit.LicenseHeadersTask
 import org.gradle.api.GradleException
 import org.gradle.api.JavaVersion
@@ -98,7 +97,7 @@ class BuildPlugin implements Plugin<Project>  {
 
             project.rootProject.ext.eshadoopVersion = EshVersionProperties.ESHADOOP_VERSION
             project.rootProject.ext.elasticsearchVersion = EshVersionProperties.ELASTICSEARCH_VERSION
-            project.rootProject.ext.luceneVersion = VersionProperties.lucene
+            project.rootProject.ext.luceneVersion = EshVersionProperties.ELASTICSEARCH_VERSION
             project.rootProject.ext.versions = EshVersionProperties.VERSIONS
             project.rootProject.ext.versionsConfigured = true
 

--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/EshVersionProperties.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/EshVersionProperties.groovy
@@ -3,14 +3,14 @@ package org.elasticsearch.hadoop.gradle
 /**
  * Loads the locally available version information from the build source.
  */
-class VersionProperties {
+class EshVersionProperties {
 
     public static final String ESHADOOP_VERSION
     public static final String ELASTICSEARCH_VERSION
     public static final Map<String, String> VERSIONS
     static {
         Properties versionProperties = new Properties()
-        InputStream propertyStream = VersionProperties.class.getResourceAsStream('/esh-version.properties')
+        InputStream propertyStream = EshVersionProperties.class.getResourceAsStream('/esh-version.properties')
         if (propertyStream == null) {
             throw new RuntimeException("Could not locate the esh-version.properties file!")
         }

--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/EshVersionProperties.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/EshVersionProperties.groovy
@@ -7,6 +7,7 @@ class EshVersionProperties {
 
     public static final String ESHADOOP_VERSION
     public static final String ELASTICSEARCH_VERSION
+    public static final String LUCENE_VERSION
     public static final Map<String, String> VERSIONS
     static {
         Properties versionProperties = new Properties()
@@ -17,6 +18,7 @@ class EshVersionProperties {
         versionProperties.load(propertyStream)
         ESHADOOP_VERSION = versionProperties.getProperty('eshadoop')
         ELASTICSEARCH_VERSION = versionProperties.getProperty('elasticsearch')
+        LUCENE_VERSION = versionProperties.getProperty('lucene')
         VERSIONS = new HashMap<>()
         for (String propertyName: versionProperties.stringPropertyNames()) {
             VERSIONS.put(propertyName, versionProperties.getProperty(propertyName))

--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/RootBuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/RootBuildPlugin.groovy
@@ -6,7 +6,6 @@ import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.file.CopySpec
 import org.gradle.api.file.DuplicatesStrategy
-import org.gradle.api.tasks.TaskInputs
 import org.gradle.api.tasks.bundling.Jar
 import org.gradle.api.tasks.bundling.Zip
 


### PR DESCRIPTION
Elasticsearch has upgraded the minimum required version of Java to be 11. ES-Hadoop's build setup still relies on Java 8. In order to get the build running on Java 11, Gradle would need to be upgraded to version 5.0, which currently breaks the Scala cross compilation set up in the Spark projects.

In order to get snapshot builds running again, this PR changes the build-tools artifact to an older version that still supports Java 8. Once the build versions have been updated, we can restore the build tools dependency to how it was before.