### PR TITLE
Add scala docs to javadocs

### DIFF
--- a/spark/sql-13/build.gradle
+++ b/spark/sql-13/build.gradle
@@ -124,7 +124,7 @@ jar {
 }
 
 javadoc {
-    dependsOn scaladoc //ensures that scala compiles and scala docs are valid
+    dependsOn compileScala
     source += project(":elasticsearch-hadoop-mr").sourceSets.main.allJava
     source += "$buildDir/generated/java"
     classpath += files(project(":elasticsearch-hadoop-mr").sourceSets.main.compileClasspath)

--- a/spark/sql-13/build.gradle
+++ b/spark/sql-13/build.gradle
@@ -12,6 +12,14 @@ variants {
     targetVersions '2.11.12'
 }
 
+configurations {
+    scalaCompilerPlugin {
+        defaultDependencies { dependencies ->
+            dependencies.add(project.dependencies.create( "com.typesafe.genjavadoc:genjavadoc-plugin_${scalaVersion}:0.13"))
+        }
+    }
+}
+
 println "Compiled using Scala ${project.ext.scalaMajorVersion} [${project.ext.scalaVersion}]"
 String sparkVersion = spark13Version
 
@@ -116,7 +124,9 @@ jar {
 }
 
 javadoc {
+    dependsOn scaladoc //ensures that scala compiles and scala docs are valid
     source += project(":elasticsearch-hadoop-mr").sourceSets.main.allJava
+    source += "$buildDir/generated/java"
     classpath += files(project(":elasticsearch-hadoop-mr").sourceSets.main.compileClasspath)
 }
 
@@ -141,4 +151,13 @@ configurations.all { Configuration conf ->
     }
 
     conf.exclude group: "org.mortbay.jetty"
+}
+
+tasks.withType(ScalaCompile) {
+    scalaCompileOptions.with {
+        additionalParameters = [
+                "-Xplugin:" + configurations.scalaCompilerPlugin.asPath,
+                "-P:genjavadoc:out=$buildDir/generated/java".toString()
+        ]
+    }
 }

--- a/spark/sql-20/build.gradle
+++ b/spark/sql-20/build.gradle
@@ -139,7 +139,7 @@ jar {
 }
 
 javadoc {
-    dependsOn scaladoc //ensures that scala compiles and scala docs are valid
+    dependsOn compileScala
     source += project(":elasticsearch-hadoop-mr").sourceSets.main.allJava
     source += "$buildDir/generated/java"
     classpath += files(project(":elasticsearch-hadoop-mr").sourceSets.main.compileClasspath)

--- a/spark/sql-20/build.gradle
+++ b/spark/sql-20/build.gradle
@@ -46,9 +46,7 @@ compileScala {
         "-Yno-adapted-args",
         "-Ywarn-dead-code",
         "-Ywarn-numeric-widen",
-        "-Xfatal-warnings",
-        "-Xplugin:" + configurations.scalaCompilerPlugin.asPath,
-        "-P:genjavadoc:out=$buildDir/generated/java".toString()
+        "-Xfatal-warnings"
     ]
 }
 
@@ -151,4 +149,13 @@ sourcesJar {
 
 scaladoc {
     title = "${rootProject.description} ${version} API"
+}
+
+tasks.withType(ScalaCompile) {
+    scalaCompileOptions.with {
+        additionalParameters = [
+                "-Xplugin:" + configurations.scalaCompilerPlugin.asPath,
+                "-P:genjavadoc:out=$buildDir/generated/java".toString()
+        ]
+    }
 }

--- a/spark/sql-20/build.gradle
+++ b/spark/sql-20/build.gradle
@@ -12,6 +12,14 @@ variants {
     targetVersions '2.11.12'
 }
 
+configurations {
+    scalaCompilerPlugin {
+        defaultDependencies { dependencies ->
+            dependencies.add(project.dependencies.create( "com.typesafe.genjavadoc:genjavadoc-plugin_${scalaVersion}:0.13"))
+        }
+    }
+}
+
 println "Compiled using Scala ${project.ext.scalaMajorVersion} [${project.ext.scalaVersion}]"
 String sparkVersion = spark20Version
 
@@ -38,7 +46,9 @@ compileScala {
         "-Yno-adapted-args",
         "-Ywarn-dead-code",
         "-Ywarn-numeric-widen",
-        "-Xfatal-warnings"
+        "-Xfatal-warnings",
+        "-Xplugin:" + configurations.scalaCompilerPlugin.asPath,
+        "-P:genjavadoc:out=$buildDir/generated/java".toString()
     ]
 }
 
@@ -129,7 +139,9 @@ jar {
 }
 
 javadoc {
+    dependsOn scaladoc //ensures that scala compiles and scala docs are valid
     source += project(":elasticsearch-hadoop-mr").sourceSets.main.allJava
+    source += "$buildDir/generated/java"
     classpath += files(project(":elasticsearch-hadoop-mr").sourceSets.main.compileClasspath)
 }
 


### PR DESCRIPTION
This commit introduces a 3rd party plugin to co-locate
scala docs with java docs. https://github.com/lightbend/genjavadoc

Fixes: #1363
