### PR TITLE
[DOCS] Updates version attributes filename

### DIFF
--- a/docs/src/reference/asciidoc/index.adoc
+++ b/docs/src/reference/asciidoc/index.adoc
@@ -18,7 +18,7 @@
 :hv-v:	1.2.1
 :cs-v:	2.6.3
 
-include::{asciidoc-dir}/../../shared/versions74.asciidoc[]
+include::{asciidoc-dir}/../../shared/versions75.asciidoc[]
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
 [[float]]


### PR DESCRIPTION
Related to elastic/docs#1109 and elastic/docs#1108

This PR updates the Elasticsearch for Hadoop book (https://www.elastic.co/guide/en/elasticsearch/hadoop/current/index.html) in the 7.x branch to use the appropriate shared version attributes file.