### PR TITLE
[DOCS] Bump docs version to 7.3.1

### DIFF
--- a/docs/src/reference/asciidoc/index.adoc
+++ b/docs/src/reference/asciidoc/index.adoc
@@ -9,9 +9,9 @@
 :krb:   Kerberos
 :ey:	Elasticsearch on YARN
 :description: Reference documentation of {eh}
-:ver:	7.3.0
+:ver:	7.3.1
 :ver-d: 7.3.1-SNAPSHOT
-:es-v:	7.3.0
+:es-v:	7.3.1
 :sp-v:	2.2.0
 :st-v:	1.0.1
 :pg-v:	0.15.0


### PR DESCRIPTION
Increments the documentation attribute for the 7.3.1 release.

**DO NOT MERGE UNTIL RELEASE DAY**