### PR TITLE
Adapt to upstream for type safe build globals

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/BuildPlugin.groovy
@@ -1,6 +1,7 @@
 package org.elasticsearch.hadoop.gradle
 
 import org.apache.tools.ant.taskdefs.condition.Os
+import org.elasticsearch.gradle.info.BuildParams
 import org.elasticsearch.gradle.info.GenerateGlobalBuildInfoTask
 import org.elasticsearch.gradle.info.GlobalBuildInfoPlugin
 import org.elasticsearch.gradle.info.JavaHome
@@ -91,8 +92,7 @@ class BuildPlugin implements Plugin<Project>  {
 
             // We snap the runtime to java 8 since Hadoop needs to see some significant
             // upgrades to support any runtime higher than that
-            List<JavaHome> javaVersions = project.rootProject.ext.javaVersions as List<JavaHome>
-            JavaHome esHadoopRuntimeJava = javaVersions.find { it.version == 8 }
+            JavaHome esHadoopRuntimeJava = BuildParams.javaVersions.find { it.version == 8 }
             if (esHadoopRuntimeJava == null) {
                 throw new GradleException(
                         '$JAVA8_HOME must be set to build ES-Hadoop. ' +
@@ -202,7 +202,7 @@ class BuildPlugin implements Plugin<Project>  {
         }
         project.ext.gitHead = project.rootProject.ext.gitHead
         project.ext.revHash = project.rootProject.ext.revHash
-        project.ext.javaVersions = project.rootProject.ext.javaVersions
+        project.ext.javaVersions = BuildParams.javaVersions
         project.ext.isRuntimeJavaHomeSet = project.rootProject.ext.isRuntimeJavaHomeSet
     }
 

--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/fixture/hadoop/InstanceInfo.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/fixture/hadoop/InstanceInfo.groovy
@@ -20,6 +20,7 @@
 package org.elasticsearch.hadoop.gradle.fixture.hadoop
 
 import org.apache.tools.ant.taskdefs.condition.Os
+import org.elasticsearch.gradle.info.BuildParams
 import org.elasticsearch.hadoop.gradle.util.WaitForURL
 import org.elasticsearch.hadoop.gradle.fixture.hadoop.conf.InstanceConfiguration
 import org.gradle.api.GradleException
@@ -236,7 +237,7 @@ class InstanceInfo {
 
     /** Return the java home used by this node. */
     String getJavaHome() {
-        return javaVersion == null ? project.runtimeJavaHome : project.javaVersions.find { it.version == javaVersion }.javaHome.absolutePath
+        return javaVersion == null ? project.runtimeJavaHome : BuildParams.javaVersions.find { it.version == javaVersion }.javaHome.absolutePath
     }
 
     /** Returns debug string for the command that started this node. */


### PR DESCRIPTION
This commit adapts the elasticsearch-hadoop build to an upstream change to make some build globals type safe. In particular, we adapt the usage of Java versions.

Relates elastic/elasticsearch#48778