### PR TITLE
Update text around es.read.field.as.array.include

### DIFF
--- a/docs/src/reference/asciidoc/core/configuration.adoc
+++ b/docs/src/reference/asciidoc/core/configuration.adoc
@@ -277,7 +277,7 @@ es.read.field.exclude = company.income
 added[2.2]
 `es.read.field.as.array.include` (default empty)::
 Fields/properties that should be considered as arrays/lists. Since {es} can map one or multiple values to a field, {eh} cannot determine from the mapping
-whether to treat a field on a document as a single value or an array of values. When encountering multiple values, {eh} will automatically read
+whether to treat a field on a document as a single value or an array. When encountering multiple values, {eh} automatically reads
 the field into the appropriate array/list type for an integration, but in strict mapping scenarios (like Spark SQL) this
 may lead to problems (an array is encountered when Spark's Catalyst engine expects a single value).
 The syntax for this setting is similar to that of {es} {ref}/search-request-body.html#request-body-search-source-filtering[include/exclude].

--- a/docs/src/reference/asciidoc/core/configuration.adoc
+++ b/docs/src/reference/asciidoc/core/configuration.adoc
@@ -283,7 +283,7 @@ may lead to problems (an array is encountered when Spark's Catalyst engine expec
 The syntax for this setting is similar to that of {es} {ref}/search-request-body.html#request-body-search-source-filtering[include/exclude].
 Multiple values can be specified by using a comma. By default, no value is specified, meaning no properties/fields are treated as arrays.
 
-NOTE: Not all fields need to specify `es.read.field.as.array` in order to be treated as an array in {eh}. Fields of type `nested` are always
+NOTE: Not all fields need to specify `es.read.field.as.array` to be treated as an array. Fields of type `nested` are always
 treated as an array of objects, and should not be marked under `es.read.field.as.array.include`.
 
 For example, given the document:

--- a/docs/src/reference/asciidoc/core/configuration.adoc
+++ b/docs/src/reference/asciidoc/core/configuration.adoc
@@ -284,7 +284,7 @@ The syntax for this setting is similar to that of {es} {ref}/search-request-body
 Multiple values can be specified by using a comma. By default, no value is specified, meaning no properties/fields are treated as arrays.
 
 NOTE: Not all fields need to specify `es.read.field.as.array` to be treated as an array. Fields of type `nested` are always
-treated as an array of objects, and should not be marked under `es.read.field.as.array.include`.
+treated as an array of objects and should not be marked under `es.read.field.as.array.include`.
 
 For example, given the document:
 [source,json]

--- a/docs/src/reference/asciidoc/core/configuration.adoc
+++ b/docs/src/reference/asciidoc/core/configuration.adoc
@@ -277,19 +277,47 @@ es.read.field.exclude = company.income
 added[2.2]
 `es.read.field.as.array.include` (default empty)::
 Fields/properties that should be considered as arrays/lists. Since {es} can map one or multiple values to a field, {eh} cannot determine from the mapping
-whether to instantiate one value or a array type (depending on the library type). When encountering multiple values, {eh} will automatically use 
-the array/list type but in strict mapping scenarios (like Spark SQL) this might lead to an unexpected schema change.
-The syntax is similar to that of {es} {ref}/search-request-body.html#request-body-search-source-filtering[include/exclude]. 
-Multiple values can be specified by using a comma. By default, no value is specified meaning no properties/fields are included.
+whether to treat a field on a document as a single value or an array of values. When encountering multiple values, {eh} will automatically read
+the field into the appropriate array/list type for an integration, but in strict mapping scenarios (like Spark SQL) this
+may lead to problems (an array is encountered when Spark's Catalyst engine expects a single value).
+The syntax for this setting is similar to that of {es} {ref}/search-request-body.html#request-body-search-source-filtering[include/exclude].
+Multiple values can be specified by using a comma. By default, no value is specified, meaning no properties/fields are treated as arrays.
 
-For example:
+NOTE: Not all fields need to specify `es.read.field.as.array` in order to be treated as an array in {eh}. Fields of type `nested` are always
+treated as an array of objects, and should not be marked under `es.read.field.as.array.include`.
+
+For example, given the document:
+[source,json]
+----
+{
+  "foo": {
+    "bar": [ "abc", "def" ]
+  }
+}
+----
+
+Use the following configuration:
 [source,ini]
 ----
-# mapping nested.bar as an array
-es.read.field.as.array.include = nested.bar
+# mapping foo.bar as an array
+es.read.field.as.array.include = foo.bar
+----
 
-# mapping nested.bar as a 3-level/dimensional array
-es.read.field.as.array.include = nested.bar:3
+If your document contains multiple levels of arrays:
+[source,json]
+----
+{
+  "foo": {
+    "bar": [[["abc", "def"], ["ghi", "jkl"]], [["mno", "pqr"], ["stu", "vwx"]]]
+  }
+}
+----
+
+Then specify the dimensionality of the array in the configuration
+[source,ini]
+----
+# mapping foo.bar as a 3-level/dimensional array
+es.read.field.as.array.include = foo.bar:3
 ----
 
 `es.read.field.as.array.exclude` (default empty)::

--- a/docs/src/reference/asciidoc/core/configuration.adoc
+++ b/docs/src/reference/asciidoc/core/configuration.adoc
@@ -313,7 +313,7 @@ If your document contains multiple levels of arrays:
 }
 ----
 
-Then specify the dimensionality of the array in the configuration
+Then specify the dimensionality of the array in the configuration:
 [source,ini]
 ----
 # mapping foo.bar as a 3-level/dimensional array

--- a/docs/src/reference/asciidoc/core/configuration.adoc
+++ b/docs/src/reference/asciidoc/core/configuration.adoc
@@ -281,7 +281,7 @@ whether to treat a field on a document as a single value or an array. When encou
 the field into the appropriate array/list type for an integration, but in strict mapping scenarios (like Spark SQL) this
 may lead to problems (an array is encountered when Spark's Catalyst engine expects a single value).
 The syntax for this setting is similar to that of {es} {ref}/search-request-body.html#request-body-search-source-filtering[include/exclude].
-Multiple values can be specified by using a comma. By default, no value is specified, meaning no properties/fields are treated as arrays.
+Multiple values can be specified by using a comma. By default, no value is specified, meaning no fields/properties are treated as arrays.
 
 NOTE: Not all fields need to specify `es.read.field.as.array` to be treated as an array. Fields of type `nested` are always
 treated as an array of objects and should not be marked under `es.read.field.as.array.include`.


### PR DESCRIPTION
This setting is often misunderstood and misused, especially when it comes to nested fields. This PR updates the docs in an attempt to better explain the usage of the field with more information in the examples.