### PR TITLE
Set ubuntu dist to trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: java
 jdk:
   - oraclejdk8
-  
+
+dist: trusty
+
 before_install:
  - "chmod +x gradlew"
  - export JAVA_OPTS="-Xmx2048m -XX:MaxPermSize=386m"


### PR DESCRIPTION
Travis CI task is failing due to not being able to install/use Java 8. This PR resets the ubuntu distribution to Trusty in order to pick up the older version of Java.