### PR TITLE
Set build to use external build tools during snapshots

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -47,12 +47,13 @@ repositories {
     maven { url 'https://repo.spring.io/plugins-release' }
 
     // For Elasticsearch snapshots.
-    if (localRepo) {
-        // For some reason the root dirs all point to the buildSrc folder. The local Repo will be one above that.
-        flatDir { dirs new File(project.rootDir, "../localRepo") }
-    } else {
+    // TODO: Un-comment this once we can safely depend on build-tools again.
+//    if (localRepo) {
+//        // For some reason the root dirs all point to the buildSrc folder. The local Repo will be one above that.
+//        flatDir { dirs new File(project.rootDir, "../localRepo") }
+//    } else {
         maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
-    }
+//    }
 }
 
 dependencies {
@@ -63,11 +64,12 @@ dependencies {
     compile 'org.springframework.build.gradle:propdeps-plugin:0.0.7'
     implementation 'org.apache.logging.log4j:log4j-core:2.11.1'
 
-    if (localRepo) {
-        compile name: "build-tools-${buildToolsVersion}"
-    } else {
+    // TODO: Un-comment this once we can safely depend on build-tools again.
+//    if (localRepo) {
+//        compile name: "build-tools-${buildToolsVersion}"
+//    } else {
         compile group: 'org.elasticsearch.gradle', name: 'build-tools', version: buildToolsVersion
-    }
+//    }
 }
 
 // write the updated properties to a temp property file

--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/BuildPlugin.groovy
@@ -103,7 +103,7 @@ class BuildPlugin implements Plugin<Project>  {
             project.rootProject.ext.versionsConfigured = true
 
             println "Testing against Elasticsearch [${project.rootProject.ext.elasticsearchVersion}] with Lucene [${project.rootProject.ext.luceneVersion}]"
-
+            println "Using Elasticsearch Build Tools [${project.rootProject.ext.buildToolsVersion}]"
             println "Using Gradle [${project.gradle.gradleVersion}]"
 
             // Hadoop versions

--- a/qa/build.gradle
+++ b/qa/build.gradle
@@ -35,12 +35,13 @@ subprojects {
         repositories {
             jcenter()
             mavenCentral()
-            if (localRepo) {
-                // For some reason the root dirs all point to the buildSrc folder. The local Repo will be one above that.
-                flatDir { dirs new File(project.rootProject.rootDir, "localRepo") }
-            } else {
+            // TODO: Uncomment this once we can safely depend on build-tools again.
+//            if (localRepo) {
+//                // For some reason the root dirs all point to the buildSrc folder. The local Repo will be one above that.
+//                flatDir { dirs new File(project.rootProject.rootDir, "localRepo") }
+//            } else {
                 maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
-            }
+//            }
         }
         dependencies {
             // TODO: Uncomment this once we can safely depend on build-tools again.


### PR DESCRIPTION
This PR sets the build to return to using non-local build tools dependencies when building snapshots.

Related to #1347