### PR TITLE
[DOCS] Remove release dates from release notes

### DIFF
--- a/docs/src/reference/asciidoc/appendix/release-notes/6.0.0-alpha-1.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/6.0.0-alpha-1.adoc
@@ -1,6 +1,5 @@
 [[eshadoop-6.0.0-alpha-1]]
 == Elasticsearch for Apache Hadoop version 6.0.0-alpha1
-May 09, 2017
 
 Tested against the latest and greatest Elasticsearch 6.0.0-alpha-1,
 the first alpha of ES-Hadoop for 6.0.0 includes much needed fixes

--- a/docs/src/reference/asciidoc/appendix/release-notes/6.0.0-alpha-2.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/6.0.0-alpha-2.adoc
@@ -1,6 +1,5 @@
 [[eshadoop-6.0.0-alpha-2]]
 == Elasticsearch for Apache Hadoop version 6.0.0-alpha2
-June 6, 2017
 
 [[new-6.0.0-alpha-2]]
 === New Features

--- a/docs/src/reference/asciidoc/appendix/release-notes/6.0.0-beta-1.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/6.0.0-beta-1.adoc
@@ -1,7 +1,5 @@
 [[eshadoop-6.0.0-beta-1]]
 == Elasticsearch for Apache Hadoop version 6.0.0-beta1
-July 31, 2017
-
 Tested against the latest and greatest Elasticsearch 6.0.0-beta1, the first beta of ES-Hadoop for 6.0.0 includes much
 needed fixes and features to work in harmony with all the hearty changes landing in Elasticsearch 6.0.
 

--- a/docs/src/reference/asciidoc/appendix/release-notes/6.0.0-beta-2.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/6.0.0-beta-2.adoc
@@ -1,6 +1,5 @@
 [[eshadoop-6.0.0-beta-2]]
 == Elasticsearch for Apache Hadoop version 6.0.0-beta2
-August 31, 2017
 
 Please note that this is a beta release and that we do not recommend running this in production! See our
 <<breaking-changes-6.0>> page for more information on what you might need to modify.

--- a/docs/src/reference/asciidoc/appendix/release-notes/6.0.0-rc-1.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/6.0.0-rc-1.adoc
@@ -1,6 +1,5 @@
 [[eshadoop-6.0.0-rc-1]]
 == Elasticsearch for Apache Hadoop version 6.0.0-rc1
-September 28, 2017
 
 Please note that this is an RC release and that we do not recommend running this in production! See our
 <<breaking-changes-6.0>> page for more information on what you might need to modify.

--- a/docs/src/reference/asciidoc/appendix/release-notes/6.0.0-rc-2.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/6.0.0-rc-2.adoc
@@ -1,6 +1,5 @@
 [[eshadoop-6.0.0-rc-2]]
 == Elasticsearch for Apache Hadoop version 6.0.0-rc2
-October 31, 2017
 
 Please note that this is an RC release and that we do not recommend running this in production! See our
 <<breaking-changes-6.0>> page for more information on what you might need to modify.

--- a/docs/src/reference/asciidoc/appendix/release-notes/6.0.0.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/6.0.0.adoc
@@ -1,6 +1,5 @@
 [[eshadoop-6.0.0]]
 == Elasticsearch for Apache Hadoop version 6.0.0
-November 14, 2017
 
 [[breaking-6.0.0]]
 === Breaking Changes

--- a/docs/src/reference/asciidoc/appendix/release-notes/6.0.1.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/6.0.1.adoc
@@ -1,6 +1,5 @@
 [[eshadoop-6.0.1]]
 == Elasticsearch for Apache Hadoop version 6.0.1
-December 06, 2017
 
 [[bugs-6.0.1]]
 === Bug Fixes

--- a/docs/src/reference/asciidoc/appendix/release-notes/6.1.0.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/6.1.0.adoc
@@ -1,6 +1,5 @@
 [[eshadoop-6.1.0]]
 == Elasticsearch for Apache Hadoop version 6.1.0
-December 13, 2017
 
 [[bugs-6.1.0]]
 === Bug Fixes

