### PR TITLE
Do not retry scroll requests in NetworkClient.

### DIFF
--- a/mr/src/main/java/org/elasticsearch/hadoop/rest/RestClient.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/rest/RestClient.java
@@ -412,6 +412,10 @@ public class RestClient implements Closeable, StatsAware {
         return execute(new SimpleRequest(method, null, path, null, buffer), checkStatus);
     }
 
+    protected Response execute(Method method, String path, ByteSequence buffer, boolean checkStatus, boolean retry) {
+        return execute(new SimpleRequest(method, null, path, null, buffer), checkStatus, retry);
+    }
+
     protected Response execute(Method method, String path, String params, ByteSequence buffer) {
         return execute(new SimpleRequest(method, null, path, params, buffer), true);
     }
@@ -421,7 +425,11 @@ public class RestClient implements Closeable, StatsAware {
     }
 
     protected Response execute(Request request, boolean checkStatus) {
-        Response response = network.execute(request);
+        return execute(request, checkStatus, true);
+    }
+
+    protected Response execute(Request request, boolean checkStatus, boolean retry) {
+        Response response = network.execute(request, retry);
         if (checkStatus) {
             checkResponse(request, response);
         }
@@ -481,7 +489,9 @@ public class RestClient implements Closeable, StatsAware {
                 body = new BytesArray(scrollId);
             }
             // use post instead of get to avoid some weird encoding issues (caused by the long URL)
-            InputStream is = execute(POST, "_search/scroll?scroll=" + scrollKeepAlive.toString(), body).body();
+            // do not retry the request on another node, because that can lead to ES returning a error or
+            // less data being returned than requested.  See: https://github.com/elastic/elasticsearch-hadoop/issues/1302
+            InputStream is = execute(POST, "_search/scroll?scroll=" + scrollKeepAlive.toString(), body, true, false).body();
             stats.scrollTotal++;
             return is;
         } finally {

--- a/mr/src/test/java/org/elasticsearch/hadoop/rest/NetworkClientTest.java
+++ b/mr/src/test/java/org/elasticsearch/hadoop/rest/NetworkClientTest.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.hadoop.rest;
+
+import org.elasticsearch.hadoop.EsHadoopException;
+import org.elasticsearch.hadoop.util.TestSettings;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class NetworkClientTest {
+
+    @Test
+    public void testExecuteRetry() throws Exception {
+        TransportFactory mockFactory = mock(TransportFactory.class);
+        Transport mockTransport = mock(Transport.class);
+        when(mockFactory.create(any(), any(), any())).thenReturn(mockTransport);
+
+        when(mockTransport.execute(any())).thenThrow(new RuntimeException("whoops"));
+        NetworkClient networkClient = new NetworkClient(new TestSettings(), mockFactory);
+        SimpleRequest simpleRequest = new SimpleRequest(Request.Method.GET, "", "");
+        try {
+            networkClient.execute(simpleRequest);
+            fail("exception should have been thrown");
+        } catch (Exception e) {
+            // EsHadoopNoNodesLeftException indicates we tried to retry (even if there is just a single node)
+            assertEquals(EsHadoopNoNodesLeftException.class, e.getClass());
+        }
+    }
+
+    @Test
+    public void testExecuteNoRetry() throws Exception {
+        TransportFactory mockFactory = mock(TransportFactory.class);
+        Transport mockTransport = mock(Transport.class);
+        when(mockFactory.create(any(), any(), any())).thenReturn(mockTransport);
+
+        when(mockTransport.execute(any())).thenThrow(new RuntimeException("whoops"));
+        NetworkClient networkClient = new NetworkClient(new TestSettings(), mockFactory);
+        SimpleRequest simpleRequest = new SimpleRequest(Request.Method.GET, "", "");
+        try {
+            networkClient.execute(simpleRequest, false);
+            fail("exception should have been thrown");
+        } catch (Exception e) {
+            assertTrue(e.getMessage().contains("Retrying has been disabled. Aborting..."));
+            assertEquals(EsHadoopException.class, e.getClass());
+        }
+    }
+
+}

--- a/mr/src/test/java/org/elasticsearch/hadoop/rest/RestClientTest.java
+++ b/mr/src/test/java/org/elasticsearch/hadoop/rest/RestClientTest.java
@@ -21,6 +21,7 @@ package org.elasticsearch.hadoop.rest;
 
 import org.elasticsearch.hadoop.cfg.Settings;
 import org.elasticsearch.hadoop.rest.query.MatchAllQueryBuilder;
+import org.elasticsearch.hadoop.rest.stats.Stats;
 import org.elasticsearch.hadoop.util.BytesArray;
 import org.elasticsearch.hadoop.util.ClusterInfo;
 import org.elasticsearch.hadoop.util.EsMajorVersion;
@@ -28,6 +29,8 @@ import org.elasticsearch.hadoop.util.FastByteArrayInputStream;
 import org.elasticsearch.hadoop.util.TestSettings;
 import org.junit.Test;
 import org.mockito.Mockito;
+
+import java.io.InputStream;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -62,7 +65,8 @@ public class RestClientTest {
                 "}";
 
         NetworkClient mock = Mockito.mock(NetworkClient.class);
-        Mockito.when(mock.execute(Mockito.eq(request))).thenReturn(new SimpleResponse(201, new FastByteArrayInputStream(new BytesArray(response)), "localhost:9200"));
+        Mockito.when(mock.execute(Mockito.eq(request), Mockito.eq(true)))
+                .thenReturn(new SimpleResponse(201, new FastByteArrayInputStream(new BytesArray(response)), "localhost:9200"));
 
         RestClient client = new RestClient(new TestSettings(), mock);
 
@@ -97,7 +101,8 @@ public class RestClientTest {
                 "}";
 
         NetworkClient mock = Mockito.mock(NetworkClient.class);
-        Mockito.when(mock.execute(Mockito.eq(request))).thenReturn(new SimpleResponse(201, new FastByteArrayInputStream(new BytesArray(response)), "localhost:9200"));
+        Mockito.when(mock.execute(Mockito.eq(request), Mockito.eq(true)))
+                .thenReturn(new SimpleResponse(201, new FastByteArrayInputStream(new BytesArray(response)), "localhost:9200"));
 
         RestClient client = new RestClient(new TestSettings(), mock);
 
@@ -135,7 +140,8 @@ public class RestClientTest {
                 "}";
 
         NetworkClient mock = Mockito.mock(NetworkClient.class);
-        Mockito.when(mock.execute(Mockito.eq(request))).thenReturn(new SimpleResponse(400, new FastByteArrayInputStream(new BytesArray(response)), "localhost:9200"));
+        Mockito.when(mock.execute(Mockito.eq(request), Mockito.eq(true)))
+                .thenReturn(new SimpleResponse(400, new FastByteArrayInputStream(new BytesArray(response)), "localhost:9200"));
 
         RestClient client = new RestClient(new TestSettings(), mock);
 
@@ -173,7 +179,8 @@ public class RestClientTest {
                 "}";
 
         NetworkClient mock = Mockito.mock(NetworkClient.class);
-        Mockito.when(mock.execute(Mockito.eq(request))).thenReturn(new SimpleResponse(400, new FastByteArrayInputStream(new BytesArray(response)), "localhost:9200"));
+        Mockito.when(mock.execute(Mockito.eq(request), Mockito.eq(true)))
+                .thenReturn(new SimpleResponse(400, new FastByteArrayInputStream(new BytesArray(response)), "localhost:9200"));
 
         RestClient client = new RestClient(new TestSettings(), mock);
 
@@ -208,7 +215,8 @@ public class RestClientTest {
                 "}";
 
         NetworkClient mock = Mockito.mock(NetworkClient.class);
-        Mockito.when(mock.execute(Mockito.eq(request))).thenReturn(new SimpleResponse(201, new FastByteArrayInputStream(new BytesArray(response)), "localhost:9200"));
+        Mockito.when(mock.execute(Mockito.eq(request), Mockito.eq(true)))
+                .thenReturn(new SimpleResponse(201, new FastByteArrayInputStream(new BytesArray(response)), "localhost:9200"));
 
         RestClient client = new RestClient(new TestSettings(), mock);
 
@@ -243,7 +251,8 @@ public class RestClientTest {
                         "}";
 
         NetworkClient mock = Mockito.mock(NetworkClient.class);
-        Mockito.when(mock.execute(Mockito.eq(request))).thenReturn(new SimpleResponse(201, new FastByteArrayInputStream(new BytesArray(response)), "localhost:9200"));
+        Mockito.when(mock.execute(Mockito.eq(request), Mockito.eq(true)))
+                .thenReturn(new SimpleResponse(201, new FastByteArrayInputStream(new BytesArray(response)), "localhost:9200"));
 
         RestClient client = new RestClient(new TestSettings(), mock);
 
@@ -278,7 +287,8 @@ public class RestClientTest {
                 "}";
 
         NetworkClient mock = Mockito.mock(NetworkClient.class);
-        Mockito.when(mock.execute(Mockito.eq(request))).thenReturn(new SimpleResponse(201, new FastByteArrayInputStream(new BytesArray(response)), "localhost:9200"));
+        Mockito.when(mock.execute(Mockito.eq(request), Mockito.eq(true)))
+                .thenReturn(new SimpleResponse(201, new FastByteArrayInputStream(new BytesArray(response)), "localhost:9200"));
 
         Settings testSettings = new TestSettings();
         testSettings.setInternalClusterInfo(ClusterInfo.unnamedClusterWithVersion(EsMajorVersion.V_5_X));
@@ -315,7 +325,8 @@ public class RestClientTest {
                         "}";
 
         NetworkClient mock = Mockito.mock(NetworkClient.class);
-        Mockito.when(mock.execute(Mockito.eq(request))).thenReturn(new SimpleResponse(201, new FastByteArrayInputStream(new BytesArray(response)), "localhost:9200"));
+        Mockito.when(mock.execute(Mockito.eq(request), Mockito.eq(true)))
+                .thenReturn(new SimpleResponse(201, new FastByteArrayInputStream(new BytesArray(response)), "localhost:9200"));
 
         Settings testSettings = new TestSettings();
         testSettings.setInternalClusterInfo(ClusterInfo.unnamedClusterWithVersion(EsMajorVersion.V_6_X));
@@ -356,7 +367,7 @@ public class RestClientTest {
 
         NetworkClient mock = Mockito.mock(NetworkClient.class);
         // Queue up two responses
-        Mockito.when(mock.execute(Mockito.eq(request)))
+        Mockito.when(mock.execute(Mockito.eq(request), Mockito.eq(true)))
                 .thenReturn(new SimpleResponse(201, new FastByteArrayInputStream(new BytesArray(response)), "localhost:9200"))
                 .thenReturn(new SimpleResponse(201, new FastByteArrayInputStream(new BytesArray(response)), "localhost:9200"));
 
@@ -400,7 +411,8 @@ public class RestClientTest {
                         "}";
 
         NetworkClient mock = Mockito.mock(NetworkClient.class);
-        Mockito.when(mock.execute(Mockito.eq(request))).thenReturn(new SimpleResponse(201, new FastByteArrayInputStream(new BytesArray(response)), "localhost:9200"));
+        Mockito.when(mock.execute(Mockito.eq(request), Mockito.eq(true)))
+                .thenReturn(new SimpleResponse(201, new FastByteArrayInputStream(new BytesArray(response)), "localhost:9200"));
 
         RestClient client = new RestClient(new TestSettings(), mock);
 
@@ -421,7 +433,8 @@ public class RestClientTest {
                 "}";
 
         NetworkClient mock = Mockito.mock(NetworkClient.class);
-        Mockito.when(mock.execute(Mockito.any(SimpleRequest.class))).thenReturn(new SimpleResponse(201, new FastByteArrayInputStream(new BytesArray(response)), "localhost:9200"));
+        Mockito.when(mock.execute(Mockito.any(SimpleRequest.class), Mockito.eq(true)))
+                .thenReturn(new SimpleResponse(201, new FastByteArrayInputStream(new BytesArray(response)), "localhost:9200"));
 
         RestClient client = new RestClient(new TestSettings(), mock);
 
@@ -444,7 +457,8 @@ public class RestClientTest {
                 "}";
 
         NetworkClient mock = Mockito.mock(NetworkClient.class);
-        Mockito.when(mock.execute(Mockito.any(SimpleRequest.class))).thenReturn(new SimpleResponse(201, new FastByteArrayInputStream(new BytesArray(response)), "localhost:9200"));
+        Mockito.when(mock.execute(Mockito.any(SimpleRequest.class), Mockito.eq(true)))
+                .thenReturn(new SimpleResponse(201, new FastByteArrayInputStream(new BytesArray(response)), "localhost:9200"));
 
         RestClient client = new RestClient(new TestSettings(), mock);
 
@@ -452,6 +466,25 @@ public class RestClientTest {
 
         assertNotNull(clusterInfo.getClusterName());
         assertEquals("uuid", clusterInfo.getClusterName().getUUID());
+    }
+
+    @Test
+    public void testScroll() {
+        NetworkClient mock = Mockito.mock(NetworkClient.class);
+        Stats stats = new Stats();
+        Mockito.when(mock.transportStats()).thenReturn(stats);
+
+        String response = "{}";
+        // Note: scroll cannot use retries:
+        Mockito.when(mock.execute(Mockito.any(SimpleRequest.class), Mockito.eq(false)))
+                .thenReturn(new SimpleResponse(201, new FastByteArrayInputStream(new BytesArray(response)), "localhost:9200"));
+
+        RestClient client = new RestClient(new TestSettings(), mock);
+
+        InputStream result = client.scroll("_id");
+        assertNotNull(result);
+
+        Mockito.verify(mock).execute(Mockito.any(SimpleRequest.class), Mockito.eq(false));
     }
 
 }


### PR DESCRIPTION
Scroll requests cannot be retried on other nodes.
This can lead to less document being returned than is expected or
ES returning an error because a scroll id is accessed multiple times.

Closes #1302