### PR TITLE
Update the QA project to use test cluster api

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/fixture/hadoop/ConfigFormats.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/fixture/hadoop/ConfigFormats.groovy
@@ -19,11 +19,13 @@
 
 package org.elasticsearch.hadoop.gradle.fixture.hadoop
 
+import static org.elasticsearch.hadoop.gradle.fixture.hadoop.conf.SettingsContainer.FileSettings
+
 class ConfigFormats {
 
     static Closure<String> hadoopXML() {
-        return { Map conf ->
-            String props = conf.collect { key, value ->
+        return { FileSettings conf ->
+            String props = conf.resolve().collect { key, value ->
                 "<property>\n\t\t<name>${key}</name>\n\t\t<value>${value}</value>\n\t</property>"
             }.join("\n\t")
             return "<configuration>\n\t${props}\n</configuration>"
@@ -31,16 +33,16 @@ class ConfigFormats {
     }
 
     static Closure<String> propertyFile() {
-        return { Map conf ->
-            conf.collect { key, value ->
+        return { FileSettings conf ->
+            conf.resolve().collect { key, value ->
                 "${key}=${value}"
             }.join("\n")
         }
     }
 
     static Closure<String> whiteSpaced() {
-        return { Map conf ->
-            conf.collect { key, value ->
+        return { FileSettings conf ->
+            conf.resolve().collect { key, value ->
                 "${key}   ${value}"
             }.join("\n")
         }

--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/fixture/hadoop/HadoopClusterFormationTasks.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/fixture/hadoop/HadoopClusterFormationTasks.groovy
@@ -71,8 +71,6 @@ class HadoopClusterFormationTasks {
      * Adds dependent tasks to the given task to start and stop a cluster with the given configuration.
      * <p>
      * Returns a list of NodeInfo objects for each node in the cluster.
-     *
-     * Based on (now removed) org.elasticsearch.gradle.test.ClusterFormationTasks
      */
     static List<InstanceInfo> setup(Project project, HadoopClusterConfiguration clusterConfiguration) {
         String prefix = clusterConfiguration.getName()

--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/fixture/hadoop/ServiceDescriptor.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/fixture/hadoop/ServiceDescriptor.groovy
@@ -24,6 +24,8 @@ import org.elasticsearch.hadoop.gradle.fixture.hadoop.conf.InstanceConfiguration
 import org.elasticsearch.hadoop.gradle.fixture.hadoop.conf.ServiceConfiguration
 import org.elasticsearch.hadoop.gradle.tasks.ApacheMirrorDownload
 
+import static org.elasticsearch.hadoop.gradle.fixture.hadoop.conf.SettingsContainer.FileSettings
+
 /**
  * Describes deployment characteristics for different Hadoop ecosystem projects.
  *
@@ -100,7 +102,7 @@ interface ServiceDescriptor {
     /**
      * Collect all configuration entries, setting defaults for the service, role, and instance.
      */
-    Map<String, Map<String, String>> collectConfigFilesContents(InstanceConfiguration configuration)
+    Map<String, FileSettings> collectConfigFilesContents(InstanceConfiguration configuration)
 
     /**
      * Closure that formats a configuration map into a String for the config file contents.
@@ -110,7 +112,7 @@ interface ServiceDescriptor {
     /**
      * Produces the HTTP/S URI to reach the web front end for a running instance, or null if there is no web interface.
      */
-    String httpUri(InstanceConfiguration configuration, Map<String, Map<String, String>> configFileContents)
+    String httpUri(InstanceConfiguration configuration, Map<String, FileSettings> configFileContents)
 
     /**
      * The command line to use for starting the given role and instance.

--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/fixture/hadoop/conf/EndProcessConfiguration.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/fixture/hadoop/conf/EndProcessConfiguration.groovy
@@ -19,6 +19,9 @@
 
 package org.elasticsearch.hadoop.gradle.fixture.hadoop.conf
 
+import org.elasticsearch.gradle.testclusters.ElasticsearchCluster
+import org.gradle.api.Project
+
 /**
  * Provides defaults and can be slotted in as the last parent configuration in a chain.
  *
@@ -29,8 +32,8 @@ package org.elasticsearch.hadoop.gradle.fixture.hadoop.conf
  */
 class EndProcessConfiguration extends ProcessConfiguration {
 
-    EndProcessConfiguration() {
-        super(null)
+    EndProcessConfiguration(Project project) {
+        super(project)
     }
 
     @Override
@@ -69,6 +72,11 @@ class EndProcessConfiguration extends ProcessConfiguration {
     }
 
     @Override
+    String getJavaHome() {
+        return project.runtimeJavaHome
+    }
+
+    @Override
     String getJvmArgs() {
         return ""
     }
@@ -76,5 +84,10 @@ class EndProcessConfiguration extends ProcessConfiguration {
     @Override
     boolean getDebug() {
         return false
+    }
+
+    @Override
+    ElasticsearchCluster getElasticsearchCluster() {
+        return null
     }
 }

--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/fixture/hadoop/conf/HadoopClusterConfiguration.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/fixture/hadoop/conf/HadoopClusterConfiguration.groovy
@@ -47,11 +47,10 @@ class HadoopClusterConfiguration extends ProcessConfiguration {
     private static final Map<String, ServiceDescriptor> SUPPORTED_SERVICES = [HADOOP, HIVE, PIG, SPARK]
                     .collectEntries { [(it.id()): it] }
 
-    private static final ProcessConfiguration END = new EndProcessConfiguration()
-
     private final Project project
     private final String name
     private final List<Task> clusterTasks
+    private final ProcessConfiguration defaultConfiguration
     private final Map<String, ServiceConfiguration> serviceConfigurations
     private final List<ServiceConfiguration> serviceCreationOrder
 
@@ -60,6 +59,7 @@ class HadoopClusterConfiguration extends ProcessConfiguration {
         this.project = project
         this.name = name
         this.clusterTasks = []
+        this.defaultConfiguration = new EndProcessConfiguration(project)
         this.serviceConfigurations = [:]
         this.serviceCreationOrder = []
     }
@@ -126,6 +126,6 @@ class HadoopClusterConfiguration extends ProcessConfiguration {
 
     @Override
     protected ProcessConfiguration parent() {
-        return END
+        return defaultConfiguration
     }
 }

--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/fixture/hadoop/conf/ProcessConfiguration.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/fixture/hadoop/conf/ProcessConfiguration.groovy
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.hadoop.gradle.fixture.hadoop.conf
 
+import org.elasticsearch.gradle.testclusters.ElasticsearchCluster
 import org.gradle.api.InvalidUserDataException
 import org.gradle.api.Project
 import org.gradle.api.Task
@@ -38,7 +39,7 @@ abstract class ProcessConfiguration {
         this.project = project
     }
 
-    private final Project project
+    protected final Project project
     private Map<String, String> systemProperties = new HashMap<>()
     private Map<String, String> environmentVariables = new HashMap<>()
     private SettingsContainer settingsContainer = new SettingsContainer()
@@ -46,8 +47,10 @@ abstract class ProcessConfiguration {
     private LinkedHashMap<String, Object[]> setupCommands = new LinkedHashMap<>()
     private List<Object> dependencies = new ArrayList<>()
     private List<Task> clusterTasks = new ArrayList<>()
+    private String javaHome = null
     private String jvmArgs = ''
     private boolean debug = false
+    private ElasticsearchCluster elasticsearchCluster = null
 
     void addSystemProperty(String key, String value) {
         systemProperties.put(key, value)
@@ -77,7 +80,7 @@ abstract class ProcessConfiguration {
         return combined
     }
 
-    void addSetting(String key, String value) {
+    void addSetting(String key, Object value) {
         settingsContainer.addSetting(key, value)
     }
 
@@ -145,6 +148,23 @@ abstract class ProcessConfiguration {
         return combined
     }
 
+    void setJavaHome(String javaHome) {
+        this.javaHome = javaHome
+    }
+
+    String getJavaHome() {
+        if (this.javaHome != null) {
+            return this.javaHome
+        } else {
+            ProcessConfiguration parent = parent()
+            if (parent != null) {
+                return parent.getJavaHome()
+            } else {
+                return null
+            }
+        }
+    }
+
     void setJvmArgs(String jvmArgs) {
         this.jvmArgs = jvmArgs
     }
@@ -176,6 +196,23 @@ abstract class ProcessConfiguration {
         }
         // No parent, return value (which should be false)
         return debug
+    }
+
+    void useElasticsearchCluster(ElasticsearchCluster elasticsearchCluster) {
+        this.elasticsearchCluster = elasticsearchCluster
+    }
+
+    ElasticsearchCluster getElasticsearchCluster() {
+        if (this.elasticsearchCluster != null) {
+            return this.elasticsearchCluster
+        } else {
+            ProcessConfiguration parent = parent()
+            if (parent != null) {
+                return parent.getElasticsearchCluster()
+            } else {
+                return null
+            }
+        }
     }
 
     Task createClusterTask(Map<String, ?> options) throws InvalidUserDataException {

--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/fixture/hadoop/services/HiveServiceDescriptor.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/fixture/hadoop/services/HiveServiceDescriptor.groovy
@@ -29,6 +29,8 @@ import org.elasticsearch.hadoop.gradle.fixture.hadoop.conf.ServiceConfiguration
 import org.elasticsearch.hadoop.gradle.tasks.ApacheMirrorDownload
 import org.gradle.api.GradleException
 
+import static org.elasticsearch.hadoop.gradle.fixture.hadoop.conf.SettingsContainer.FileSettings
+
 class HiveServiceDescriptor implements ServiceDescriptor {
 
     static final Map<Version, Map<String, String>> VERSION_MAP = [:]
@@ -114,8 +116,8 @@ class HiveServiceDescriptor implements ServiceDescriptor {
     }
 
     @Override
-    Map<String, Map<String, String>> collectConfigFilesContents(InstanceConfiguration configuration) {
-        Map<String, String> hiveSite = configuration.getSettingsContainer().flattenFile('hive-site.xml')
+    Map<String, FileSettings> collectConfigFilesContents(InstanceConfiguration configuration) {
+        FileSettings hiveSite = configuration.getSettingsContainer().flattenFile('hive-site.xml')
         return ['hive-site.xml' : hiveSite]
     }
 
@@ -125,7 +127,7 @@ class HiveServiceDescriptor implements ServiceDescriptor {
     }
 
     @Override
-    String httpUri(InstanceConfiguration configuration, Map<String, Map<String, String>> configFileContents) {
+    String httpUri(InstanceConfiguration configuration, Map<String, FileSettings> configFileContents) {
         if (HIVESERVER.equals(configuration.roleDescriptor)) {
             return null
         }

--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/fixture/hadoop/services/PigServiceDescriptor.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/fixture/hadoop/services/PigServiceDescriptor.groovy
@@ -29,6 +29,8 @@ import org.elasticsearch.hadoop.gradle.fixture.hadoop.conf.ServiceConfiguration
 import org.elasticsearch.hadoop.gradle.tasks.ApacheMirrorDownload
 import org.gradle.api.GradleException
 
+import static org.elasticsearch.hadoop.gradle.fixture.hadoop.conf.SettingsContainer.FileSettings
+
 class PigServiceDescriptor implements ServiceDescriptor {
 
     static final Map<Version, Map<String, String>> VERSION_MAP = [:]
@@ -112,7 +114,7 @@ class PigServiceDescriptor implements ServiceDescriptor {
     }
 
     @Override
-    Map<String, Map<String, String>> collectConfigFilesContents(InstanceConfiguration configuration) {
+    Map<String, FileSettings> collectConfigFilesContents(InstanceConfiguration configuration) {
         return ['pig.properties' : configuration.getSettingsContainer().flattenFile('pig.properties')]
     }
 
@@ -122,7 +124,7 @@ class PigServiceDescriptor implements ServiceDescriptor {
     }
 
     @Override
-    String httpUri(InstanceConfiguration configuration, Map<String, Map<String, String>> configFileContents) {
+    String httpUri(InstanceConfiguration configuration, Map<String, FileSettings> configFileContents) {
         if (GATEWAY.equals(configuration.roleDescriptor)) {
             return null
         }

--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/fixture/hadoop/services/SparkYarnServiceDescriptor.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/fixture/hadoop/services/SparkYarnServiceDescriptor.groovy
@@ -29,12 +29,15 @@ import org.elasticsearch.hadoop.gradle.fixture.hadoop.conf.ServiceConfiguration
 import org.elasticsearch.hadoop.gradle.tasks.ApacheMirrorDownload
 import org.gradle.api.GradleException
 
+import static org.elasticsearch.hadoop.gradle.fixture.hadoop.conf.SettingsContainer.FileSettings
+
 class SparkYarnServiceDescriptor implements ServiceDescriptor {
 
+    static final Version VERSION = new Version(2, 3, 4)
     static final Map<Version, Map<String, String>> VERSION_MAP = [:]
     static {
-        VERSION_MAP.put(new Version(2, 3, 3),
-                ['SHA-512': '27CF9AD268E684D6926201BB5478F7F5A410659972BC79FC14AF61245EFF50C9A4363E400311B2FA9E1326E8AF1EB6DDE1D359B88B9143F25A49B3E11596B002'])
+        VERSION_MAP.put(VERSION,
+                ['SHA-512': '9FBEFCE2739990FFEDE6968A9C2F3FE399430556163BFDABDF5737A8F9E52CD535489F5CA7D641039A87700F50BFD91A706CA47979EE51A3A18787A92E2D6D53'])
     }
 
     static RoleDescriptor GATEWAY = RoleDescriptor.requiredGateway('spark', [])
@@ -61,7 +64,7 @@ class SparkYarnServiceDescriptor implements ServiceDescriptor {
 
     @Override
     Version defaultVersion() {
-        return new Version(2, 3, 3)
+        return VERSION
     }
 
     @Override
@@ -116,7 +119,7 @@ class SparkYarnServiceDescriptor implements ServiceDescriptor {
     }
 
     @Override
-    Map<String, Map<String, String>> collectConfigFilesContents(InstanceConfiguration configuration) {
+    Map<String, FileSettings> collectConfigFilesContents(InstanceConfiguration configuration) {
         return ['spark-defaults.conf' : configuration.getSettingsContainer().flattenFile('spark-defaults.conf')]
     }
 
@@ -126,7 +129,7 @@ class SparkYarnServiceDescriptor implements ServiceDescriptor {
     }
 
     @Override
-    String httpUri(InstanceConfiguration configuration, Map<String, Map<String, String>> configFileContents) {
+    String httpUri(InstanceConfiguration configuration, Map<String, FileSettings> configFileContents) {
         if (GATEWAY.equals(configuration.roleDescriptor)) {
             return null
         }

--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/fixture/hadoop/tasks/HadoopMRJob.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/fixture/hadoop/tasks/HadoopMRJob.groovy
@@ -26,22 +26,27 @@ import org.gradle.api.GradleException
 import org.gradle.api.tasks.TaskAction
 import org.gradle.process.ExecSpec
 
+import static org.elasticsearch.hadoop.gradle.util.ObjectUtil.unapplyString
+
 class HadoopMRJob extends AbstractClusterTask {
 
     String jobClass
     File jobJar
-    Map<String, String> jobSettings = [:]
+    Map<String, Object> jobSettings = [:]
     List<File> libJars = []
     List<String> args = []
     Map<String, String> systemProperties = [:]
-    Map<String, String> environmentVariables = [:]
 
-    void jobSetting(String key, String value) {
+    void jobSetting(String key, Object value) {
         jobSettings.put(key, value)
     }
 
-    void jobSettings(Map<String, String> settings) {
+    void jobSettings(Map<String, Object> settings) {
         jobSettings.putAll(settings)
+    }
+
+    void libJars(File... files) {
+        libJars.addAll(files)
     }
 
     void systemProperty(String key, String value) {
@@ -50,6 +55,50 @@ class HadoopMRJob extends AbstractClusterTask {
 
     void systemProperties(Map<String, String> settings) {
         systemProperties.putAll(settings)
+    }
+
+    @Override
+    InstanceConfiguration defaultInstance(HadoopClusterConfiguration clusterConfiguration) {
+        return clusterConfiguration
+                .service(HadoopClusterConfiguration.HADOOP)
+                .role(HadoopServiceDescriptor.GATEWAY)
+                .instance(0)
+    }
+
+    @Override
+    Map<String, String> taskEnvironmentVariables() {
+        Map<String, String> taskEnv = [:]
+        InstanceConfiguration instance = getInstance()
+
+        // Add lib jars to the user classpath if needed
+        if (!libJars.isEmpty()) {
+            taskEnv.put('YARN_USER_CLASSPATH', libJars.join(":"))
+        }
+
+        // Collect the java properties and JVM options from the cluster configuration, as well as the system props from
+        // this specific task. Add them to the environment variable that Hadoop would expect them to be specified under.
+        String javaPropertyEnvVariable = instance.getServiceDescriptor().javaOptsEnvSetting(instance)
+        if (javaPropertyEnvVariable != null) {
+            List<String> javaOpts = [taskEnv.get(javaPropertyEnvVariable, '')]
+            javaOpts.add(instance.getJvmArgs())
+            for (Map<String, String> propertyMap : [instance.getSystemProperties(), systemProperties]) {
+                String collectedSystemProperties = propertyMap
+                        .collect { key, value -> "-D${key}=${value}" }
+                        .join(" ")
+                if (!collectedSystemProperties.isEmpty()) {
+                    javaOpts.add(collectedSystemProperties)
+                }
+            }
+            // Force the javaOptsEnvSetting to be the correct one for executing a hadoop jar command.
+            // We might be running this command "on a different instance" than gateway
+            // (it might be running on namenode, and be using namenode's env property names)
+            String hadoopJarCommandJavaPropertyEnvVariable = instance
+                    .getServiceDescriptor()
+                    .javaOptsEnvSetting(defaultInstance(clusterConfiguration))
+            taskEnv.put(hadoopJarCommandJavaPropertyEnvVariable, javaOpts.join(" ").trim())
+        }
+
+        return taskEnv
     }
 
     @TaskAction
@@ -85,35 +134,13 @@ class HadoopMRJob extends AbstractClusterTask {
             commandLine.addAll(['-libjars', libJars.join(',')])
         }
         if (!jobSettings.isEmpty()) {
-            commandLine.addAll(jobSettings.collect { k, v -> "-D${k}=${v}"})
+            commandLine.addAll(jobSettings.collect { k, v -> "-D${k}=${unapplyString(v)}"})
         }
         if (!args.isEmpty()) {
             commandLine.addAll(args)
         }
 
-        Map<String, String> finalEnv = hadoopGateway.getEnvironmentVariables()
-        hadoopGateway.getServiceDescriptor().finalizeEnv(finalEnv, hadoopGateway)
-
-        if (!libJars.isEmpty()) {
-            finalEnv.put('YARN_USER_CLASSPATH', libJars.join(":"))
-        }
-
-        String javaPropertyEnvVariable = hadoopGateway.getServiceDescriptor().javaOptsEnvSetting(hadoopGateway)
-        if (javaPropertyEnvVariable != null) {
-            List<String> javaOpts = [finalEnv.get(javaPropertyEnvVariable, '')]
-            javaOpts.add(hadoopGateway.getJvmArgs())
-            for (Map<String, String> propertyMap : [hadoopGateway.getSystemProperties(), systemProperties]) {
-                String collectedSystemProperties = propertyMap
-                        .collect { key, value -> "-D${key}=${value}" }
-                        .join(" ")
-                if (!collectedSystemProperties.isEmpty()) {
-                    javaOpts.add(collectedSystemProperties)
-                }
-            }
-            finalEnv.put('YARN_OPTS', javaOpts.join(" "))
-        }
-
-        finalEnv.putAll(environmentVariables)
+        Map<String, String> finalEnv = collectEnvVars()
 
         // Do command
         project.logger.info("Executing Command: " + commandLine)

--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/util/ObjectUtil.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/util/ObjectUtil.groovy
@@ -19,11 +19,13 @@
 
 package org.elasticsearch.hadoop.gradle.util
 
+import java.util.concurrent.Callable
+
 class ObjectUtil {
     static String unapplyString(Object value) {
         if (value == null) {
             return null
-        } else if (value instanceof Closure) {
+        } else if (value instanceof Callable) {
             return ((Closure) value).call().toString()
         } else {
             return value.toString()

--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/util/ObjectUtil.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/util/ObjectUtil.groovy
@@ -1,0 +1,32 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.hadoop.gradle.util
+
+class ObjectUtil {
+    static String unapplyString(Object value) {
+        if (value == null) {
+            return null
+        } else if (value instanceof Closure) {
+            return ((Closure) value).call().toString()
+        } else {
+            return value.toString()
+        }
+    }
+}

--- a/qa/kerberos/build.gradle
+++ b/qa/kerberos/build.gradle
@@ -84,7 +84,7 @@ dependencies {
 
 // Disable the integration tests for Kerberos until we can find a solution to the failures due to + sign 
 // in the file path on CI.
-boolean disableTests = true
+boolean disableTests = false
 if (disableTests) {
     // Disable the integration tests for Kerberos until we can find a solution to the failures due to + sign 
     // in the file path on CI.
@@ -151,7 +151,7 @@ if (disableTests) {
     // Configure MiniKDC
     AntFixture kdcFixture = project.tasks.create('kdcFixture', AntFixture) {
         dependsOn project.configurations.kdcFixture
-        executable = new File(project.compilerJavaHome, 'bin/java')
+        executable = new File(project.runtimeJavaHome, 'bin/java')
         env 'CLASSPATH', "${ -> project.configurations.kdcFixture.asPath }"
         waitCondition = { fixture, ant ->
             // the kdc wrapper writes the ports file when
@@ -218,7 +218,8 @@ if (disableTests) {
 
         extraConfigFile('es.keytab', esKeytab.toFile())
     }
-    
+    def esAddress = "${-> testClusters.integTest.getAllHttpSocketURI().get(0)}"
+
     // Configure Integration Test Task
     Test integrationTest = project.tasks.findByName('integrationTest') as Test
     integrationTest.dependsOn(kdcFixture)
@@ -242,9 +243,10 @@ if (disableTests) {
         useCluster(testClusters.integTest)
         doLast {
             project.javaexec {
+                executable = project.runtimeJavaHome.toString() + "/bin/java"
                 main = 'org.elasticsearch.hadoop.qa.kerberos.setup.SetupKerberosUsers'
                 classpath = sourceSets.main.runtimeClasspath
-                systemProperty('es.nodes', 'localhost:9500')
+                systemProperty('es.nodes', esAddress)
                 systemProperty('es.net.http.auth.user', 'test_admin')
                 systemProperty('es.net.http.auth.pass', 'x-pack-test-password')
                 systemProperty('principals', "$clientPrincipal$realm")
@@ -265,6 +267,7 @@ if (disableTests) {
     
     // Hadoop cluster depends on KDC Fixture being up and running
     config.addDependency(kdcFixture)
+    config.useElasticsearchCluster(testClusters.integTest)
     
     config.service('hadoop') { ServiceConfiguration s ->
         s.addSystemProperty("java.security.krb5.conf", krb5Conf.toString())
@@ -330,7 +333,7 @@ if (disableTests) {
             r.addEnvironmentVariable('YARN_USER_CLASSPATH', testingJar.archivePath.toString())
             r.settingsFile('yarn-site.xml') { SettingsContainer.FileSettings f ->
                 // Add settings specifically for ES Node to allow for cancelling the tokens
-                f.addSetting('es.nodes', 'localhost:9500')
+                f.addSetting('es.nodes', esAddress)
             }
         }
     }
@@ -344,6 +347,7 @@ if (disableTests) {
         s.addSetting('yarn.app.mapreduce.am.command-opts', "-Djava.security.krb5.conf=${krb5Conf.toString()}")
         s.addSetting('mapreduce.map.java.opts', "-Djava.security.krb5.conf=${krb5Conf.toString()}")
         s.addSetting('mapreduce.reduce.java.opts', "-Djava.security.krb5.conf=${krb5Conf.toString()}")
+        s.addSetting('es.nodes', esAddress)
     }
     config.service('pig') { ServiceConfiguration s ->
         s.addSetting('java.security.krb5.conf', krb5Conf.toString())
@@ -352,6 +356,7 @@ if (disableTests) {
         s.addSetting('yarn.app.mapreduce.am.command-opts', "-Djava.security.krb5.conf=${krb5Conf.toString()}")
         s.addSetting('mapreduce.map.java.opts', "-Djava.security.krb5.conf=${krb5Conf.toString()}")
         s.addSetting('mapreduce.reduce.java.opts', "-Djava.security.krb5.conf=${krb5Conf.toString()}")
+        s.addSetting('es.nodes', esAddress)
     }
     config.addDependency(jar)
     config.addDependency(testingJar)
@@ -417,7 +422,6 @@ if (disableTests) {
                 "test.krb5.keytab": clientKeytab.toString(),
                 "java.security.krb5.conf": krb5Conf.toString()
         ])
-        environmentVariables.put('HADOOP_ROOT_LOGGER','TRACE,console')
         args = ['-copyFromLocal', project.file(new File(mrItestResourceDir, 'artists.dat')), "/data/artists/artists.dat"]
     }
     
@@ -428,20 +432,21 @@ if (disableTests) {
     // Run the MR job to load data to ES. Ensure Kerberos settings are available.
     HadoopMRJob mrLoadData = config.createClusterTask('mrLoadData', HadoopMRJob.class) {
         clusterConfiguration = config
+        useCluster(testClusters.integTest)
         dependsOn(copyData, setupUsers)
         jobJar = jar.archivePath
-        libJars.add(testingJar.archivePath)
+        libJars(testingJar.archivePath)
         jobClass = 'org.elasticsearch.hadoop.qa.kerberos.mr.LoadToES'
-        jobSettings = [
+        jobSettings([
                 'es.resource': 'qa_kerberos_mr_data',
-                'es.nodes': 'localhost:9500',
+                'es.nodes': esAddress,
                 'es.security.authentication': 'kerberos',
                 'es.net.spnego.auth.elasticsearch.principal': "${esPrincipal}${realm}",
                 'load.field.names': 'number,name,url,picture,@timestamp,tag',
                 'mapreduce.map.java.opts': "-Djava.security.krb5.conf=${krb5Conf.toString()}",
                 'mapreduce.reduce.java.opts': "-Djava.security.krb5.conf=${krb5Conf.toString()}",
                 'yarn.app.mapreduce.am.command-opts': "-Djava.security.krb5.conf=${krb5Conf.toString()}"
-        ]
+        ])
         systemProperties([
                 "test.krb5.principal": clientPrincipal,
                 "test.krb5.keytab": clientKeytab.toString(),
@@ -454,19 +459,20 @@ if (disableTests) {
     // Run the MR job to read data out of ES. Ensure Kerberos settings are available.
     HadoopMRJob mrReadData = config.createClusterTask('mrReadData', HadoopMRJob.class) {
         clusterConfiguration = config
+        useCluster(testClusters.integTest)
         dependsOn(mrLoadData)
         jobJar = jar.archivePath
-        libJars.add(testingJar.archivePath)
+        libJars(testingJar.archivePath)
         jobClass = 'org.elasticsearch.hadoop.qa.kerberos.mr.ReadFromES'
-        jobSettings = [
+        jobSettings([
                 'es.resource': 'qa_kerberos_mr_data',
-                'es.nodes': 'localhost:9500',
+                'es.nodes': esAddress,
                 'es.security.authentication': 'kerberos',
                 'es.net.spnego.auth.elasticsearch.principal': "${esPrincipal}${realm}",
                 'mapreduce.map.java.opts': "-Djava.security.krb5.conf=${krb5Conf.toString()}",
                 'mapreduce.reduce.java.opts': "-Djava.security.krb5.conf=${krb5Conf.toString()}",
                 'yarn.app.mapreduce.am.command-opts': "-Djava.security.krb5.conf=${krb5Conf.toString()}"
-        ]
+        ])
         systemProperties([
                 "test.krb5.principal": clientPrincipal,
                 "test.krb5.keytab": clientKeytab.toString(),
@@ -483,16 +489,17 @@ if (disableTests) {
     // Run the Spark job to load data to ES. Ensure Kerberos settings are available.
     SparkApp sparkLoadData = config.createClusterTask('sparkLoadData', SparkApp.class) {
         clusterConfiguration = config
+        useCluster(testClusters.integTest)
         dependsOn(copyData)
     //    deployModeCluster()
     //    principal = clientPrincipal + realm
     //    keytab = clientKeytab.toString()
         jobJar = jar.archivePath
-        libJars.add(testingJar.archivePath)
+        libJars(testingJar.archivePath)
         jobClass = 'org.elasticsearch.hadoop.qa.kerberos.spark.LoadToES'
         jobSettings([
                 'spark.es.resource': 'qa_kerberos_spark_data',
-                'spark.es.nodes': 'localhost:9500',
+                'spark.es.nodes': esAddress,
                 'spark.es.security.authentication': 'kerberos',
                 'spark.es.net.spnego.auth.elasticsearch.principal': "${esPrincipal}${realm}",
                 'spark.load.field.names': 'number,name,url,picture,@timestamp,tag',
@@ -500,7 +507,7 @@ if (disableTests) {
                 'spark.driver.extraJavaOptions': "-Djava.security.krb5.conf=${krb5Conf.toString()}",
                 'spark.executor.extraJavaOptions': "-Djava.security.krb5.conf=${krb5Conf.toString()}"
         ])
-        env.put('SPARK_SUBMIT_OPTS', "-Djava.security.krb5.conf=${krb5Conf.toString()} " +
+        environmentVariables.put('SPARK_SUBMIT_OPTS', "-Djava.security.krb5.conf=${krb5Conf.toString()} " +
                 "-Dtest.krb5.principal=$clientPrincipal$realm " +
                 "-Dtest.krb5.keytab=${clientKeytab.toString()}")
         args = ['/data/artists/artists.dat']
@@ -510,23 +517,24 @@ if (disableTests) {
     // Run the Spark job to load data to ES. Ensure Kerberos settings are available.
     SparkApp sparkReadData = config.createClusterTask('sparkReadData', SparkApp.class) {
         clusterConfiguration = config
+        useCluster(testClusters.integTest)
         dependsOn(sparkLoadData)
     //    deployModeCluster()
     //    principal = clientPrincipal + realm
     //    keytab = clientKeytab.toString()
         jobJar = jar.archivePath
-        libJars.add(testingJar.archivePath)
+        libJars(testingJar.archivePath)
         jobClass = 'org.elasticsearch.hadoop.qa.kerberos.spark.ReadFromES'
         jobSettings([
                 'spark.es.resource': 'qa_kerberos_spark_data',
-                'spark.es.nodes': 'localhost:9500',
+                'spark.es.nodes': esAddress,
                 'spark.es.security.authentication': 'kerberos',
                 'spark.es.net.spnego.auth.elasticsearch.principal': "${esPrincipal}${realm}",
                 'spark.yarn.am.extraJavaOptions': "-Djava.security.krb5.conf=${krb5Conf.toString()}",
                 'spark.driver.extraJavaOptions': "-Djava.security.krb5.conf=${krb5Conf.toString()}",
                 'spark.executor.extraJavaOptions': "-Djava.security.krb5.conf=${krb5Conf.toString()}"
         ])
-        env.put('SPARK_SUBMIT_OPTS', "-Djava.security.krb5.conf=${krb5Conf.toString()} " +
+        environmentVariables.put('SPARK_SUBMIT_OPTS', "-Djava.security.krb5.conf=${krb5Conf.toString()} " +
                 "-Dtest.krb5.principal=$clientPrincipal$realm " +
                 "-Dtest.krb5.keytab=${clientKeytab.toString()}")
         args = ['/data/output/spark']
@@ -553,11 +561,12 @@ if (disableTests) {
     
     HiveBeeline hiveLoadData = config.createClusterTask('hiveLoadData', HiveBeeline.class) {
         clusterConfiguration = config
+        useCluster(testClusters.integTest)
         dependsOn(jar, setupUsers, copyData, patchBeeline)
         hivePrincipal = hivePrincipalName + realm
         script = new File(resourceDir, 'hive/load_to_es.sql')
-        libJars.add(testingJar.archivePath)
-        env.putAll([
+        libJars(testingJar.archivePath)
+        environmentVariables.putAll([
                 'HADOOP_CLIENT_OPTS':
                         "-Djava.security.krb5.conf=${krb5Conf.toString()} " +
                         "-Dtest.krb5.principal=$clientPrincipal$realm " +
@@ -569,11 +578,12 @@ if (disableTests) {
     
     HiveBeeline hiveReadData = config.createClusterTask('hiveReadData', HiveBeeline.class) {
         clusterConfiguration = config
+        useCluster(testClusters.integTest)
         dependsOn(hiveLoadData)
         hivePrincipal = hivePrincipalName + realm
         script = new File(resourceDir, 'hive/read_from_es.sql')
-        libJars.add(testingJar.archivePath)
-        env.putAll([
+        libJars(testingJar.archivePath)
+        environmentVariables.putAll([
                 'HADOOP_CLIENT_OPTS':
                         "-Djava.security.krb5.conf=${krb5Conf.toString()} " +
                                 "-Dtest.krb5.principal=$clientPrincipal$realm " +
@@ -589,23 +599,25 @@ if (disableTests) {
     
     PigScript pigLoadData = config.createClusterTask('pigLoadData', PigScript.class) {
         clusterConfiguration = config
+        useCluster(testClusters.integTest)
         dependsOn(jar, setupUsers, copyData)
         script = new File(resourceDir, 'pig/load_to_es.pig')
-        libJars.add(testingJar.archivePath)
-        env = [
+        libJars(testingJar.archivePath)
+        environmentVariables.putAll([
                 'PIG_OPTS': "-Djava.security.krb5.conf=${krb5Conf.toString()}"
-        ]
+        ])
     }
     integrationTest.dependsOn(pigLoadData)
     
     PigScript pigReadData = config.createClusterTask('pigReadData', PigScript.class) {
         clusterConfiguration = config
+        useCluster(testClusters.integTest)
         dependsOn(pigLoadData)
         script = new File(resourceDir, 'pig/read_from_es.pig')
-        libJars.add(testingJar.archivePath)
-        env = [
+        libJars(testingJar.archivePath)
+        environmentVariables.putAll([
                 'PIG_OPTS': "-Djava.security.krb5.conf=${krb5Conf.toString()}"
-        ]
+        ])
     }
     integrationTest.dependsOn(pigReadData)
     
@@ -644,7 +656,6 @@ if (disableTests) {
                     "test.krb5.keytab": clientKeytab.toString(),
                     "java.security.krb5.conf": krb5Conf.toString()
             ])
-            environmentVariables.put('HADOOP_ROOT_LOGGER','TRACE,console')
             args = ['-copyToLocal', "/data/output/$integrationName", outputDataDir]
         }
         // Integration test needs to depend on copy output tasks

--- a/qa/kerberos/build.gradle
+++ b/qa/kerberos/build.gradle
@@ -84,7 +84,7 @@ dependencies {
 
 // Disable the integration tests for Kerberos until we can find a solution to the failures due to + sign 
 // in the file path on CI.
-boolean disableTests = false
+boolean disableTests = true
 if (disableTests) {
     // Disable the integration tests for Kerberos until we can find a solution to the failures due to + sign 
     // in the file path on CI.

--- a/qa/kerberos/src/main/java/org/elasticsearch/hadoop/qa/kerberos/setup/SetupKerberosUsers.java
+++ b/qa/kerberos/src/main/java/org/elasticsearch/hadoop/qa/kerberos/setup/SetupKerberosUsers.java
@@ -19,8 +19,6 @@
 
 package org.elasticsearch.hadoop.qa.kerberos.setup;
 
-import java.util.Properties;
-
 import org.apache.commons.logging.LogFactory;
 import org.elasticsearch.hadoop.cfg.PropertiesSettings;
 import org.elasticsearch.hadoop.cfg.Settings;

--- a/qa/kerberos/src/main/java/org/elasticsearch/hadoop/qa/kerberos/storm/StreamFromEs.java
+++ b/qa/kerberos/src/main/java/org/elasticsearch/hadoop/qa/kerberos/storm/StreamFromEs.java
@@ -37,12 +37,13 @@ public class StreamFromEs {
     public static void main(String[] args) throws Exception {
         final String submitPrincipal = args[0];
         final String submitKeytab = args[1];
+        final String esNodes = args[2];
         LoginContext loginContext = LoginUtil.keytabLogin(submitPrincipal, submitKeytab);
         try {
             Subject.doAs(loginContext.getSubject(), new PrivilegedExceptionAction<Void>() {
                 @Override
                 public Void run() throws Exception {
-                    submitJob(submitPrincipal, submitKeytab);
+                    submitJob(submitPrincipal, submitKeytab, esNodes);
                     return null;
                 }
             });
@@ -51,7 +52,7 @@ public class StreamFromEs {
         }
     }
 
-    public static void submitJob(String principal, String keytab) throws Exception {
+    public static void submitJob(String principal, String keytab, String esNodes) throws Exception {
         TopologyBuilder builder = new TopologyBuilder();
         builder.setSpout("ES", new EsSpout("storm-test"));
         builder.setBolt("Output", new CapturingBolt()).shuffleGrouping("ES");
@@ -62,7 +63,7 @@ public class StreamFromEs {
         List<Object> plugins = new ArrayList<Object>();
         plugins.add(AutoElasticsearch.class.getName());
         conf.put(Config.TOPOLOGY_AUTO_CREDENTIALS, plugins);
-        conf.put(ConfigurationOptions.ES_PORT, "9500");
+        conf.put(ConfigurationOptions.ES_NODES, esNodes);
         conf.put(ConfigurationOptions.ES_SECURITY_AUTHENTICATION, "kerberos");
         conf.put(ConfigurationOptions.ES_NET_SPNEGO_AUTH_ELASTICSEARCH_PRINCIPAL, "HTTP/build.elastic.co@BUILD.ELASTIC.CO");
         conf.put(ConfigurationOptions.ES_INPUT_JSON, "true");

--- a/qa/kerberos/src/main/java/org/elasticsearch/hadoop/qa/kerberos/storm/StreamToEs.java
+++ b/qa/kerberos/src/main/java/org/elasticsearch/hadoop/qa/kerberos/storm/StreamToEs.java
@@ -41,12 +41,13 @@ public class StreamToEs {
     public static void main(String[] args) throws Exception {
         final String submitPrincipal = args[0];
         final String submitKeytab = args[1];
+        final String esNodes = args[2];
         LoginContext loginContext = LoginUtil.keytabLogin(submitPrincipal, submitKeytab);
         try {
             Subject.doAs(loginContext.getSubject(), new PrivilegedExceptionAction<Void>() {
                 @Override
                 public Void run() throws Exception {
-                    submitJob(submitPrincipal, submitKeytab);
+                    submitJob(submitPrincipal, submitKeytab, esNodes);
                     return null;
                 }
             });
@@ -55,7 +56,7 @@ public class StreamToEs {
         }
     }
 
-    public static void submitJob(String principal, String keytab) throws Exception {
+    public static void submitJob(String principal, String keytab, String esNodes) throws Exception {
         List doc1 = Collections.singletonList("{\"reason\" : \"business\",\"airport\" : \"SFO\"}");
         List doc2 = Collections.singletonList("{\"participants\" : 5,\"airport\" : \"OTP\"}");
 
@@ -71,7 +72,7 @@ public class StreamToEs {
         List<Object> plugins = new ArrayList<Object>();
         plugins.add(AutoElasticsearch.class.getName());
         conf.put(Config.TOPOLOGY_AUTO_CREDENTIALS, plugins);
-        conf.put(ConfigurationOptions.ES_PORT, "9500");
+        conf.put(ConfigurationOptions.ES_NODES, esNodes);
         conf.put(ConfigurationOptions.ES_SECURITY_AUTHENTICATION, "kerberos");
         conf.put(ConfigurationOptions.ES_NET_SPNEGO_AUTH_ELASTICSEARCH_PRINCIPAL, "HTTP/build.elastic.co@BUILD.ELASTIC.CO");
         conf.put(ConfigurationOptions.ES_INPUT_JSON, "true");

--- a/qa/kerberos/src/main/resources/hive/load_to_es.sql
+++ b/qa/kerberos/src/main/resources/hive/load_to_es.sql
@@ -26,7 +26,6 @@ CREATE EXTERNAL TABLE IF NOT EXISTS es_artist_data (
 STORED BY 'org.elasticsearch.hadoop.hive.EsStorageHandler'
 TBLPROPERTIES(
   'es.resource' = 'qa_kerberos_hive_data',
-  'es.nodes' = 'localhost:9500',
   'es.security.authentication' = 'kerberos',
   'es.net.spnego.auth.elasticsearch.principal' = 'HTTP/build.elastic.co@BUILD.ELASTIC.CO'
 );

--- a/qa/kerberos/src/main/resources/hive/read_from_es.sql
+++ b/qa/kerberos/src/main/resources/hive/read_from_es.sql
@@ -8,7 +8,7 @@ CREATE EXTERNAL TABLE IF NOT EXISTS es_artist_data (
   ts TIMESTAMP,
   tag STRING)
 STORED BY 'org.elasticsearch.hadoop.hive.EsStorageHandler'
-TBLPROPERTIES('es.resource' = 'qa_kerberos_hive_data', 'es.nodes' = 'localhost:9500');
+TBLPROPERTIES('es.resource' = 'qa_kerberos_hive_data');
 
 DROP TABLE IF EXISTS artist_data;
 

--- a/qa/kerberos/src/main/resources/pig/load_to_es.pig
+++ b/qa/kerberos/src/main/resources/pig/load_to_es.pig
@@ -1,7 +1,6 @@
 A = LOAD '/data/artists' USING PigStorage('\t') AS (number: chararray, name: chararray, uri: chararray, picture: chararray, timestamp: chararray, tag: chararray);
 
 STORE A INTO 'qa_kerberos_pig_data' USING org.elasticsearch.hadoop.pig.EsStorage(
-    'es.nodes = localhost:9500',
     'es.security.authentication = kerberos',
     'es.net.spnego.auth.elasticsearch.principal = HTTP/build.elastic.co@BUILD.ELASTIC.CO'
 );

--- a/qa/kerberos/src/main/resources/pig/read_from_es.pig
+++ b/qa/kerberos/src/main/resources/pig/read_from_es.pig
@@ -1,5 +1,4 @@
 A = LOAD 'qa_kerberos_pig_data' USING org.elasticsearch.hadoop.pig.EsStorage(
-    'es.nodes = localhost:9500',
     'es.security.authentication = kerberos',
     'es.net.spnego.auth.elasticsearch.principal = HTTP/build.elastic.co@BUILD.ELASTIC.CO'
 );

--- a/test/fixtures/minikdc/build.gradle
+++ b/test/fixtures/minikdc/build.gradle
@@ -31,6 +31,10 @@ dependencies {
     }
 }
 
+// Target Java 1.8 compilation
+sourceCompatibility = '1.8'
+targetCompatibility = '1.8'
+
 // for testing, until fixture are actually debuggable.
 // gradle hides EVERYTHING so you have no clue what went wrong.
 task kdc(type: JavaExec) {


### PR DESCRIPTION
This PR includes changes necessary to run the Kerberos QA tests using the new test clusters functionality in build-tools. 

This also updates the project to run fixtures on the Java 8 runtime. JAVA_HOME can now be set on cluster configs and is used by fixtures.

A cluster can be configured with a dependent ElasticsearchCluster. This cluster is depended on for any configuration tasks in case its cluster address is used.

Settings are now stored as objects in cluster configurations instead of Strings since they may be GStrings with closures inside of them that must be resolved ONLY at configuration writing time. This is needed to resolve test cluster http addresses which are only discoverable once the cluster is started.

In order to make this resolution process simpler, removed most of the Map<String, String> types in the code and replaced them with the FileSettings type which can resolve closures as needed when writing the configuration to a file.

Upgraded Spark QA runtime to 2.3.4 as the older version has been removed from apache's mirrors.

AbstractClusterTask now extends DefaultTestClustersTask, as it is the only way to ensure that Elasticsearch is still running when starting the task.

In order to configure JAVA_HOME consistently, each AbstractClusterTask now has its environment variables resolved in its super class instead of with duplicated code in each task.