--- a/docs/src/reference/asciidoc/appendix/release-notes/6.1.1.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/6.1.1.adoc
@@ -1,5 +1,4 @@
 [[eshadoop-6.1.1]]
 == Elasticsearch for Apache Hadoop version 6.1.1
-December 19, 2017
 
 ES-Hadoop 6.1.1 is a version compatibility release, tested specifically against Elasticsearch 6.1.1.

--- a/docs/src/reference/asciidoc/appendix/release-notes/6.1.2.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/6.1.2.adoc
@@ -1,6 +1,5 @@
 [[eshadoop-6.1.2]]
 == Elasticsearch for Apache Hadoop version 6.1.2
-January 16, 2018
 
 ES-Hadoop 6.1.2 is a version compatibility release, tested specifically against Elasticsearch 6.1.2.
 

--- a/docs/src/reference/asciidoc/appendix/release-notes/6.1.3.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/6.1.3.adoc
@@ -1,6 +1,5 @@
 [[eshadoop-6.1.3]]
 == Elasticsearch for Apache Hadoop version 6.1.3
-January 30, 2018
 
 ES-Hadoop 6.1.3 is a version compatibility release, tested specifically against Elasticsearch 6.1.3.
 

--- a/docs/src/reference/asciidoc/appendix/release-notes/6.1.4.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/6.1.4.adoc
@@ -1,6 +1,5 @@
 [[eshadoop-6.1.4]]
 == Elasticsearch for Apache Hadoop version 6.1.4
-March 20, 2018
 
 ES-Hadoop 6.1.4 is a version compatibility release, tested specifically against Elasticsearch 6.1.4.
 

--- a/docs/src/reference/asciidoc/appendix/release-notes/6.2.0.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/6.2.0.adoc
@@ -1,6 +1,5 @@
 [[eshadoop-6.2.0]]
 == Elasticsearch for Apache Hadoop version 6.2.0
-February 6, 2018
 
 [[new-6.2.0]]
 === New Features

--- a/docs/src/reference/asciidoc/appendix/release-notes/6.2.1.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/6.2.1.adoc
@@ -1,5 +1,4 @@
 [[eshadoop-6.2.1]]
 == Elasticsearch for Apache Hadoop version 6.2.1
-February 8, 2018
 
 ES-Hadoop 6.2.1 is a version compatibility release, tested specifically against Elasticsearch 6.2.1.

--- a/docs/src/reference/asciidoc/appendix/release-notes/6.2.2.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/6.2.2.adoc
@@ -1,6 +1,5 @@
 [[eshadoop-6.2.2]]
 == Elasticsearch for Apache Hadoop version 6.2.2
-February 20, 2018
 
 [[enhancements-6.2.2]]
 === Enhancements

--- a/docs/src/reference/asciidoc/appendix/release-notes/6.2.3.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/6.2.3.adoc
@@ -1,6 +1,5 @@
 [[eshadoop-6.2.3]]
 == Elasticsearch for Apache Hadoop version 6.2.3
-March 20, 2018
 
 [[enhancements-6.2.3]]
 === Enhancements

--- a/docs/src/reference/asciidoc/appendix/release-notes/6.2.4.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/6.2.4.adoc
@@ -1,6 +1,5 @@
 [[eshadoop-6.2.4]]
 == Elasticsearch for Apache Hadoop version 6.2.4
-April 17, 2018
 
 ES-Hadoop 6.2.4 is a version compatibility release, tested specifically against Elasticsearch 6.2.4.
 

--- a/docs/src/reference/asciidoc/appendix/release-notes/6.3.0.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/6.3.0.adoc
@@ -1,6 +1,5 @@
 [[eshadoop-6.3.0]]
 == Elasticsearch for Apache Hadoop version 6.3.0
-June 13, 2018
 
 [[enhancements-6.3.0]]
 === Enhancements

--- a/docs/src/reference/asciidoc/appendix/release-notes/6.3.1.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/6.3.1.adoc
@@ -1,6 +1,5 @@
 [[eshadoop-6.3.1]]
-== Elasticsearch for Apache Hadoop version 6.3.1
-June 13, 2018
+== Elasticsearch for Apache Hadoop version 6.3.1å
 
 [[known-5.3.1]]
 === Known Issues

