### PR TITLE
use File type for javaHome and bump build-tools version

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -58,6 +58,7 @@ dependencies {
 
     // Provided/Optional Dependencies
     compile 'org.springframework.build.gradle:propdeps-plugin:0.0.7'
+    implementation 'org.apache.logging.log4j:log4j-core:2.11.1'
 
     // TODO: Un-comment this once we can safely depend on build-tools again.
 //    if (localRepo) {

--- a/buildSrc/esh-version.properties
+++ b/buildSrc/esh-version.properties
@@ -1,4 +1,4 @@
 eshadoop        = 8.0.0
 elasticsearch   = 8.0.0
 lucene          = 8.1.0-snapshot-e460356abe
-build-tools     = 7.1.1
+build-tools     = 7.4.0-SNAPSHOT

--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/BuildPlugin.groovy
@@ -144,7 +144,7 @@ class BuildPlugin implements Plugin<Project>  {
         if (!project.rootProject.ext.has('settingsConfigured')) {
             project.rootProject.ext.java8 = JavaVersion.current().isJava8Compatible()
 
-            String javaHome = findJavaHome()
+            File javaHome = findJavaHome()
             // Register the currently running JVM version under its version number.
             final Map<Integer, String> javaVersions = [:]
             javaVersions.put(Integer.parseInt(JavaVersion.current().getMajorVersion()), javaHome)
@@ -650,7 +650,7 @@ class BuildPlugin implements Plugin<Project>  {
     /**
      * @return the location of the JDK for the currently executing JVM
      */
-    private static String findJavaHome() {
+    private static File findJavaHome() {
         String javaHome = System.getenv('JAVA_HOME')
         if (javaHome == null) {
             if (System.getProperty("idea.active") != null || System.getProperty("eclipse.launcher") != null) {
@@ -660,11 +660,11 @@ class BuildPlugin implements Plugin<Project>  {
                 throw new GradleException('JAVA_HOME must be set to build Elasticsearch')
             }
         }
-        return javaHome
+        return new File(javaHome);
     }
 
     /** Runs the given javascript using jjs from the jdk, and returns the output */
-    private static String runJavascript(Project project, String javaHome, String script) {
+    private static String runJavascript(Project project, File javaHome, String script) {
         ByteArrayOutputStream stdout = new ByteArrayOutputStream()
         ByteArrayOutputStream stderr = new ByteArrayOutputStream()
         if (Os.isFamily(Os.FAMILY_WINDOWS)) {


### PR DESCRIPTION
As of https://github.com/elastic/elasticsearch/pull/45677 build tools 
now uses a function that requires javaHome to be a `File` type.

This commit updates the JavaHome property to be a File type. This
commit also bumps the latest supported version of build-tools (8.0.0-SNAPSHOT
is not supported yet). 