### PR TITLE
Update README to point to 7.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,14 +19,14 @@ ES-Hadoop 2.0.x and 2.1.x are compatible with Elasticsearch __1.X__ *only*
 
 ## Installation
 
-### Stable Release (currently `7.4.1`)
+### Stable Release (currently `7.6.0`)
 Available through any Maven-compatible tool:
 
 ```xml
 <dependency>
   <groupId>org.elasticsearch</groupId>
   <artifactId>elasticsearch-hadoop</artifactId>
-  <version>7.4.1</version>
+  <version>7.6.0</version>
 </dependency>
 ```
 or as a stand-alone [ZIP](http://www.elastic.co/downloads/hadoop).


### PR DESCRIPTION
Noticed the master README was still pointing at `7.4.1`, updates to `7.6.0`