### PR TITLE
[DOCS] Update anchors and links for Elasticserach API relocation.

### DIFF
--- a/docs/src/reference/asciidoc/core/configuration.adoc
+++ b/docs/src/reference/asciidoc/core/configuration.adoc
@@ -211,7 +211,7 @@ Will not work on Elasticsearch 6.0+ index versions, but support will continue fo
 added[2.1]
 `es.mapping.include` (default none)::
 Field/property to be included in the document sent to {es}. Useful for _extracting_ the needed data from entities. The syntax is similar
-to that of {es} {ref}/search-request-source-filtering.html[include/exclude].
+to that of {es} {ref}/search-request-body.html#request-body-search-source-filtering[include/exclude].
 Multiple values can be specified by using a comma. By default, no value is specified meaning all properties/fields are included.
 
 IMPORTANT: The `es.mapping.include` feature is ignored when `es.input.json` is specified. In order to prevent the connector from indexing
@@ -220,7 +220,7 @@ data that is implicitly excluded, any jobs with these property conflicts will re
 added[2.1]
 `es.mapping.exclude` (default none)::
 Field/property to be excluded in the document sent to {es}. Useful for _eliminating_ unneeded data from entities. The syntax is similar
-to that of {es} {ref}/search-request-source-filtering.html[include/exclude].
+to that of {es} {ref}/search-request-body.html#request-body-search-source-filtering[include/exclude].
 Multiple values can be specified by using a comma. By default, no value is specified meaning no properties/fields are excluded.
 
 IMPORTANT: The `es.mapping.exclude` feature is ignored when `es.input.json` is specified. In order to prevent the connector from indexing
@@ -279,7 +279,7 @@ added[2.2]
 Fields/properties that should be considered as arrays/lists. Since {es} can map one or multiple values to a field, {eh} cannot determine from the mapping
 whether to instantiate one value or a array type (depending on the library type). When encountering multiple values, {eh} will automatically use 
 the array/list type but in strict mapping scenarios (like Spark SQL) this might lead to an unexpected schema change.
-The syntax is similar to that of {es} {ref}/search-request-source-filtering.html[include/exclude]. 
+The syntax is similar to that of {es} {ref}/search-request-body.html#request-body-search-source-filtering[include/exclude]. 
 Multiple values can be specified by using a comma. By default, no value is specified meaning no properties/fields are included.
 
 For example:

--- a/docs/src/reference/asciidoc/core/spark.adoc
+++ b/docs/src/reference/asciidoc/core/spark.adoc
@@ -1577,7 +1577,7 @@ val smiths = sqlContext.esDF("spark/people","?q=Smith") <1>
 
 In some cases, especially when the index in {es} contains a lot of fields, it is desireable to create a +DataFrame+ that contains only a _subset_ of them. While one can modify the +DataFrame+ (by working on its backing +RDD+) through the official Spark API or through dedicated queries, {eh} allows the user to specify what fields to include and exclude from {es} when creating the +DataFrame+.
 
-Through +es.read.field.include+ and +es.read.field.exclude+ properties, one can indicate what fields to include or exclude from the index mapping. The syntax is similar to that of {es} {ref}/search-request-source-filtering.html[include/exclude]. Multiple values can be specified by using a comma. By default, no value is specified meaning all properties/fields are included and no properties/fields are excluded.
+Through +es.read.field.include+ and +es.read.field.exclude+ properties, one can indicate what fields to include or exclude from the index mapping. The syntax is similar to that of {es} {ref}/search-request-body.html#request-body-search-source-filtering[include/exclude]. Multiple values can be specified by using a comma. By default, no value is specified meaning all properties/fields are included and no properties/fields are excluded.
 
 For example:
 [source,ini]


### PR DESCRIPTION
elastic/elasticsearch#44372 moved the navigation for several Elasticsearch APIs under the [REST APIs section](https://www.elastic.co/guide/en/elasticsearch/reference/master/rest-apis.html). That PR included [several redirects](https://github.com/elastic/elasticsearch/pull/44372/files#diff-427622c7e85f29d0b8f204c583e153f1) to avoid broken links.

This PR updates links pointing to those redirected anchors and links. This saves users a step when visiting these links.

[skip ci]