### PR TITLE
Bump version to 7.6.1

### DIFF
--- a/buildSrc/esh-version.properties
+++ b/buildSrc/esh-version.properties
@@ -1,3 +1,3 @@
-eshadoop        = 7.6.0
-elasticsearch   = 7.6.0
-build-tools     = 7.6.0
+eshadoop        = 7.6.1
+elasticsearch   = 7.6.1
+build-tools     = 7.6.1


### PR DESCRIPTION
Note: I did not update the README since it already points to 7.6.0 for the stable release, which I believe is correct?