### PR TITLE
Fix the mapping client call on ES 5.x and earlier.

### DIFF
--- a/hive/src/itest/java/org/elasticsearch/hadoop/integration/hive/AbstractHiveSaveTest.java
+++ b/hive/src/itest/java/org/elasticsearch/hadoop/integration/hive/AbstractHiveSaveTest.java
@@ -588,8 +588,8 @@ public class AbstractHiveSaveTest {
         EsAssume.versionOnOrBefore(EsMajorVersion.V_5_X, "Parent Child Disabled in 6.0");
         assertThat(RestUtils.getMapping("hive-pc", "child").toString(),
                 targetVersion.onOrAfter(V_5_X)
-                        ? is("child=[id=LONG, links=[picture=TEXT, url=TEXT], name=TEXT]")
-                        : is("child=[id=LONG, links=[picture=STRING, url=STRING], name=STRING]"));
+                        ? is("hive-pc/child=[id=LONG, links=[picture=TEXT, url=TEXT], name=TEXT]")
+                        : is("hive-pc/child=[id=LONG, links=[picture=STRING, url=STRING], name=STRING]"));
     }
 
     @Test

--- a/mr/src/test/java/org/elasticsearch/hadoop/rest/ResourceTest.java
+++ b/mr/src/test/java/org/elasticsearch/hadoop/rest/ResourceTest.java
@@ -68,6 +68,13 @@ public class ResourceTest {
     }
 
     @Test
+    public void testToString() throws Exception {
+        assumeTyped();
+        Resource res = createResource("foo/bar");
+        assertEquals("foo/bar", res.toString());
+    }
+
+    @Test
     public void testJustIndex() throws Exception {
         assumeTyped();
         Resource res = createResource("foo/_all");

--- a/pig/src/itest/java/org/elasticsearch/hadoop/integration/pig/AbstractPigSaveTest.java
+++ b/pig/src/itest/java/org/elasticsearch/hadoop/integration/pig/AbstractPigSaveTest.java
@@ -283,8 +283,8 @@ public class AbstractPigSaveTest extends AbstractPigTests {
         EsAssume.versionOnOrBefore(EsMajorVersion.V_5_X, "Parent Child Disabled in 6.0");
         assertThat(RestUtils.getMapping("pig-pc", "child").toString(),
                 VERSION.onOrAfter(V_5_X)
-                        ? is("child=[id=LONG, links=TEXT, name=TEXT]")
-                        : is("child=[id=LONG, links=STRING, name=STRING]"));
+                        ? is("pig-pc/child=[id=LONG, links=TEXT, name=TEXT]")
+                        : is("pig-pc/child=[id=LONG, links=STRING, name=STRING]"));
     }
 
     @Test

--- a/spark/core/itest/scala/org/elasticsearch/spark/integration/AbstractScalaEsSpark.scala
+++ b/spark/core/itest/scala/org/elasticsearch/spark/integration/AbstractScalaEsSpark.scala
@@ -497,7 +497,7 @@ class AbstractScalaEsScalaSpark(prefix: String, readMetadata: jl.Boolean) extend
     val target = resource(index, typename, version)
     val docPath = docEndpoint(index, typename, version)
 
-    RestUtils.putMapping(index, typename, mapping)
+    RestUtils.putMapping(index, typename, mapping.getBytes)
 
     RestUtils.refresh(index)
     RestUtils.put(s"$docPath/1", """{"id":"1", "counter":4}""".getBytes(StringUtils.UTF_8))

--- a/spark/sql-20/src/itest/scala/org/elasticsearch/spark/integration/AbstractScalaEsSparkSQL.scala
+++ b/spark/sql-20/src/itest/scala/org/elasticsearch/spark/integration/AbstractScalaEsSparkSQL.scala
@@ -751,7 +751,7 @@ class AbstractScalaEsScalaSparkSQL(prefix: String, readMetadata: jl.Boolean, pus
     val dataIndex = wrapIndex("sparksql-test-scala-error-handler-es")
     val errorIndex = wrapIndex("sparksql-test-scala-error-handler-es-errors")
 
-    val typeName = "/data"
+    val typeName = "data"
 
     val (dataTarget, _) = makeTargets(dataIndex, typeName)
     val (errorTarget, _) = makeTargets(errorIndex, typeName)


### PR DESCRIPTION
This PR removes the include_type_names parameter from mapping requests made to versions of ES that do not recognize it. Included are a set of test updates that ensures that test runs against ES 5.x complete correctly.

Relates #1276