### PR TITLE
[DOCS] Use shared attributes

### DIFF
--- a/docs/src/reference/asciidoc/core/intro/download.adoc
+++ b/docs/src/reference/asciidoc/core/intro/download.adoc
@@ -8,7 +8,7 @@
 <dependency>
   <groupId>org.elasticsearch</groupId>
   <artifactId>elasticsearch-hadoop</artifactId>
-  <version>{ver}</version>
+  <version>{version}</version>
 </dependency>
 ----
 
@@ -29,7 +29,7 @@ These are available under the same `groupId`, using an `artifactId` with the pat
 <dependency>
   <groupId>org.elasticsearch</groupId>
   <artifactId>elasticsearch-hadoop-mr</artifactId> <1>
-  <version>{ver}</version>
+  <version>{version}</version>
 </dependency>
 ----
 
@@ -41,7 +41,7 @@ These are available under the same `groupId`, using an `artifactId` with the pat
 <dependency>
   <groupId>org.elasticsearch</groupId>
   <artifactId>elasticsearch-hadoop-hive</artifactId> <1>
-  <version>{ver}</version>
+  <version>{version}</version>
 </dependency>
 ----
 
@@ -53,7 +53,7 @@ These are available under the same `groupId`, using an `artifactId` with the pat
 <dependency>
   <groupId>org.elasticsearch</groupId>
   <artifactId>elasticsearch-hadoop-pig</artifactId> <1>
-  <version>{ver}</version>
+  <version>{version}</version>
 </dependency>
 ----
 
@@ -65,7 +65,7 @@ These are available under the same `groupId`, using an `artifactId` with the pat
 <dependency>
   <groupId>org.elasticsearch</groupId>
   <artifactId>elasticsearch-spark-20_2.10</artifactId> <1>
-  <version>{ver}</version>
+  <version>{version}</version>
 </dependency>
 ----
 
@@ -93,7 +93,7 @@ The Spark connector framework is the most sensitive to version incompatibilities
 <dependency>
   <groupId>org.elasticsearch</groupId>
   <artifactId>elasticsearch-storm</artifactId> <1>
-  <version>{ver}</version>
+  <version>{version}</version>
 </dependency>
 ----
 

--- a/docs/src/reference/asciidoc/core/intro/requirements.adoc
+++ b/docs/src/reference/asciidoc/core/intro/requirements.adoc
@@ -23,7 +23,7 @@ java version "1.8.0_45"
 [[requirements-es]]
 === {es}
 
-We *highly* recommend using the latest Elasticsearch (currently {es-v}). While {eh} maintains backwards compatibility
+We *highly* recommend using the latest Elasticsearch (currently {elasticsearch_version}). While {eh} maintains backwards compatibility
 with previous versions of {es}, we strongly recommend using the latest, stable version of Elasticsearch. You can
 find a matrix of supported versions https://www.elastic.co/support/matrix#matrix_compatibility[here].
 
@@ -32,7 +32,7 @@ The {es} version is shown in its folder name:
 ["source","bash",subs="attributes"]
 ----
 $ ls
-elasticsearch-{es-v}
+elasticsearch-{elasticsearch_version}
 ----
 
 If {es} is running (locally or remotely), one can find out its version through REST:
@@ -44,7 +44,7 @@ $ curl -XGET http://localhost:9200
   "status" : 200,
   "name" : "Dazzler",
   "version" : {
-    "number" : "{es-v}",
+    "number" : "{elasticsearch_version}",
     ...
   },
   "tagline" : "You Know, for Search"

--- a/docs/src/reference/asciidoc/index.adoc
+++ b/docs/src/reference/asciidoc/index.adoc
@@ -9,9 +9,7 @@
 :krb:   Kerberos
 :ey:	Elasticsearch on YARN
 :description: Reference documentation of {eh}
-:ver:	8.0.0
-:ver-d: 8.0.0-SNAPSHOT
-:es-v:	8.0.0-SNAPSHOT
+:ver-d: {version}-SNAPSHOT
 :sp-v:	2.2.0
 :st-v:	1.0.1
 :pg-v:	0.15.0


### PR DESCRIPTION
### Changes

- Replaces the `{vers}` attribute with the `{version}` attribute from the [stack version file](https://raw.githubusercontent.com/elastic/docs/master/shared/versions/stack/master.asciidoc).
- Replaces the `{es-vers}` attribute with the `{elasticsearch_version}` attribute from the [stack version file](https://raw.githubusercontent.com/elastic/docs/master/shared/versions/stack/master.asciidoc).
- Update the `ver-d` attribute value