### PR TITLE
support es shard number as partition number

### DIFF
--- a/mr/src/main/java/org/elasticsearch/hadoop/cfg/ConfigurationOptions.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/cfg/ConfigurationOptions.java
@@ -142,6 +142,9 @@ public interface ConfigurationOptions {
     String ES_INPUT_JSON = "es.input.json";
     String ES_INPUT_JSON_DEFAULT = "no";
 
+    String ES_INPUT_SHARDS_AS_PARTITION = "es.input.shard.num.as.partition.num";
+    String ES_INPUT_SHARDS_AS_PARTITION_DEFAULT = "no";
+
     /** Index settings */
     String ES_INDEX_AUTO_CREATE = "es.index.auto.create";
     String ES_INDEX_AUTO_CREATE_DEFAULT = "yes";

--- a/mr/src/main/java/org/elasticsearch/hadoop/cfg/Settings.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/cfg/Settings.java
@@ -651,6 +651,10 @@ public abstract class Settings {
         return null;
     }
 
+    public boolean getInputShardsAsPartition(){
+        return Booleans.parseBoolean(getProperty(ES_INPUT_SHARDS_AS_PARTITION, ES_INPUT_SHARDS_AS_PARTITION_DEFAULT));
+    }
+
     public boolean getReadMetadata() {
         return Booleans.parseBoolean(getProperty(ES_READ_METADATA, ES_READ_METADATA_DEFAULT));
     }


### PR DESCRIPTION
This commit can change the execution time from hours to minutes in some scenarios like：
1) query a lot of index and each index has one shard, like thousands of index
2) each shard has ten millions of docs, and aboud 20GB size
3) user use match phrase query, the term will match a lot but the phrase match little

in scenarios like above, when we count partitions, we will query each shard to count hit docs, because we use match phrase, each shard will spend about one second average, then it will spend about hours in `findSlicePartitions` function total.

so maybe we shoud support parameter to skip this count if each shard hit little. 