### PR TITLE
Boost default scroll size to 1000

### DIFF
--- a/docs/src/reference/asciidoc/core/configuration.adoc
+++ b/docs/src/reference/asciidoc/core/configuration.adoc
@@ -510,8 +510,8 @@ available {es} node (based on the declaration of `es.nodes`, followed by the dis
 `es.scroll.keepalive` (default 10m)::
 The maximum duration of result scrolls between query requests.
 
-`es.scroll.size` (default 50)::
-Number of results/items returned by each individual per request.
+`es.scroll.size` (default 1000)::
+Number of results/items/documents returned per scroll request on each executor/worker/task.
 
 added[2.2]
 `es.scroll.limit` (default -1)::

--- a/mr/src/main/java/org/elasticsearch/hadoop/cfg/ConfigurationOptions.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/cfg/ConfigurationOptions.java
@@ -114,7 +114,7 @@ public interface ConfigurationOptions {
 
     /** Scroll size */
     String ES_SCROLL_SIZE = "es.scroll.size";
-    String ES_SCROLL_SIZE_DEFAULT = "50";
+    String ES_SCROLL_SIZE_DEFAULT = "1000";
 
     /** Scroll limit */
     String ES_SCROLL_LIMIT = "es.scroll.limit";


### PR DESCRIPTION
The default scroll size we use for reading data from Elasticsearch is currently set to 50. We feel like this number is much too low for a default value. This PR increases the default scroll size from 50 documents to 1000 documents, parallel to the default scroll size used in Elasticsearch's reindex api.

This change is marked as breaking since it changes a default configuration value which may affect existing low memory Hadoop deployments that do not set this property.