### PR TITLE
Docs: Remove a broken [float]

### DIFF
--- a/docs/src/reference/asciidoc/core/configuration.adoc
+++ b/docs/src/reference/asciidoc/core/configuration.adoc
@@ -496,7 +496,6 @@ Whether the connector is used against an {es} instance in a cloud/restricted env
 Note that in this mode, performance is _highly_  affected.
 
 added[2.2]
-[float]
 `es.nodes.resolve.hostname` (default depends)::
 Whether the connector should resolve the nodes hostnames to IP addresses or not. By default it is +true+ unless +wan+ mode is enabled (see above) in which case it will default to false.
 


### PR DESCRIPTION
This float tag is broken and docbook has been ignoring it.
`--direct_html` doesn't ignore it though.
