### PR TITLE
Fix Lucene's snapshot version

### DIFF
--- a/buildSrc/esh-version.properties
+++ b/buildSrc/esh-version.properties
@@ -1,4 +1,4 @@
 eshadoop        = 7.4.0
 elasticsearch   = 7.4.0
-lucene          = 8.1.0-snapshot-e460356abe
+lucene          = 8.1.0-snapshot-860e0be5378
 build-tools     = 7.1.1

--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/BuildPlugin.groovy
@@ -95,7 +95,7 @@ class BuildPlugin implements Plugin<Project>  {
 
             project.rootProject.ext.eshadoopVersion = EshVersionProperties.ESHADOOP_VERSION
             project.rootProject.ext.elasticsearchVersion = EshVersionProperties.ELASTICSEARCH_VERSION
-            project.rootProject.ext.luceneVersion = EshVersionProperties.ELASTICSEARCH_VERSION
+            project.rootProject.ext.luceneVersion = EshVersionProperties.LUCENE_VERSION
             project.rootProject.ext.buildToolsVersion = EshVersionProperties.BUILD_TOOLS_VERSION
             project.rootProject.ext.versions = EshVersionProperties.VERSIONS
             project.rootProject.ext.versionsConfigured = true
@@ -204,7 +204,7 @@ class BuildPlugin implements Plugin<Project>  {
             String revision = (project.ext.luceneVersion =~ /\w+-snapshot-([a-z0-9]+)/)[0][1]
             project.repositories.maven {
                 name 'lucene-snapshots'
-                url "http://s3.amazonaws.com/download.elasticsearch.org/lucenesnapshots/${revision}"
+                url "https://s3.amazonaws.com/download.elasticsearch.org/lucenesnapshots/${revision}"
             }
         }
     }


### PR DESCRIPTION
Lucene's snapshot version was wrong which resulted in failed builds.

1. ES version was used instead of Lucene version in the BuildPlugin`
2. Lucene's snapshot version was wrong in the properties file
