### PR TITLE
[DOCS] [7.x] Remove release dates from release notes

### DIFF
--- a/docs/src/reference/asciidoc/appendix/release-notes/7.0.0-alpha1.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/7.0.0-alpha1.adoc
@@ -1,6 +1,5 @@
 [[eshadoop-7.0.0-alpha1]]
 == Elasticsearch for Apache Hadoop version 7.0.0-alpha1
-November 15, 2018
 
 [[new-7.0.0-alpha1]]
 === New Features

--- a/docs/src/reference/asciidoc/appendix/release-notes/7.0.0-alpha2.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/7.0.0-alpha2.adoc
@@ -1,5 +1,4 @@
 [[eshadoop-7.0.0-alpha2]]
 == Elasticsearch for Apache Hadoop version 7.0.0-alpha2
-December 20, 2018
 
 ES-Hadoop 7.0.0-alpha2 is a version compatibility release, tested specifically against Elasticsearch 7.0.0-alpha2.

--- a/docs/src/reference/asciidoc/appendix/release-notes/7.0.0-beta1.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/7.0.0-beta1.adoc
@@ -1,6 +1,5 @@
 [[eshadoop-7.0.0-beta1]]
 == Elasticsearch for Apache Hadoop version 7.0.0-beta1
-February 14, 2019
 
 [[breaking-7.0.0-beta1]]
 === Breaking Changes

--- a/docs/src/reference/asciidoc/appendix/release-notes/7.0.0-rc1.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/7.0.0-rc1.adoc
@@ -1,6 +1,5 @@
 [[eshadoop-7.0.0-rc1]]
 == Elasticsearch for Apache Hadoop version 7.0.0-rc1
-March 27, 2019
 
 [[bugs-7.0.0-rc1]]
 === Bug Fixes

--- a/docs/src/reference/asciidoc/appendix/release-notes/7.0.0-rc2.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/7.0.0-rc2.adoc
@@ -1,5 +1,4 @@
 [[eshadoop-7.0.0-rc2]]
 == Elasticsearch for Apache Hadoop version 7.0.0-rc2
-April 3, 2019
 
 This is the second release candidate for 7.0.0. No major changes.

--- a/docs/src/reference/asciidoc/appendix/release-notes/7.0.0.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/7.0.0.adoc
@@ -1,6 +1,5 @@
 [[eshadoop-7.0.0]]
 == Elasticsearch for Apache Hadoop version 7.0.0
-April 10, 2019
 
 [[breaking-7.0.0]]
 === Breaking Changes

--- a/docs/src/reference/asciidoc/appendix/release-notes/7.0.1.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/7.0.1.adoc
@@ -1,5 +1,4 @@
 [[eshadoop-7.0.1]]
 == Elasticsearch for Apache Hadoop version 7.0.1
-May 1, 2019
 
 ES-Hadoop 7.0.1 is a version compatibility release, tested specifically against Elasticsearch 7.0.1.

--- a/docs/src/reference/asciidoc/appendix/release-notes/7.1.0.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/7.1.0.adoc
@@ -1,5 +1,4 @@
 [[eshadoop-7.1.0]]
 == Elasticsearch for Apache Hadoop version 7.1.0
-May 20, 2019
 
 ES-Hadoop 7.1.0 is a version compatibility release, tested specifically against Elasticsearch 7.1.0.

--- a/docs/src/reference/asciidoc/appendix/release-notes/7.1.1.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/7.1.1.adoc
@@ -1,6 +1,5 @@
 [[eshadoop-7.1.1]]
 == Elasticsearch for Apache Hadoop version 7.1.1
-May 28, 2019
 
 [[bugs-7.1.1]]
 === Bug Fixes

--- a/docs/src/reference/asciidoc/appendix/release-notes/7.2.0.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/7.2.0.adoc
@@ -1,5 +1,4 @@
 [[eshadoop-7.2.0]]
 == Elasticsearch for Apache Hadoop version 7.2.0
-June 25, 2019
 
 ES-Hadoop 7.2.0 is a version compatibility release, tested specifically against Elasticsearch 7.2.0.

--- a/docs/src/reference/asciidoc/appendix/release-notes/7.2.1.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/7.2.1.adoc
@@ -1,5 +1,4 @@
 [[eshadoop-7.2.1]]
 == Elasticsearch for Apache Hadoop version 7.2.1
-July 16, 2019
 
 ES-Hadoop 7.2.1 is a version compatibility release, tested specifically against Elasticsearch 7.2.1.

--- a/docs/src/reference/asciidoc/appendix/release-notes/7.3.0.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/7.3.0.adoc
@@ -1,6 +1,5 @@
 [[eshadoop-7.3.0]]
 == Elasticsearch for Apache Hadoop version 7.3.0
-July 31, 2019
 
 [[docs-7.3.0]]
 === Documentation

--- a/docs/src/reference/asciidoc/appendix/release-notes/7.3.1.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/7.3.1.adoc
@@ -1,5 +1,4 @@
 [[eshadoop-7.3.1]]
 == Elasticsearch for Apache Hadoop version 7.3.1
-August 22, 2019
 
 ES-Hadoop 7.3.1 is a version compatibility release, tested specifically against Elasticsearch 7.3.1.

--- a/docs/src/reference/asciidoc/appendix/release-notes/7.3.2.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/7.3.2.adoc
@@ -1,5 +1,4 @@
 [[eshadoop-7.3.2]]
 == Elasticsearch for Apache Hadoop version 7.3.2
-September 12, 2019
 
 ES-Hadoop 7.3.2 is a version compatibility release, tested specifically against Elasticsearch 7.3.2.

--- a/docs/src/reference/asciidoc/appendix/release-notes/7.4.0.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/7.4.0.adoc
@@ -1,6 +1,5 @@
 [[eshadoop-7.4.0]]
 == Elasticsearch for Apache Hadoop version 7.4.0
-October 1, 2019
 
 ES-Hadoop 7.4.0 is a version compatibility release,
 tested specifically against Elasticsearch 7.4.0.

--- a/docs/src/reference/asciidoc/appendix/release-notes/7.4.1.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/7.4.1.adoc
@@ -1,6 +1,5 @@
 [[eshadoop-7.4.1]]
 == Elasticsearch for Apache Hadoop version 7.4.1
-October 23, 2019
 
 ES-Hadoop 7.4.1 is a version compatibility release,
 tested specifically against Elasticsearch 7.4.1.

--- a/docs/src/reference/asciidoc/appendix/release-notes/7.4.2.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/7.4.2.adoc
@@ -1,6 +1,5 @@
 [[eshadoop-7.4.2]]
 == Elasticsearch for Apache Hadoop version 7.4.2
-October 31, 2019
 
 ES-Hadoop 7.4.2 is a version compatibility release,
 tested specifically against Elasticsearch 7.4.2.

--- a/docs/src/reference/asciidoc/appendix/release-notes/7.5.0.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/7.5.0.adoc
@@ -1,6 +1,5 @@
 [[eshadoop-7.5.0]]
 == Elasticsearch for Apache Hadoop version 7.5.0
-December 2, 2019
 
 ES-Hadoop 7.5.0 is a version compatibility release,
 tested specifically against Elasticsearch 7.5.0.


### PR DESCRIPTION
Removes release dates from Elasticsearch Hadoop release notes for the 7.x branch.

Backport of #1396. I plan to backport this to 7.5.

Relates to #1393 and #1396