### PR TITLE
[DOCS] Updates documentation version

### DIFF
--- a/docs/src/reference/asciidoc/index.adoc
+++ b/docs/src/reference/asciidoc/index.adoc
@@ -11,9 +11,9 @@
 :ey:	Elasticsearch on YARN
 :ref:  	http://www.elastic.co/guide/en/elasticsearch/reference/5.0
 :description: Reference documentation of {eh}
-:ver:	6.8.0
+:ver:	6.8.1
 :ver-d: 6.8.1.BUILD-SNAPSHOT
-:es-v:	6.8.0
+:es-v:	6.8.1
 :sp-v:	2.2.0
 :st-v:	1.0.1
 :pg-v:	0.15.0

--- a/docs/src/reference/asciidoc/index.adoc
+++ b/docs/src/reference/asciidoc/index.adoc
@@ -12,7 +12,7 @@
 :ref:  	http://www.elastic.co/guide/en/elasticsearch/reference/5.0
 :description: Reference documentation of {eh}
 :ver:	6.8.1
-:ver-d: 6.8.1.BUILD-SNAPSHOT
+:ver-d: 6.8.2.BUILD-SNAPSHOT
 :es-v:	6.8.1
 :sp-v:	2.2.0
 :st-v:	1.0.1


### PR DESCRIPTION
Related to https://github.com/elastic/docs/issues/930

This PR updates the documentation version attributes from 6.8.0 to 6.8.1