### PR TITLE
Use new snapshot of build-tools with Java 8 support

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -58,6 +58,7 @@ dependencies {
 
     // Provided/Optional Dependencies
     compile 'org.springframework.build.gradle:propdeps-plugin:0.0.7'
+    implementation 'org.apache.logging.log4j:log4j-core:2.11.1'
 
     // TODO: Un-comment this once we can safely depend on build-tools again.
 //    if (localRepo) {

--- a/buildSrc/esh-version.properties
+++ b/buildSrc/esh-version.properties
@@ -1,4 +1,3 @@
 eshadoop        = 7.4.0
 elasticsearch   = 7.4.0
-lucene          = 8.1.0-snapshot-860e0be5378
-build-tools     = 7.1.1
+build-tools     = 7.4.0-SNAPSHOT

--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/EshVersionProperties.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/EshVersionProperties.groovy
@@ -7,7 +7,6 @@ class EshVersionProperties {
 
     public static final String ESHADOOP_VERSION
     public static final String ELASTICSEARCH_VERSION
-    public static final String LUCENE_VERSION
     public static final String BUILD_TOOLS_VERSION
     public static final Map<String, String> VERSIONS
     static {
@@ -19,7 +18,6 @@ class EshVersionProperties {
         versionProperties.load(propertyStream)
         ESHADOOP_VERSION = versionProperties.getProperty('eshadoop')
         ELASTICSEARCH_VERSION = versionProperties.getProperty('elasticsearch')
-        LUCENE_VERSION = versionProperties.getProperty('lucene')
         BUILD_TOOLS_VERSION = versionProperties.getProperty('build-tools')
         VERSIONS = new HashMap<>()
         for (String propertyName: versionProperties.stringPropertyNames()) {


### PR DESCRIPTION
Part of 7.x build-tools now have Java 8 support, so VersionProperties
can be used to retrieve Lucene's snapshot version and therefore there is
no need to set it manually to the properties file.

Fixes: #1321
