### PR TITLE
Remove Scala 2.10 Support

### DIFF
--- a/spark/sql-13/build.gradle
+++ b/spark/sql-13/build.gradle
@@ -3,13 +3,13 @@ description = "Elasticsearch Spark (for Spark 1.3-1.6)"
 
 evaluationDependsOn(':elasticsearch-hadoop-mr')
 
-apply plugin: 'es.hadoop.build'
 apply plugin: 'scala'
+apply plugin: 'es.hadoop.build'
 apply plugin: 'scala.variants'
 
 variants {
     defaultVersion '2.11.12'
-    targetVersions '2.10.7', '2.11.12'
+    targetVersions '2.11.12'
 }
 
 println "Compiled using Scala ${project.ext.scalaMajorVersion} [${project.ext.scalaVersion}]"
@@ -21,14 +21,14 @@ compileScala {
         jvmArgs = ['-XX:MaxPermSize=512m']
     }
     scalaCompileOptions.additionalParameters = [
-            "-feature",
-            "-unchecked",
-            "-deprecation",
-            "-Xfuture",
-            "-Yno-adapted-args",
-            "-Ywarn-dead-code",
-            "-Ywarn-numeric-widen",
-            "-Xfatal-warnings"
+        "-feature",
+        "-unchecked",
+        "-deprecation",
+        "-Xfuture",
+        "-Yno-adapted-args",
+        "-Ywarn-dead-code",
+        "-Ywarn-numeric-widen",
+        "-Xfatal-warnings"
     ]
 }
 

--- a/spark/sql-20/build.gradle
+++ b/spark/sql-20/build.gradle
@@ -9,7 +9,7 @@ apply plugin: 'scala.variants'
 
 variants {
     defaultVersion '2.11.12'
-    targetVersions '2.10.7', '2.11.12'
+    targetVersions '2.11.12'
 }
 
 println "Compiled using Scala ${project.ext.scalaMajorVersion} [${project.ext.scalaVersion}]"


### PR DESCRIPTION
Scala 2.10 has been around since December 2012, and Spark has deprecated and recently dropped support for it in the more recent releases. On top of this, Scala 2.10 is blocking us from upgrading the version of Java that we use to run the build in ES-Hadoop. Due to these factors, we should remove support for Scala 2.10 artifacts in the next major release (8.0).

Relates #1347 