### PR TITLE
Remove deprecated Gradle configurations

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/IntegrationBuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/IntegrationBuildPlugin.groovy
@@ -88,7 +88,7 @@ class IntegrationBuildPlugin implements Plugin<Project> {
         // If this becomes a problem, we could see if there's a way to listen for new dependencies and add them
         // to root at the same time.
         project.afterEvaluate {
-            project.getConfigurations().getByName('compile').getAllDependencies()
+            project.getConfigurations().getByName('implementation').getAllDependencies()
                     .withType(ExternalDependency.class)
                     .each { Dependency dependency ->
                     // Convert the scope to optional on the root project - it will have every integration in it, and

--- a/hive/build.gradle
+++ b/hive/build.gradle
@@ -9,8 +9,8 @@ dependencies {
     provided(project(":elasticsearch-hadoop-mr"))
     provided(project(path: ":elasticsearch-hadoop-mr", configuration:"compile"))
 
-    testCompile project(":elasticsearch-hadoop-mr").sourceSets.test.runtimeClasspath
-    itestCompile project(":elasticsearch-hadoop-mr").sourceSets.itest.runtimeClasspath
+    testImplementation(project(":elasticsearch-hadoop-mr").sourceSets.test.runtimeClasspath)
+    itestImplementation(project(":elasticsearch-hadoop-mr").sourceSets.itest.runtimeClasspath)
 }
 
 jar {
@@ -37,10 +37,10 @@ dependencies {
     provided("org.apache.hive:hive-exec:$hiveVersion")
     provided("org.apache.hive:hive-metastore:$hiveVersion")
 
-    itestRuntime("org.apache.hive:hive-service:$hiveVersion") {
+    itestImplementation("org.apache.hive:hive-service:$hiveVersion") {
         exclude module: "log4j-slf4j-impl"
     }
-    itestRuntime("org.apache.hive:hive-jdbc:$hiveVersion") {
+    itestImplementation("org.apache.hive:hive-jdbc:$hiveVersion") {
         exclude module: "log4j-slf4j-impl"
     }
 }

--- a/mr/build.gradle
+++ b/mr/build.gradle
@@ -17,9 +17,9 @@ dependencies {
     provided("org.codehaus.jackson:jackson-mapper-asl:${project.ext.jacksonVersion}")
     provided("org.codehaus.jackson:jackson-core-asl:${project.ext.jacksonVersion}")
     
-    testCompile(project.ext.hadoopClient)
-    testCompile "io.netty:netty-all:4.0.29.Final"
-    testCompile "org.elasticsearch:securemock:1.2"
+    testImplementation(project.ext.hadoopClient)
+    testImplementation("io.netty:netty-all:4.0.29.Final")
+    testImplementation("org.elasticsearch:securemock:1.2")
 }
 
 String generatedResources = "$buildDir/generated-resources/main"

--- a/pig/build.gradle
+++ b/pig/build.gradle
@@ -9,8 +9,8 @@ dependencies {
     provided(project(":elasticsearch-hadoop-mr"))
     provided(project(path: ":elasticsearch-hadoop-mr", configuration:"compile"))
 
-    testCompile project(":elasticsearch-hadoop-mr").sourceSets.test.runtimeClasspath
-    itestCompile project(":elasticsearch-hadoop-mr").sourceSets.itest.runtimeClasspath
+    testImplementation(project(":elasticsearch-hadoop-mr").sourceSets.test.runtimeClasspath)
+    itestImplementation(project(":elasticsearch-hadoop-mr").sourceSets.itest.runtimeClasspath)
 }
 
 jar {
@@ -36,11 +36,11 @@ dependencies {
     provided("org.apache.pig:pig:$pigVersion:$pigClassifier")
     provided("joda-time:joda-time:$jodaVersion")
 
-    testRuntime("org.apache.pig:pig:$pigVersion:$pigClassifier")
-    testRuntime("joda-time:joda-time:$jodaVersion")
+    testImplementation("org.apache.pig:pig:$pigVersion:$pigClassifier")
+    testImplementation("joda-time:joda-time:$jodaVersion")
 
-    testRuntime "com.google.guava:guava:11.0"
-    testRuntime "jline:jline:0.9.94"
+    testImplementation("com.google.guava:guava:11.0")
+    testImplementation("jline:jline:0.9.94")
 
-    itestRuntime "dk.brics.automaton:automaton:1.11-8"
+    itestImplementation("dk.brics.automaton:automaton:1.11-8")
 }

--- a/qa/kerberos/build.gradle
+++ b/qa/kerberos/build.gradle
@@ -48,22 +48,23 @@ tasks.withType(ScalaCompile) { ScalaCompile task ->
 boolean localRepo = project.getProperties().containsKey("localRepo")
 
 dependencies {
-    compile project(":elasticsearch-hadoop-mr")
-    compile project(":elasticsearch-storm")
+    implementation(project(":elasticsearch-hadoop-mr"))
+    implementation(project(":elasticsearch-storm"))
 
-    compile 'org.scala-lang:scala-library:2.11.8'
-    compile project(":elasticsearch-spark-20")
+    implementation('org.scala-lang:scala-library:2.11.12')
+    implementation('org.scala-lang:scala-reflect:2.11.12')
+    implementation(project(":elasticsearch-spark-20"))
     
     compileOnly("com.fasterxml.jackson.module:jackson-module-scala_2.11:2.6.7.1")
     compileOnly("com.fasterxml.jackson.core:jackson-annotations:2.6.7")
     compileOnly("org.json4s:json4s-jackson_2.11:3.2.11")
     compileOnly("org.slf4j:slf4j-api:1.7.6")
 
-    compile("org.apache.hadoop:hadoop-client:${HadoopClusterConfiguration.HADOOP.defaultVersion()}")
-    compile("org.apache.spark:spark-sql_2.11:$project.ext.spark20Version")
+    implementation("org.apache.hadoop:hadoop-client:${HadoopClusterConfiguration.HADOOP.defaultVersion()}")
+    implementation("org.apache.spark:spark-sql_2.11:$project.ext.spark20Version")
 
-    compile project(":elasticsearch-hadoop-mr").sourceSets.itest.runtimeClasspath
-    compile project(":elasticsearch-storm").sourceSets.itest.runtimeClasspath
+    implementation(project(":elasticsearch-hadoop-mr").sourceSets.itest.runtimeClasspath)
+    implementation(project(":elasticsearch-storm").sourceSets.itest.runtimeClasspath)
 
     kdcFixture project(':test:fixtures:minikdc')
 

--- a/spark/sql-13/build.gradle
+++ b/spark/sql-13/build.gradle
@@ -3,6 +3,7 @@ description = "Elasticsearch Spark (for Spark 1.3-1.6)"
 
 evaluationDependsOn(':elasticsearch-hadoop-mr')
 
+apply plugin: 'java-library'
 apply plugin: 'scala'
 apply plugin: 'es.hadoop.build'
 apply plugin: 'scala.variants'
@@ -88,10 +89,9 @@ eclipse {
 
 dependencies {
     provided(project(":elasticsearch-hadoop-mr"))
-    provided(project(path: ":elasticsearch-hadoop-mr", configuration:"compile"))
 
-    compile("org.scala-lang:scala-library:${project.ext.scalaVersion}")
-    compile("org.scala-lang:scala-reflect:${project.ext.scalaVersion}")
+    api("org.scala-lang:scala-library:${project.ext.scalaVersion}")
+    api("org.scala-lang:scala-reflect:${project.ext.scalaVersion}")
 
     provided("org.apache.spark:spark-core_${project.ext.scalaMajorVersion}:$sparkVersion") {
         exclude group: 'javax.servlet'
@@ -122,17 +122,17 @@ dependencies {
         exclude group: 'org.apache.hadoop'
     }
 
-    testCompile project(":elasticsearch-hadoop-mr").sourceSets.test.runtimeClasspath
-    itestCompile project(":elasticsearch-hadoop-mr").sourceSets.itest.runtimeClasspath
+    testImplementation(project(":elasticsearch-hadoop-mr").sourceSets.test.runtimeClasspath)
+    itestImplementation(project(":elasticsearch-hadoop-mr").sourceSets.itest.runtimeClasspath)
 
-    testCompile("org.apache.spark:spark-core_${project.ext.scalaMajorVersion}:$sparkVersion") {
+    testImplementation("org.apache.spark:spark-core_${project.ext.scalaMajorVersion}:$sparkVersion") {
         exclude group: 'javax.servlet'
         exclude group: 'org.apache.hadoop'
     }
-    itestCompile("org.apache.spark:spark-streaming_${project.ext.scalaMajorVersion}:$sparkVersion") {
+    itestImplementation("org.apache.spark:spark-streaming_${project.ext.scalaMajorVersion}:$sparkVersion") {
         exclude group: 'org.apache.hadoop'
     }
-    testCompile("org.apache.spark:spark-sql_${project.ext.scalaMajorVersion}:$sparkVersion") {
+    testImplementation("org.apache.spark:spark-sql_${project.ext.scalaMajorVersion}:$sparkVersion") {
         exclude group: 'org.apache.hadoop'
     }
 }
@@ -171,8 +171,14 @@ configurations.all { Configuration conf ->
             }
         }
     }
-
-    conf.exclude group: "org.mortbay.jetty"
+}
+configurations {
+    testImplementation {
+        exclude group: "org.mortbay.jetty"
+    }
+    itestImplementation {
+        exclude group: "org.mortbay.jetty"
+    }
 }
 
 tasks.withType(ScalaCompile) {

--- a/spark/sql-20/build.gradle
+++ b/spark/sql-20/build.gradle
@@ -3,6 +3,7 @@ description = "Elasticsearch Spark (for Spark 2.X)"
 
 evaluationDependsOn(':elasticsearch-hadoop-mr')
 
+apply plugin: 'java-library'
 apply plugin: 'scala'
 apply plugin: 'es.hadoop.build.integration'
 apply plugin: 'scala.variants'
@@ -93,10 +94,9 @@ eclipse {
 
 dependencies {
     provided(project(":elasticsearch-hadoop-mr"))
-    provided(project(path: ":elasticsearch-hadoop-mr", configuration:"compile"))
 
-    compile("org.scala-lang:scala-library:$scalaVersion")
-    compile("org.scala-lang:scala-reflect:$scalaVersion")
+    api("org.scala-lang:scala-library:$scalaVersion")
+    api("org.scala-lang:scala-reflect:$scalaVersion")
 
     provided("org.apache.spark:spark-core_${project.ext.scalaMajorVersion}:$sparkVersion") {
         exclude group: 'javax.servlet'
@@ -130,23 +130,23 @@ dependencies {
         exclude group: 'org.apache.hadoop'
     }
 
-    testCompile "org.elasticsearch:securemock:1.2"
-    testCompile(project(":elasticsearch-hadoop-mr").sourceSets.test.output)
+    testImplementation("org.elasticsearch:securemock:1.2")
+    testImplementation(project(":elasticsearch-hadoop-mr").sourceSets.test.output)
 
-    itestCompile(project(":elasticsearch-hadoop-mr").sourceSets.itest.output)
+    itestImplementation(project(":elasticsearch-hadoop-mr").sourceSets.itest.output)
 
-    testCompile(project.ext.hadoopClient)
-    testCompile("org.apache.spark:spark-core_${project.ext.scalaMajorVersion}:$sparkVersion") {
+    testImplementation(project.ext.hadoopClient)
+    testImplementation("org.apache.spark:spark-core_${project.ext.scalaMajorVersion}:$sparkVersion") {
         exclude group: 'javax.servlet'
         exclude group: 'org.apache.hadoop'
     }
-    itestCompile("org.apache.spark:spark-yarn_${project.ext.scalaMajorVersion}:$sparkVersion") {
+    itestImplementation("org.apache.spark:spark-yarn_${project.ext.scalaMajorVersion}:$sparkVersion") {
         exclude group: 'org.apache.hadoop'
     }
-    testCompile("org.apache.spark:spark-sql_${project.ext.scalaMajorVersion}:$sparkVersion") {
+    testImplementation("org.apache.spark:spark-sql_${project.ext.scalaMajorVersion}:$sparkVersion") {
         exclude group: 'org.apache.hadoop'
     }
-    itestCompile("org.apache.spark:spark-streaming_${project.ext.scalaMajorVersion}:$sparkVersion") {
+    itestImplementation("org.apache.spark:spark-streaming_${project.ext.scalaMajorVersion}:$sparkVersion") {
         exclude group: 'org.apache.hadoop'
     }
 }

--- a/storm/build.gradle
+++ b/storm/build.gradle
@@ -7,10 +7,9 @@ evaluationDependsOn(':elasticsearch-hadoop-mr')
 
 dependencies {
     provided(project(":elasticsearch-hadoop-mr"))
-    provided(project(path: ":elasticsearch-hadoop-mr", configuration:"compile"))
 
-    testCompile project(":elasticsearch-hadoop-mr").sourceSets.test.runtimeClasspath
-    itestCompile project(":elasticsearch-hadoop-mr").sourceSets.itest.runtimeClasspath
+    testImplementation(project(":elasticsearch-hadoop-mr").sourceSets.test.runtimeClasspath)
+    itestImplementation(project(":elasticsearch-hadoop-mr").sourceSets.itest.runtimeClasspath)
 }
 
 jar {
@@ -35,8 +34,8 @@ dependencies {
         exclude module: "log4j-slf4j-impl"
     }
 
-    itestCompile "com.google.guava:guava:16.0.1"
-    itestRuntime "com.twitter:carbonite:1.4.0"
+    itestImplementation("com.google.guava:guava:16.0.1")
+    itestImplementation("com.twitter:carbonite:1.4.0")
 }
 
 // add itest to Eclipse

--- a/test/fixtures/minikdc/build.gradle
+++ b/test/fixtures/minikdc/build.gradle
@@ -24,7 +24,7 @@ repositories {
 }
 
 dependencies {
-    compile("org.apache.hadoop:hadoop-minikdc:${project.ext.minikdcVersion}") {
+    implementation("org.apache.hadoop:hadoop-minikdc:${project.ext.minikdcVersion}") {
         // For some reason, the dependencies that are pulled in with MiniKDC have multiple resource files
         // that cause issues when they are loaded. We exclude the ldap schema data jar to get around this.
         exclude group: "org.apache.directory.api", module: "api-ldap-schema-data"


### PR DESCRIPTION
The original Gradle configuration names of `compile` and `runtime` are deprecated. This PR replaces their uses in the build with new/current configurations. 

Specifically, this PR converts uses of the `compile`  configuration to instead use the `implementation` or `api` configurations. It also swaps the use of the `runtime` configuration over to use `runtimeClasspath`.

Did some light tidying up as well.