### PR TITLE
Fix DataFrameFieldExtractor results when receiving nested rows.

### DIFF
--- a/spark/sql-13/src/main/scala/org/elasticsearch/spark/sql/DataFrameFieldExtractor.scala
+++ b/spark/sql-13/src/main/scala/org/elasticsearch/spark/sql/DataFrameFieldExtractor.scala
@@ -47,7 +47,7 @@ class DataFrameFieldExtractor extends ScalaMapFieldExtractor {
 
     // Return the value or unpack the value if it's a row-schema tuple
     obj match {
-      case (row: Row, _: StructType) => row
+      case (row: Row, structType: StructType) => (row, structType)
       case any => any
     }
   }

--- a/spark/sql-13/src/test/scala/org/elasticsearch/spark/sql/DataFrameFieldExtractorTest.scala
+++ b/spark/sql-13/src/test/scala/org/elasticsearch/spark/sql/DataFrameFieldExtractorTest.scala
@@ -59,7 +59,9 @@ class DataFrameFieldExtractorTest {
           StructField("test", StringType)
         )))
       )))
-    val expected = Row("target")
+    val expected = (Row("target"), StructType(Seq(
+      StructField("test", StringType)
+    )))
     val actual = extractor.field(data)
 
     assertEquals(expected, actual)

--- a/spark/sql-20/src/main/scala/org/elasticsearch/spark/sql/DataFrameFieldExtractor.scala
+++ b/spark/sql-20/src/main/scala/org/elasticsearch/spark/sql/DataFrameFieldExtractor.scala
@@ -23,6 +23,7 @@ import org.apache.spark.sql.types.StructType
 import org.elasticsearch.hadoop.serialization.field.FieldExtractor
 import org.elasticsearch.spark.serialization.ScalaMapFieldExtractor
 
+
 class DataFrameFieldExtractor extends ScalaMapFieldExtractor {
 
   override protected def extractField(target: AnyRef): AnyRef = {
@@ -47,7 +48,7 @@ class DataFrameFieldExtractor extends ScalaMapFieldExtractor {
 
     // Return the value or unpack the value if it's a row-schema tuple
     obj match {
-      case (row: Row, _: StructType) => row
+      case (row: Row, structType: StructType) => (row, structType)
       case any => any
     }
   }

--- a/spark/sql-20/src/test/scala/org/elasticsearch/spark/sql/DataFrameFieldExtractorTest.scala
+++ b/spark/sql-20/src/test/scala/org/elasticsearch/spark/sql/DataFrameFieldExtractorTest.scala
@@ -59,7 +59,9 @@ class DataFrameFieldExtractorTest {
           StructField("test", StringType)
         )))
       )))
-    val expected = Row("target")
+    val expected = (Row("target"),StructType(Seq(
+      StructField("test", StringType)
+    )))
     val actual = extractor.field(data)
 
     assertEquals(expected, actual)


### PR DESCRIPTION
This fixes the issue when trying to update data by script using nested fields in a dataframe.

Thank you for submitting a pull request! 

Please make sure you have signed our [Contributor License Agreement (CLA)][].  
We are not asking you to assign copyright to us, but to give us the right to distribute your code without restriction. We ask this of all contributors in order to assure our users of the origin and continuing existence of the code.  
You only need to sign the CLA once.

- [X] I have signed the [Contributor License Agreement (CLA)][]

[Contributor License Agreement (CLA)]: https://www.elastic.co/contributor-agreement/
