### PR TITLE
Fix spark test failures

### DIFF
--- a/spark/sql-13/src/itest/scala/org/elasticsearch/spark/integration/AbstractScalaEsSparkSQL.scala
+++ b/spark/sql-13/src/itest/scala/org/elasticsearch/spark/integration/AbstractScalaEsSparkSQL.scala
@@ -487,8 +487,8 @@ class AbstractScalaEsScalaSparkSQL(prefix: String, readMetadata: jl.Boolean, pus
     val jsonDF = sqc.read.json(rdd).toDF.select("id", "name")
     jsonDF.saveToEs(target, conf)
     RestUtils.refresh(idx)
-    val hit1 = RestUtils.get(s"$docEndpoint/1/_source")
-    val hit2 = RestUtils.get(s"$docEndpoint/2/_source")
+    val hit1 = RestUtils.get(s"$docEndpoint/1")
+    val hit2 = RestUtils.get(s"$docEndpoint/2")
 
     assertThat(hit1, containsString("suffix"))
     assertThat(hit2, not(containsString("suffix")))
@@ -509,8 +509,8 @@ class AbstractScalaEsScalaSparkSQL(prefix: String, readMetadata: jl.Boolean, pus
     val jsonDF = sqc.read.json(rdd).toDF.select("id", "name")
     jsonDF.saveToEs(target, conf)
     RestUtils.refresh(index)
-    val hit1 = RestUtils.get(s"$docEndpoint/1/_source")
-    val hit2 = RestUtils.get(s"$docEndpoint/2/_source")
+    val hit1 = RestUtils.get(s"$docEndpoint/1")
+    val hit2 = RestUtils.get(s"$docEndpoint/2")
 
     assertThat(hit1, containsString("suffix"))
     assertThat(hit2, containsString("suffix"))
@@ -537,8 +537,8 @@ class AbstractScalaEsScalaSparkSQL(prefix: String, readMetadata: jl.Boolean, pus
     val df = sqc.createDataFrame(rdd, schema)
     df.saveToEs(target, conf)
     RestUtils.refresh(index)
-    val hit1 = RestUtils.get(s"$docEndpoint/1/_source")
-    val hit2 = RestUtils.get(s"$docEndpoint/2/_source")
+    val hit1 = RestUtils.get(s"$docEndpoint/1")
+    val hit2 = RestUtils.get(s"$docEndpoint/2")
 
     assertThat(hit1, containsString("suffix"))
     assertThat(hit2, not(containsString("suffix")))
@@ -564,8 +564,8 @@ class AbstractScalaEsScalaSparkSQL(prefix: String, readMetadata: jl.Boolean, pus
     val df = sqc.createDataFrame(rdd, schema)
     df.saveToEs(target, conf)
     RestUtils.refresh(index)
-    val hit1 = RestUtils.get(s"$docEndpoint/1/_source")
-    val hit2 = RestUtils.get(s"$docEndpoint/2/_source")
+    val hit1 = RestUtils.get(s"$docEndpoint/1")
+    val hit2 = RestUtils.get(s"$docEndpoint/2")
 
     assertThat(hit1, containsString("suffix"))
     assertThat(hit2, containsString("suffix"))

--- a/spark/sql-20/src/itest/scala/org/elasticsearch/spark/integration/AbstractScalaEsSparkSQL.scala
+++ b/spark/sql-20/src/itest/scala/org/elasticsearch/spark/integration/AbstractScalaEsSparkSQL.scala
@@ -503,8 +503,8 @@ class AbstractScalaEsScalaSparkSQL(prefix: String, readMetadata: jl.Boolean, pus
     val jsonDF = sqc.read.json(rdd).toDF.select("id", "name")
     jsonDF.saveToEs(target, conf)
     RestUtils.refresh(index)
-    val hit1 = RestUtils.get(s"$docPath/1/_source")
-    val hit2 = RestUtils.get(s"$docPath/2/_source")
+    val hit1 = RestUtils.get(s"$docPath/1")
+    val hit2 = RestUtils.get(s"$docPath/2")
 
     assertThat(hit1, containsString("suffix"))
     assertThat(hit2, not(containsString("suffix")))
@@ -525,8 +525,8 @@ class AbstractScalaEsScalaSparkSQL(prefix: String, readMetadata: jl.Boolean, pus
     val jsonDF = sqc.read.json(rdd).toDF.select("id", "name")
     jsonDF.saveToEs(target, conf)
     RestUtils.refresh(index)
-    val hit1 = RestUtils.get(s"$docPath/1/_source")
-    val hit2 = RestUtils.get(s"$docPath/2/_source")
+    val hit1 = RestUtils.get(s"$docPath/1")
+    val hit2 = RestUtils.get(s"$docPath/2")
 
     assertThat(hit1, containsString("suffix"))
     assertThat(hit2, containsString("suffix"))
@@ -554,8 +554,8 @@ class AbstractScalaEsScalaSparkSQL(prefix: String, readMetadata: jl.Boolean, pus
     val df = sqc.createDataFrame(rdd, schema)
     df.saveToEs(target, conf)
     RestUtils.refresh(index)
-    val hit1 = RestUtils.get(s"$docPath/1/_source")
-    val hit2 = RestUtils.get(s"$docPath/2/_source")
+    val hit1 = RestUtils.get(s"$docPath/1")
+    val hit2 = RestUtils.get(s"$docPath/2")
 
     assertThat(hit1, containsString("suffix"))
     assertThat(hit2, not(containsString("suffix")))
@@ -581,8 +581,8 @@ class AbstractScalaEsScalaSparkSQL(prefix: String, readMetadata: jl.Boolean, pus
     val df = sqc.createDataFrame(rdd, schema)
     df.saveToEs(target, conf)
     RestUtils.refresh(index)
-    val hit1 = RestUtils.get(s"$docPath/1/_source")
-    val hit2 = RestUtils.get(s"$docPath/2/_source")
+    val hit1 = RestUtils.get(s"$docPath/1")
+    val hit2 = RestUtils.get(s"$docPath/2")
 
     assertThat(hit1, containsString("suffix"))
     assertThat(hit2, containsString("suffix"))


### PR DESCRIPTION
Recently the `_source` endpoints have had their types removed. There are a few spots in the test code that uses these end points that really don't need to be using them in the first place. This PR removes them to get the tests passing again.