### PR TITLE
Bump version to 7.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Grab the latest nightly build from the [repository](http://oss.sonatype.org/cont
 <dependency>
   <groupId>org.elasticsearch</groupId>
   <artifactId>elasticsearch-hadoop</artifactId>
-  <version>7.3.0-SNAPSHOT</version>
+  <version>7.3.1-SNAPSHOT</version>
 </dependency>
 ```
 

--- a/buildSrc/esh-version.properties
+++ b/buildSrc/esh-version.properties
@@ -1,4 +1,4 @@
-eshadoop        = 7.3.0
-elasticsearch   = 7.3.0
+eshadoop        = 7.3.1
+elasticsearch   = 7.3.1
 lucene          = 8.1.0-snapshot-e460356abe
 build-tools     = 7.1.1

--- a/docs/src/reference/asciidoc/index.adoc
+++ b/docs/src/reference/asciidoc/index.adoc
@@ -10,8 +10,8 @@
 :ey:	Elasticsearch on YARN
 :description: Reference documentation of {eh}
 :ver:	7.3.0
-:ver-d: 7.3.0-SNAPSHOT
-:es-v:	7.3.0-SNAPSHOT
+:ver-d: 7.3.1-SNAPSHOT
+:es-v:	7.3.1-SNAPSHOT
 :sp-v:	2.2.0
 :st-v:	1.0.1
 :pg-v:	0.15.0

--- a/docs/src/reference/asciidoc/index.adoc
+++ b/docs/src/reference/asciidoc/index.adoc
@@ -11,7 +11,7 @@
 :description: Reference documentation of {eh}
 :ver:	7.3.0
 :ver-d: 7.3.1-SNAPSHOT
-:es-v:	7.3.1-SNAPSHOT
+:es-v:	7.3.0
 :sp-v:	2.2.0
 :st-v:	1.0.1
 :pg-v:	0.15.0


### PR DESCRIPTION
Prepping for version bump.

Do not merge until green light given to bump versions (CI failures are expected)