### PR TITLE
Do not build scala docs as javadocs for scala 2.10

### DIFF
--- a/spark/sql-13/build.gradle
+++ b/spark/sql-13/build.gradle
@@ -15,7 +15,9 @@ variants {
 configurations {
     scalaCompilerPlugin {
         defaultDependencies { dependencies ->
-            dependencies.add(project.dependencies.create( "com.typesafe.genjavadoc:genjavadoc-plugin_${scalaVersion}:0.13"))
+            if (project.ext.scalaMajorVersion != '2.10') {
+                dependencies.add(project.dependencies.create("com.typesafe.genjavadoc:genjavadoc-plugin_${scalaVersion}:0.13"))
+            }
         }
     }
 }
@@ -119,9 +121,11 @@ jar {
 }
 
 javadoc {
-    dependsOn compileScala
+    if (project.ext.scalaMajorVersion != '2.10') {
+        dependsOn compileScala
+        source += "$buildDir/generated/java"
+    }
     source += project(":elasticsearch-hadoop-mr").sourceSets.main.allJava
-    source += "$buildDir/generated/java"
     classpath += files(project(":elasticsearch-hadoop-mr").sourceSets.main.compileClasspath)
 }
 
@@ -149,10 +153,12 @@ configurations.all { Configuration conf ->
 }
 
 tasks.withType(ScalaCompile) {
-    scalaCompileOptions.with {
-        additionalParameters = [
-                "-Xplugin:" + configurations.scalaCompilerPlugin.asPath,
-                "-P:genjavadoc:out=$buildDir/generated/java".toString()
-        ]
+    if (project.ext.scalaMajorVersion != '2.10') {
+        scalaCompileOptions.with {
+            additionalParameters = [
+                    "-Xplugin:" + configurations.scalaCompilerPlugin.asPath,
+                    "-P:genjavadoc:out=$buildDir/generated/java".toString()
+            ]
+        }
     }
 }

--- a/spark/sql-20/build.gradle
+++ b/spark/sql-20/build.gradle
@@ -15,7 +15,9 @@ variants {
 configurations {
     scalaCompilerPlugin {
         defaultDependencies { dependencies ->
-            dependencies.add(project.dependencies.create( "com.typesafe.genjavadoc:genjavadoc-plugin_${scalaVersion}:0.13"))
+            if (project.ext.scalaMajorVersion != '2.10') {
+                dependencies.add(project.dependencies.create("com.typesafe.genjavadoc:genjavadoc-plugin_${scalaVersion}:0.13"))
+            }
         }
     }
 }
@@ -132,9 +134,11 @@ jar {
 }
 
 javadoc {
-    dependsOn compileScala
+    if (project.ext.scalaMajorVersion != '2.10') {
+        dependsOn compileScala
+        source += "$buildDir/generated/java"
+    }
     source += project(":elasticsearch-hadoop-mr").sourceSets.main.allJava
-    source += "$buildDir/generated/java"
     classpath += files(project(":elasticsearch-hadoop-mr").sourceSets.main.compileClasspath)
 }
 
@@ -147,10 +151,12 @@ scaladoc {
 }
 
 tasks.withType(ScalaCompile) {
-    scalaCompileOptions.with {
-        additionalParameters = [
-                "-Xplugin:" + configurations.scalaCompilerPlugin.asPath,
-                "-P:genjavadoc:out=$buildDir/generated/java".toString()
-        ]
+    if (project.ext.scalaMajorVersion != '2.10') {
+        scalaCompileOptions.with {
+            additionalParameters = [
+                    "-Xplugin:" + configurations.scalaCompilerPlugin.asPath,
+                    "-P:genjavadoc:out=$buildDir/generated/java".toString()
+            ]
+        }
     }
 }


### PR DESCRIPTION
#1368 introduces a plugin that is documents scala apis
for java developers. This plugin does not support 2.10 and
this variant was missed in the initial testing.

This commit for 7.x conditionally uses this plugin based on the
scala major version. 2.10 support has been removed for 8.x.
