### PR TITLE
[DOCS] Updates version attributes

### DIFF
--- a/docs/src/reference/asciidoc/index.adoc
+++ b/docs/src/reference/asciidoc/index.adoc
@@ -18,7 +18,7 @@
 :hv-v:	1.2.1
 :cs-v:	2.6.3
 
-include::{asciidoc-dir}/../../shared/versions71.asciidoc[]
+include::{asciidoc-dir}/../../shared/versions72.asciidoc[]
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
 [[float]]


### PR DESCRIPTION
This PR updates the version attributes (https://github.com/elastic/docs/blob/master/shared/versions72.asciidoc) that are used by the 7.x branch of the Elasticsearch for Apache Hadoop book.