--- a/docs/src/reference/asciidoc/appendix/release-notes/6.3.2.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/6.3.2.adoc
@@ -1,6 +1,5 @@
 [[eshadoop-6.3.2]]
 == Elasticsearch for Apache Hadoop version 6.3.2
-July 24, 2018
 
 [[enhancements-6.3.2]]
 === Enhancements

--- a/docs/src/reference/asciidoc/appendix/release-notes/6.4.0.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/6.4.0.adoc
@@ -1,6 +1,5 @@
 [[eshadoop-6.4.0]]
 == Elasticsearch for Apache Hadoop version 6.4.0
-August 23, 2018
 
 [[new-6.4.0]]
 === New Features

--- a/docs/src/reference/asciidoc/appendix/release-notes/6.4.1.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/6.4.1.adoc
@@ -1,5 +1,4 @@
 [[eshadoop-6.4.1]]
 == Elasticsearch for Apache Hadoop version 6.4.1
-September 18, 2018
 
 ES-Hadoop 6.4.1 is a version compatibility release, tested specifically against Elasticsearch 6.4.1.

--- a/docs/src/reference/asciidoc/appendix/release-notes/6.4.2.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/6.4.2.adoc
@@ -1,5 +1,4 @@
 [[eshadoop-6.4.2]]
 == Elasticsearch for Apache Hadoop version 6.4.2
-October 2, 2018
 
 ES-Hadoop 6.4.2 is a version compatibility release, tested specifically against Elasticsearch 6.4.2.

--- a/docs/src/reference/asciidoc/appendix/release-notes/6.4.3.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/6.4.3.adoc
@@ -1,6 +1,5 @@
 [[eshadoop-6.4.3]]
 == Elasticsearch for Apache Hadoop version 6.4.3
-November 6, 2018
 
 [[bugs-6.4.3]]
 === Bug Fixes

--- a/docs/src/reference/asciidoc/appendix/release-notes/6.5.0.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/6.5.0.adoc
@@ -1,6 +1,5 @@
 [[eshadoop-6.5.0]]
 == Elasticsearch for Apache Hadoop version 6.5.0
-November 6, 2018
 
 [[deprecation-6.5.0]]
 === Deprecations

--- a/docs/src/reference/asciidoc/appendix/release-notes/6.5.1.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/6.5.1.adoc
@@ -1,5 +1,4 @@
 [[eshadoop-6.5.1]]
 == Elasticsearch for Apache Hadoop version 6.5.1
-November 20, 2018
 
 ES-Hadoop 6.5.1 is a version compatibility release, tested specifically against Elasticsearch 6.5.1.

--- a/docs/src/reference/asciidoc/appendix/release-notes/6.5.2.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/6.5.2.adoc
@@ -1,5 +1,4 @@
 [[eshadoop-6.5.2]]
 == Elasticsearch for Apache Hadoop version 6.5.2
-December 5, 2018
 
 ES-Hadoop 6.5.2 is a version compatibility release, tested specifically against Elasticsearch 6.5.2.

--- a/docs/src/reference/asciidoc/appendix/release-notes/6.5.3.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/6.5.3.adoc
@@ -1,5 +1,4 @@
 [[eshadoop-6.5.3]]
 == Elasticsearch for Apache Hadoop version 6.5.3
-December 11, 2018
 
 ES-Hadoop 6.5.3 is a version compatibility release, tested specifically against Elasticsearch 6.5.3.

--- a/docs/src/reference/asciidoc/appendix/release-notes/6.5.4.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/6.5.4.adoc
@@ -1,5 +1,4 @@
 [[eshadoop-6.5.4]]
 == Elasticsearch for Apache Hadoop version 6.5.4
-December 19, 2018
 
 ES-Hadoop 6.5.4 is a version compatibility release, tested specifically against Elasticsearch 6.5.4.

--- a/docs/src/reference/asciidoc/appendix/release-notes/6.6.0.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/6.6.0.adoc
@@ -1,6 +1,5 @@
 [[eshadoop-6.6.0]]
 == Elasticsearch for Apache Hadoop version 6.6.0
-January 29, 2019
 
 [[deprecation-6.6.0]]
 === Deprecations

