### PR TITLE
[DOCS] Updates location of version attribute for Apache Hadoop Guide

### DIFF
--- a/docs/src/reference/asciidoc/index.adoc
+++ b/docs/src/reference/asciidoc/index.adoc
@@ -18,7 +18,7 @@
 :hv-v:	1.2.1
 :cs-v:	2.6.3
 
-include::{asciidoc-dir}/../../shared/versions.asciidoc[]
+include::{asciidoc-dir}/../../shared/versions/stack/{source_branch}.asciidoc[]
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
 [[float]]


### PR DESCRIPTION
Related to elastic/docs#804
Depends on elastic/docs#1148 and elastic/docs#1147

This PR changes the location of the shared version attributes (so that updates are not required every time there's a new branch).