### PR TITLE
[DOCS] Fix broken links for ES API docs move

### DIFF
--- a/docs/src/reference/asciidoc/core/configuration.adoc
+++ b/docs/src/reference/asciidoc/core/configuration.adoc
@@ -211,7 +211,7 @@ Will not work on Elasticsearch 6.0+ index versions, but support will continue fo
 added[2.1]
 `es.mapping.include` (default none)::
 Field/property to be included in the document sent to {es}. Useful for _extracting_ the needed data from entities. The syntax is similar
-to that of {es} {ref}/search-request-source-filtering.html[include/exclude].
+to that of {es} {ref}/search-request-body.html#search-request-source-filtering[include/exclude].
 Multiple values can be specified by using a comma. By default, no value is specified meaning all properties/fields are included.
 
 IMPORTANT: The `es.mapping.include` feature is ignored when `es.input.json` is specified. In order to prevent the connector from indexing
@@ -220,7 +220,7 @@ data that is implicitly excluded, any jobs with these property conflicts will re
 added[2.1]
 `es.mapping.exclude` (default none)::
 Field/property to be excluded in the document sent to {es}. Useful for _eliminating_ unneeded data from entities. The syntax is similar
-to that of {es} {ref}/search-request-source-filtering.html[include/exclude].
+to that of {es} {ref}/search-request-body.html#search-request-source-filtering[include/exclude].
 Multiple values can be specified by using a comma. By default, no value is specified meaning no properties/fields are excluded.
 
 IMPORTANT: The `es.mapping.exclude` feature is ignored when `es.input.json` is specified. In order to prevent the connector from indexing
@@ -279,7 +279,7 @@ added[2.2]
 Fields/properties that should be considered as arrays/lists. Since {es} can map one or multiple values to a field, {eh} cannot determine from the mapping
 whether to instantiate one value or a array type (depending on the library type). When encountering multiple values, {eh} will automatically use 
 the array/list type but in strict mapping scenarios (like Spark SQL) this might lead to an unexpected schema change.
-The syntax is similar to that of {es} {ref}/search-request-source-filtering.html[include/exclude]. 
+The syntax is similar to that of {es} {ref}/search-request-body.html#search-request-source-filtering[include/exclude]. 
 Multiple values can be specified by using a comma. By default, no value is specified meaning no properties/fields are included.
 
 For example:

--- a/docs/src/reference/asciidoc/core/spark.adoc
+++ b/docs/src/reference/asciidoc/core/spark.adoc
@@ -1553,7 +1553,7 @@ val smiths = sqlContext.esDF("spark/people","?q=Smith" <1>)
 
 In some cases, especially when the index in {es} contains a lot of fields, it is desireable to create a +DataFrame+ that contains only a _subset_ of them. While one can modify the +DataFrame+ (by working on its backing +RDD+) through the official Spark API or through dedicated queries, {eh} allows the user to specify what fields to include and exclude from {es} when creating the +DataFrame+.
 
-Through +es.read.field.include+ and +es.read.field.exclude+ properties, one can indicate what fields to include or exclude from the index mapping. The syntax is similar to that of {es} {ref}/search-request-source-filtering.html[include/exclude]. Multiple values can be specified by using a comma. By default, no value is specified meaning all properties/fields are included and no properties/fields are excluded.
+Through +es.read.field.include+ and +es.read.field.exclude+ properties, one can indicate what fields to include or exclude from the index mapping. The syntax is similar to that of {es} {ref}/search-request-body.html#search-request-source-filtering[include/exclude]. Multiple values can be specified by using a comma. By default, no value is specified meaning all properties/fields are included and no properties/fields are excluded.
 
 For example:
 [source,ini]


### PR DESCRIPTION
elastic/elasticsearch/pull/44238 moved several Elasticsearch APIs to a REST APIs section.

As a result of that move, some pages were converted to anchored sections. This will fix links to those pages once the above PR is re-applied.

I plan to merge this PR simultaneously with:
- elastic/elasticsearch/pull/44238
- elastic/elasticsearch/pull/44279
- elastic/kibana/pull/41001
- elastic/stack-docs/pull/411