### PR TITLE
Add distribution as task for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: java
 jdk:
  - oraclejdk11
 
+script:
+  - export JAVA_HOME=$HOME/oraclejdk8
+  - $TRAVIS_BUILD_DIR/install-jdk.sh --install oraclejdk8 --target $JAVA_HOME
 
 dist: trusty
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ before_install:
  - "chmod +x gradlew"
  - export JAVA_OPTS="-Xmx2048m -XX:MaxPermSize=386m"
 
-install: ./gradlew assemble -Pskip.signing
+install: ./gradlew assemble distribution -Pskip.signing

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 jdk:
- - oraclejdk8
+ - oraclejdk11
 
 
 dist: trusty


### PR DESCRIPTION
A recent failure in the javadocs caused a build issue. 
This commit adds `distribution` to the command run by Travis
which would have caught this issue with the javadocs.

------

current assemble tasks:

```:compileJava SKIPPED
:processResources SKIPPED
:classes SKIPPED
:elasticsearch-hadoop-mr:compileJava SKIPPED
:elasticsearch-hadoop-mr:generateGitHash SKIPPED
:elasticsearch-hadoop-mr:processResources SKIPPED
:elasticsearch-hadoop-mr:classes SKIPPED
:elasticsearch-hadoop-mr:jar SKIPPED
:elasticsearch-hadoop-hive:compileJava SKIPPED
:elasticsearch-hadoop-hive:processResources SKIPPED
:elasticsearch-hadoop-hive:classes SKIPPED
:elasticsearch-hadoop-hive:jar SKIPPED
:elasticsearch-hadoop-pig:compileJava SKIPPED
:elasticsearch-hadoop-pig:processResources SKIPPED
:elasticsearch-hadoop-pig:classes SKIPPED
:elasticsearch-hadoop-pig:jar SKIPPED
:elasticsearch-spark-20:compileJava SKIPPED
:elasticsearch-spark-20:compileScala SKIPPED
:elasticsearch-spark-20:processResources SKIPPED
:elasticsearch-spark-20:classes SKIPPED
:elasticsearch-spark-20:jar SKIPPED
:elasticsearch-storm:compileJava SKIPPED
:elasticsearch-storm:processResources SKIPPED
:elasticsearch-storm:classes SKIPPED
:elasticsearch-storm:jar SKIPPED
:jar SKIPPED
:assemble SKIPPED
:elasticsearch-hadoop-hive:assemble SKIPPED
:elasticsearch-hadoop-mr:assemble SKIPPED
:elasticsearch-hadoop-pig:assemble SKIPPED
:elasticsearch-spark-13:compileJava SKIPPED
:elasticsearch-spark-13:compileScala SKIPPED
:elasticsearch-spark-13:processResources SKIPPED
:elasticsearch-spark-13:classes SKIPPED
:elasticsearch-spark-13:jar SKIPPED
:elasticsearch-spark-13:assemble SKIPPED
:elasticsearch-spark-20:assemble SKIPPED
:elasticsearch-storm:assemble SKIPPED
:elasticsearch-hadoop-mr:compileTestJava SKIPPED
:elasticsearch-hadoop-mr:processTestResources SKIPPED
:elasticsearch-hadoop-mr:testClasses SKIPPED
:elasticsearch-hadoop-mr:compileItestJava SKIPPED
:elasticsearch-hadoop-mr:processItestResources SKIPPED
:elasticsearch-hadoop-mr:itestClasses SKIPPED
:elasticsearch-storm:compileTestJava SKIPPED
:elasticsearch-storm:processTestResources SKIPPED
:elasticsearch-storm:testClasses SKIPPED
:elasticsearch-storm:compileItestJava SKIPPED
:elasticsearch-storm:processItestResources SKIPPED
:elasticsearch-storm:itestClasses SKIPPED
:qa:kerberos:compileJava SKIPPED
:qa:kerberos:compileScala SKIPPED
:qa:kerberos:processResources SKIPPED
:qa:kerberos:classes SKIPPED
:qa:kerberos:jar SKIPPED
:qa:kerberos:assemble SKIPPED
:test:fixtures:minikdc:compileJava SKIPPED
:test:fixtures:minikdc:processResources SKIPPED
:test:fixtures:minikdc:classes SKIPPED
:test:fixtures:minikdc:jar SKIPPED
:test:fixtures:minikdc:assemble SKIPPED
```
ADDITIONAL TASKS NOW RUN VIA DISTRIBUTION BELOW
```
:javadoc SKIPPED
:javadocJar SKIPPED
:sourcesJar SKIPPED
:pack SKIPPED
:elasticsearch-hadoop-mr:javadoc SKIPPED
:elasticsearch-hadoop-hive:javadoc SKIPPED
:elasticsearch-hadoop-hive:javadocJar SKIPPED
:elasticsearch-hadoop-hive:sourcesJar SKIPPED
:elasticsearch-hadoop-hive:pack SKIPPED
:elasticsearch-hadoop-mr:javadocJar SKIPPED
:elasticsearch-hadoop-mr:sourcesJar SKIPPED
:elasticsearch-hadoop-mr:pack SKIPPED
:elasticsearch-hadoop-pig:javadoc SKIPPED
:elasticsearch-hadoop-pig:javadocJar SKIPPED
:elasticsearch-hadoop-pig:sourcesJar SKIPPED
:elasticsearch-hadoop-pig:pack SKIPPED
:elasticsearch-spark-20:javadoc SKIPPED
:elasticsearch-spark-20:javadocJar SKIPPED
:elasticsearch-spark-20:sourcesJar SKIPPED
:elasticsearch-spark-20:pack SKIPPED
:elasticsearch-storm:javadoc SKIPPED
:elasticsearch-storm:javadocJar SKIPPED
:elasticsearch-storm:sourcesJar SKIPPED
:elasticsearch-storm:pack SKIPPED
:distZip SKIPPED
:writePom SKIPPED
:distribution SKIPPED
:elasticsearch-hadoop-hive:writePom SKIPPED
:elasticsearch-hadoop-hive:distribution SKIPPED
:elasticsearch-hadoop-mr:writePom SKIPPED
:elasticsearch-hadoop-mr:distribution SKIPPED
:elasticsearch-hadoop-pig:writePom SKIPPED
:elasticsearch-hadoop-pig:distribution SKIPPED
:elasticsearch-spark-13:javadoc SKIPPED
:elasticsearch-spark-13:javadocJar SKIPPED
:elasticsearch-spark-13:sourcesJar SKIPPED
:elasticsearch-spark-13:pack SKIPPED
:elasticsearch-spark-13:variants#2_10 SKIPPED
:elasticsearch-spark-13:variants SKIPPED
:elasticsearch-spark-13:writePom SKIPPED
:elasticsearch-spark-13:distribution SKIPPED
:elasticsearch-spark-20:variants#2_10 SKIPPED
:elasticsearch-spark-20:variants SKIPPED
:elasticsearch-spark-20:writePom SKIPPED
:elasticsearch-spark-20:distribution SKIPPED
:elasticsearch-storm:writePom SKIPPED
:elasticsearch-storm:distribution SKIPPED
:qa:kerberos:javadoc SKIPPED
:qa:kerberos:javadocJar SKIPPED
:qa:kerberos:sourcesJar SKIPPED
:qa:kerberos:pack SKIPPED
:qa:kerberos:writePom SKIPPED
:qa:kerberos:distribution SKIPPED
```

