### PR TITLE
Fix master compilation from ES on Java 11

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/BuildPlugin.groovy
@@ -223,12 +223,7 @@ class BuildPlugin implements Plugin<Project>  {
             testCompile "junit:junit:${project.ext.junitVersion}"
             testCompile "org.hamcrest:hamcrest-all:${project.ext.hamcrestVersion}"
 
-            testCompile("org.elasticsearch:elasticsearch:${project.ext.elasticsearchVersion}") {
-                exclude group: "org.apache.logging.log4j", module: "log4j-api"
-                exclude group: "org.elasticsearch", module: "elasticsearch-cli"
-                exclude group: "org.elasticsearch", module: "elasticsearch-core"
-                exclude group: "org.elasticsearch", module: "elasticsearch-secure-sm"
-            }
+            testCompile "joda-time:joda-time:2.8"
 
             testRuntime "org.slf4j:slf4j-log4j12:1.7.6"
             testRuntime "org.apache.logging.log4j:log4j-api:${project.ext.log4jVersion}"

--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/BuildPlugin.groovy
@@ -97,7 +97,7 @@ class BuildPlugin implements Plugin<Project>  {
 
             project.rootProject.ext.eshadoopVersion = EshVersionProperties.ESHADOOP_VERSION
             project.rootProject.ext.elasticsearchVersion = EshVersionProperties.ELASTICSEARCH_VERSION
-            project.rootProject.ext.luceneVersion = EshVersionProperties.ELASTICSEARCH_VERSION
+            project.rootProject.ext.luceneVersion = EshVersionProperties.LUCENE_VERSION
             project.rootProject.ext.versions = EshVersionProperties.VERSIONS
             project.rootProject.ext.versionsConfigured = true
 
@@ -204,7 +204,7 @@ class BuildPlugin implements Plugin<Project>  {
             String revision = (project.ext.luceneVersion =~ /\w+-snapshot-([a-z0-9]+)/)[0][1]
             project.repositories.maven {
                 name 'lucene-snapshots'
-                url "http://s3.amazonaws.com/download.elasticsearch.org/lucenesnapshots/${revision}"
+                url "https://s3.amazonaws.com/download.elasticsearch.org/lucenesnapshots/${revision}"
             }
         }
     }

--- a/mr/src/test/java/org/elasticsearch/hadoop/util/EsMajorVersionTest.java
+++ b/mr/src/test/java/org/elasticsearch/hadoop/util/EsMajorVersionTest.java
@@ -18,82 +18,83 @@
  */
 package org.elasticsearch.hadoop.util;
 
-import org.elasticsearch.Version;
-import org.junit.Test;
-
-import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
-import static org.hamcrest.CoreMatchers.equalTo;
+import org.junit.Test;
+
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 public class EsMajorVersionTest {
-    private static final List<Version> SORTED_VERSIONS;
-
+    private static final List<String> TEST_VERSIONS;
     static {
-        Field[] declaredFields = Version.class.getFields();
-        Set<Integer> ids = new HashSet<Integer>();
-        for (Field field : declaredFields) {
-            final int mod = field.getModifiers();
-            if (Modifier.isStatic(mod) && Modifier.isFinal(mod) && Modifier.isPublic(mod)) {
-                if (field.getType() == Version.class) {
-                    try {
-                        Version object = (Version) field.get(null);
-                        ids.add(object.id);
-                    } catch (IllegalAccessException e) {
-                        throw new RuntimeException(e);
-                    }
-                }
-            }
-        }
-        List<Integer> idList = new ArrayList<Integer>(ids);
-        Collections.sort(idList);
-        List<Version> version = new ArrayList<Version>();
-        for (Integer integer : idList) {
-            version.add(Version.fromId(integer));
-        }
-        SORTED_VERSIONS = Collections.unmodifiableList(version);
+        List<String> versions = new ArrayList<>();
+        versions.add("0.1.0");
+        versions.add("0.1.1");
+        versions.add("1.0.0-alpha1");
+        versions.add("1.0.0-beta2");
+        versions.add("1.0.0-rc3");
+        versions.add("1.0.0");
+        versions.add("1.1.0");
+        versions.add("1.1.1");
+        versions.add("2.0.0-alpha1");
+        versions.add("2.0.0-beta2");
+        versions.add("2.0.0-rc3");
+        versions.add("2.0.0");
+        versions.add("2.1.0");
+        versions.add("2.1.1");
+        versions.add("5.0.0-alpha1");
+        versions.add("5.0.0-beta2");
+        versions.add("5.0.0-rc3");
+        versions.add("5.0.0");
+        versions.add("5.1.0");
+        versions.add("5.1.1");
+        versions.add("6.0.0-alpha1");
+        versions.add("6.0.0-beta2");
+        versions.add("6.0.0-rc3");
+        versions.add("6.0.0");
+        versions.add("6.1.0");
+        versions.add("6.1.1");
+        versions.add("7.0.0-alpha1");
+        versions.add("7.0.0-beta2");
+        versions.add("7.0.0-rc3");
+        versions.add("7.0.0");
+        versions.add("7.1.0");
+        versions.add("7.1.1");
+        versions.add("8.0.0-alpha1");
+        versions.add("8.0.0-beta2");
+        versions.add("8.0.0-rc3");
+        versions.add("8.0.0");
+        versions.add("8.1.0");
+        versions.add("8.1.1");
+        TEST_VERSIONS = Collections.unmodifiableList(versions);
     }
 
 
     @Test
     public void testVersionFromString() {
-        for (int i = 0; i < SORTED_VERSIONS.size(); i++) {
-            Version official = SORTED_VERSIONS.get(i);
-            EsMajorVersion version = EsMajorVersion.parse(official.toString());
-            EsMajorVersion version2 = EsMajorVersion.parse(official.toString());
-            assertThat(version.major,
-                    equalTo(official.major));
+        for (int i = 0; i < TEST_VERSIONS.size(); i++) {
+            String testVersion = TEST_VERSIONS.get(i);
+            EsMajorVersion version = EsMajorVersion.parse(testVersion);
+            EsMajorVersion version2 = EsMajorVersion.parse(testVersion);
             assertTrue(version.onOrAfter(version));
             assertTrue(version.equals(version));
             assertTrue(version.equals(version2));
-            for (int j = i + 1; j < SORTED_VERSIONS.size(); j++) {
-                Version cmp_official = SORTED_VERSIONS.get(j);
-                EsMajorVersion cmp_version = EsMajorVersion.parse(cmp_official.toString());
-                assertThat(cmp_version.after(version), equalTo(cmp_official.major != official.major));
-                assertTrue(cmp_version.onOrAfter(version));
-                assertFalse(cmp_version.equals(version));
+            for (int j = i + 1; j < TEST_VERSIONS.size(); j++) {
+                String laterTestVersion = TEST_VERSIONS.get(j);
+                EsMajorVersion compareVersion = EsMajorVersion.parse(laterTestVersion);
+                assertTrue(compareVersion.onOrAfter(version));
+                assertFalse(compareVersion.equals(version));
             }
 
             for (int j = i - 1; j >= 0; j--) {
-                Version cmp_official = SORTED_VERSIONS.get(j);
-                EsMajorVersion cmp_version = EsMajorVersion.parse(cmp_official.toString());
-                assertThat(cmp_version.before(version), equalTo(cmp_official.major != official.major));
+                String earlierTestVersion = TEST_VERSIONS.get(j);
+                EsMajorVersion cmp_version = EsMajorVersion.parse(earlierTestVersion);
                 assertTrue(cmp_version.onOrBefore(version));
                 assertFalse(cmp_version.equals(version));
             }
         }
-    }
-
-    @Test
-    public void testLatestIsCurrent() {
-        assertThat(EsMajorVersion.LATEST.major, equalTo(Version.CURRENT.major));
     }
 }


### PR DESCRIPTION
Master branch has been failing for a while now since the ES project bumped its required Java version to 11. ES-Hadoop is still on Java 8, and will need extra testing before compiling and running tests on Java 11. Until then, this PR replaces the version test with cases that do not depend on the versions contained within the Elasticsearch project. When ES-Hadoop is ready to bump up to a higher java version, the version parsing tests can be returned to their original functionality.