### PR TITLE
[DOCS] Bump docs version from 7.2.0 to 7.2.1

### DIFF
--- a/docs/src/reference/asciidoc/index.adoc
+++ b/docs/src/reference/asciidoc/index.adoc
@@ -9,7 +9,7 @@
 :krb:   Kerberos
 :ey:	Elasticsearch on YARN
 :description: Reference documentation of {eh}
-:ver:	7.2.0
+:ver:	7.2.1
 :ver-d: 7.2.1-SNAPSHOT
 :es-v:	7.2.1-SNAPSHOT
 :sp-v:	2.2.0


### PR DESCRIPTION
Increments the documentation attribute for the 7.2.1 release.

Will merge on release day.