--- a/docs/src/reference/asciidoc/appendix/release-notes/6.6.1.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/6.6.1.adoc
@@ -1,5 +1,4 @@
 [[eshadoop-6.6.1]]
 == Elasticsearch for Apache Hadoop version 6.6.1
-February 19, 2019
 
 ES-Hadoop 6.6.1 is a version compatibility release, tested specifically against Elasticsearch 6.6.1.

--- a/docs/src/reference/asciidoc/appendix/release-notes/6.6.2.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/6.6.2.adoc
@@ -1,5 +1,4 @@
 [[eshadoop-6.6.2]]
 == Elasticsearch for Apache Hadoop version 6.6.2
-March 12, 2019
 
 ES-Hadoop 6.6.2 is a version compatibility release, tested specifically against Elasticsearch 6.6.2.

--- a/docs/src/reference/asciidoc/appendix/release-notes/6.7.0.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/6.7.0.adoc
@@ -1,6 +1,5 @@
 [[eshadoop-6.7.0]]
 == Elasticsearch for Apache Hadoop version 6.7.0
-March 26, 2019
 
 [[new-6.7.0]]
 === New Features

--- a/docs/src/reference/asciidoc/appendix/release-notes/6.7.1.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/6.7.1.adoc
@@ -1,5 +1,4 @@
 [[eshadoop-6.7.1]]
 == Elasticsearch for Apache Hadoop version 6.7.1
-April 4, 2019
 
 ES-Hadoop 6.7.1 is a version compatibility release, tested specifically against Elasticsearch 6.7.1.

--- a/docs/src/reference/asciidoc/appendix/release-notes/6.8.0.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/6.8.0.adoc
@@ -1,5 +1,4 @@
 [[eshadoop-6.8.0]]
 == Elasticsearch for Apache Hadoop version 6.8.0
-April 20, 2019
 
 ES-Hadoop 6.8.0 is a version compatibility release, tested specifically against Elasticsearch 6.8.0.

--- a/docs/src/reference/asciidoc/appendix/release-notes/6.8.1.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/6.8.1.adoc
@@ -1,5 +1,4 @@
 [[eshadoop-6.8.1]]
 == Elasticsearch for Apache Hadoop version 6.8.1
-June 18, 2019
 
 ES-Hadoop 6.8.1 is a version compatibility release, tested specifically against Elasticsearch 6.8.1.

--- a/docs/src/reference/asciidoc/appendix/release-notes/6.8.2.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/6.8.2.adoc
@@ -1,5 +1,4 @@
 [[eshadoop-6.8.2]]
 == Elasticsearch for Apache Hadoop version 6.8.2
-July 30, 2019
 
 ES-Hadoop 6.8.2 is a version compatibility release, tested specifically against Elasticsearch 6.8.2.

--- a/docs/src/reference/asciidoc/appendix/release-notes/6.8.3.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/6.8.3.adoc
@@ -1,6 +1,5 @@
 [[eshadoop-6.8.3]]
 == Elasticsearch for Apache Hadoop version 6.8.3
-September 5, 2019
 
 [[bugs-6.8.3]]
 === Bug Fixes

--- a/docs/src/reference/asciidoc/appendix/release-notes/6.8.4.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/6.8.4.adoc
@@ -1,6 +1,5 @@
 [[eshadoop-6.8.4]]
 == Elasticsearch for Apache Hadoop version 6.8.4
-October 23, 2019
 
 ES-Hadoop 6.8.4 is a version compatibility release,
 tested specifically against Elasticsearch 6.8.4.

--- a/docs/src/reference/asciidoc/appendix/release-notes/6.8.5.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/6.8.5.adoc
@@ -1,6 +1,5 @@
 [[eshadoop-6.8.5]]
 == Elasticsearch for Apache Hadoop version 6.8.5
-November 20, 2019
 
 ES-Hadoop 6.8.5 is a version compatibility release,
 tested specifically against Elasticsearch 6.8.5.


### PR DESCRIPTION
Removes release dates from Elasticsearch Hadoop release notes for the 6.8 branch.

Backport of #1396.

Relates to #1393 and #1396