### PR TITLE
Revert "Revert build-tools to older version (#1279)"

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -7,13 +7,11 @@ apply plugin: 'groovy'
  */
 
 boolean localRepo = project.getProperties().containsKey("localRepo")
-localRepo = false // TODO: Remove this once we can safely depend on build-tools again.
 
 Properties props = new Properties()
 props.load(project.file('esh-version.properties').newDataInputStream())
 String eshVersion = props.getProperty('eshadoop')
 String esVersion = props.getProperty('elasticsearch')
-String buildToolsVersion = props.getProperty('build-tools') // TODO: Remove this once we can safely depend on build-tools again.
 
 // determine if we're building a prerelease or candidate (alphaX/betaX/rcX)
 String qualifier = System.getProperty("build.version_qualifier", "")
@@ -60,9 +58,9 @@ dependencies {
     compile 'org.springframework.build.gradle:propdeps-plugin:0.0.7'
 
     if (localRepo) {
-        compile name: "build-tools-${buildToolsVersion}"
+        compile name: "build-tools-${esVersion}"
     } else {
-        compile group: 'org.elasticsearch.gradle', name: 'build-tools', version: buildToolsVersion
+        compile group: 'org.elasticsearch.gradle', name: 'build-tools', version: esVersion
     }
 }
 

--- a/buildSrc/esh-version.properties
+++ b/buildSrc/esh-version.properties
@@ -1,4 +1,2 @@
 eshadoop        = 7.3.0
 elasticsearch   = 7.3.0
-lucene          = 8.1.0-snapshot-e460356abe
-build-tools     = 7.1.1

--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/BuildPlugin.groovy
@@ -12,6 +12,7 @@ import org.gradle.api.artifacts.DependencySubstitutions
 import org.gradle.api.artifacts.ResolutionStrategy
 import org.gradle.api.artifacts.maven.MavenPom
 import org.gradle.api.artifacts.maven.MavenResolver
+import org.gradle.api.artifacts.repositories.IvyArtifactRepository
 import org.gradle.api.file.CopySpec
 import org.gradle.api.java.archives.Manifest
 import org.gradle.api.plugins.JavaPlugin
@@ -90,14 +91,13 @@ class BuildPlugin implements Plugin<Project>  {
      */
     private static void configureVersions(Project project) {
         if (!project.rootProject.ext.has('versionsConfigured')) {
-            project.rootProject.version = EshVersionProperties.ESHADOOP_VERSION
+            project.rootProject.version = VersionProperties.ESHADOOP_VERSION
             println "Building version [${project.rootProject.version}]"
 
-            project.rootProject.ext.eshadoopVersion = EshVersionProperties.ESHADOOP_VERSION
-            project.rootProject.ext.elasticsearchVersion = EshVersionProperties.ELASTICSEARCH_VERSION
-            project.rootProject.ext.luceneVersion = EshVersionProperties.ELASTICSEARCH_VERSION
-            project.rootProject.ext.buildToolsVersion = EshVersionProperties.BUILD_TOOLS_VERSION
-            project.rootProject.ext.versions = EshVersionProperties.VERSIONS
+            project.rootProject.ext.eshadoopVersion = VersionProperties.ESHADOOP_VERSION
+            project.rootProject.ext.elasticsearchVersion = VersionProperties.ELASTICSEARCH_VERSION
+            project.rootProject.ext.luceneVersion = org.elasticsearch.gradle.VersionProperties.lucene
+            project.rootProject.ext.versions = VersionProperties.VERSIONS
             project.rootProject.ext.versionsConfigured = true
 
             println "Testing against Elasticsearch [${project.rootProject.ext.elasticsearchVersion}] with Lucene [${project.rootProject.ext.luceneVersion}]"
@@ -127,7 +127,6 @@ class BuildPlugin implements Plugin<Project>  {
         project.ext.eshadoopVersion = project.rootProject.ext.eshadoopVersion
         project.ext.elasticsearchVersion = project.rootProject.ext.elasticsearchVersion
         project.ext.luceneVersion = project.rootProject.ext.luceneVersion
-        project.ext.buildToolsVersion = project.rootProject.ext.buildToolsVersion
         project.ext.versions = project.rootProject.ext.versions
         project.ext.hadoopVersion = project.rootProject.ext.hadoopVersion
         project.ext.hadoopClient = project.rootProject.ext.hadoopClient

--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/RootBuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/RootBuildPlugin.groovy
@@ -6,6 +6,7 @@ import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.file.CopySpec
 import org.gradle.api.file.DuplicatesStrategy
+import org.gradle.api.tasks.TaskInputs
 import org.gradle.api.tasks.bundling.Jar
 import org.gradle.api.tasks.bundling.Zip
 

--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/VersionProperties.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/VersionProperties.groovy
@@ -3,24 +3,20 @@ package org.elasticsearch.hadoop.gradle
 /**
  * Loads the locally available version information from the build source.
  */
-class EshVersionProperties {
+class VersionProperties {
 
     public static final String ESHADOOP_VERSION
     public static final String ELASTICSEARCH_VERSION
-    public static final String LUCENE_VERSION
-    public static final String BUILD_TOOLS_VERSION
     public static final Map<String, String> VERSIONS
     static {
         Properties versionProperties = new Properties()
-        InputStream propertyStream = EshVersionProperties.class.getResourceAsStream('/esh-version.properties')
+        InputStream propertyStream = VersionProperties.class.getResourceAsStream('/esh-version.properties')
         if (propertyStream == null) {
             throw new RuntimeException("Could not locate the esh-version.properties file!")
         }
         versionProperties.load(propertyStream)
         ESHADOOP_VERSION = versionProperties.getProperty('eshadoop')
         ELASTICSEARCH_VERSION = versionProperties.getProperty('elasticsearch')
-        LUCENE_VERSION = versionProperties.getProperty('lucene')
-        BUILD_TOOLS_VERSION = versionProperties.getProperty('build-tools')
         VERSIONS = new HashMap<>()
         for (String propertyName: versionProperties.stringPropertyNames()) {
             VERSIONS.put(propertyName, versionProperties.getProperty(propertyName))

--- a/qa/build.gradle
+++ b/qa/build.gradle
@@ -32,7 +32,6 @@ subprojects {
     // a local repo if we're currently in the release manager (unlikely, but be future proof).
     buildscript {
         boolean localRepo = project.getProperties().containsKey("localRepo")
-        localRepo = false // TODO: Remove this once we can safely depend on build-tools again.
         repositories {
             jcenter()
             mavenCentral()
@@ -47,7 +46,7 @@ subprojects {
             if (localRepo) {
                 classpath name: "build-tools-${version}"
             } else {
-                classpath group: 'org.elasticsearch.gradle', name: 'build-tools', version: project.ext.buildToolsVersion
+                classpath group: 'org.elasticsearch.gradle', name: 'build-tools', version: project.ext.elasticsearchVersion
             }
         }
     }

--- a/qa/kerberos/build.gradle
+++ b/qa/kerberos/build.gradle
@@ -40,7 +40,6 @@ configurations {
 }
 
 boolean localRepo = project.getProperties().containsKey("localRepo")
-localRepo = false // TODO: Remove this once we can safely depend on build-tools again.
 
 dependencies {
     compile project(":elasticsearch-hadoop-mr")


### PR DESCRIPTION
I am just prepping this PR to see if the latest dependencies are in place such that this build-tools workaround is no longer necessary