### PR TITLE
[DOCS] Updates version attribute file

### DIFF
--- a/docs/src/reference/asciidoc/index.adoc
+++ b/docs/src/reference/asciidoc/index.adoc
@@ -18,7 +18,7 @@
 :hv-v:	1.2.1
 :cs-v:	2.6.3
 
-include::{asciidoc-dir}/../../shared/versions72.asciidoc[]
+include::{asciidoc-dir}/../../shared/versions73.asciidoc[]
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
 [[float]]


### PR DESCRIPTION
This PR updates the Elasticsearch for Apache Hadoop and Spark book to use appropriate version information from https://github.com/elastic/docs/blob/master/shared/versions73.asciidoc