### PR TITLE
Remove root project testing jar

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/BuildPlugin.groovy
@@ -583,15 +583,15 @@ class BuildPlugin implements Plugin<Project>  {
      */
     private static void configureIntegrationTestTask(Project project) {
         if (project != project.rootProject) {
-            Jar itestJar = project.tasks.create('itestJar', Jar)
-            itestJar.dependsOn(project.tasks.getByName('jar'))
-            itestJar.getArchiveClassifier().set('testing')
-            project.logger.info("Created [${project.name}] Testing Jar")
+            TaskProvider<Task> itestJar = project.tasks.register('itestJar', Jar) { Jar itestJar ->
+                itestJar.dependsOn(project.tasks.getByName('jar'))
+                itestJar.getArchiveClassifier().set('testing')
 
-            // Add this project's classes to the testing uber-jar
-            itestJar.from(project.sourceSets.main.output)
-            itestJar.from(project.sourceSets.test.output)
-            itestJar.from(project.sourceSets.itest.output)
+                // Add this project's classes to the testing uber-jar
+                itestJar.from(project.sourceSets.main.output)
+                itestJar.from(project.sourceSets.test.output)
+                itestJar.from(project.sourceSets.itest.output)
+            }
 
             Test integrationTest = project.tasks.create('integrationTest', RestTestRunnerTask.class)
             integrationTest.dependsOn(itestJar)

--- a/hive/build.gradle
+++ b/hive/build.gradle
@@ -21,6 +21,14 @@ jar {
     }
 }
 
+itestJar {
+    from(zipTree(project(":elasticsearch-hadoop-mr").jar.archivePath)) {
+        include "org/elasticsearch/hadoop/**"
+        include "esh-build.properties"
+        include "META-INF/services/*"
+    }
+}
+
 javadoc {
     source += project(":elasticsearch-hadoop-mr").sourceSets.main.allJava
     classpath += files(project(":elasticsearch-hadoop-mr").sourceSets.main.compileClasspath)

--- a/mr/build.gradle
+++ b/mr/build.gradle
@@ -20,6 +20,11 @@ dependencies {
     testImplementation(project.ext.hadoopClient)
     testImplementation("io.netty:netty-all:4.0.29.Final")
     testImplementation("org.elasticsearch:securemock:1.2")
+    itestImplementation("org.apache.hadoop:hadoop-minikdc:${project.ext.minikdcVersion}") {
+        // For some reason, the dependencies that are pulled in with MiniKDC have multiple resource files
+        // that cause issues when they are loaded. We exclude the ldap schema data jar to get around this.
+        exclude group: "org.apache.directory.api", module: "api-ldap-schema-data"
+    }
 }
 
 String generatedResources = "$buildDir/generated-resources/main"

--- a/mr/src/itest/java/org/elasticsearch/hadoop/Provisioner.java
+++ b/mr/src/itest/java/org/elasticsearch/hadoop/Provisioner.java
@@ -42,7 +42,7 @@ public abstract class Provisioner {
         // init ES-Hadoop JAR
         // expect the jar under build\libs
         try {
-            File folder = new File(".." + File.separator + "build" + File.separator + "libs" + File.separator).getCanonicalFile();
+            File folder = new File("build" + File.separator + "libs" + File.separator).getCanonicalFile();
             // find proper jar
             File[] files = folder.listFiles(new FileFilter() {
 

--- a/pig/build.gradle
+++ b/pig/build.gradle
@@ -21,6 +21,14 @@ jar {
     }
 }
 
+itestJar {
+    from(zipTree(project(":elasticsearch-hadoop-mr").jar.archivePath)) {
+        include "org/elasticsearch/hadoop/**"
+        include "esh-build.properties"
+        include "META-INF/services/*"
+    }
+}
+
 javadoc {
     source += project(":elasticsearch-hadoop-mr").sourceSets.main.allJava
     classpath += files(project(":elasticsearch-hadoop-mr").sourceSets.main.compileClasspath)

--- a/qa/kerberos/build.gradle
+++ b/qa/kerberos/build.gradle
@@ -98,8 +98,8 @@ if (disableTests) {
     
     // Build uber storm jar for testing Storm remotely (es-hadoop + es-storm + qa tests)
     Jar qaKerberosStormJar = project.tasks.create('kerberosStormJar', Jar)
-    qaKerberosStormJar.dependsOn(project.rootProject.tasks.getByName('jar'))
-    qaKerberosStormJar.dependsOn(project.rootProject.tasks.getByName('hadoopTestingJar'))
+    qaKerberosStormJar.dependsOn(project(':elasticsearch-storm').tasks.getByName('jar'))
+    qaKerberosStormJar.dependsOn(project(':elasticsearch-storm').tasks.getByName('itestJar'))
     qaKerberosStormJar.classifier = 'storm-testing'
     
     // Add projects to the storm testing uber-jar
@@ -233,8 +233,14 @@ if (disableTests) {
     
     // Fixtures will be depending on the jar and test jar artifacts
     def jar = project.tasks.getByName('jar') as org.gradle.jvm.tasks.Jar
-    def testingJar = project.rootProject.tasks.findByName('hadoopTestingJar') as Jar
-    
+    def kerberosItestJar = project.tasks.findByName('itestJar') as Jar
+    def mrJar = project(':elasticsearch-hadoop-mr').tasks.getByName('jar') as Jar
+    def mrItestJar = project(':elasticsearch-hadoop-mr').tasks.getByName('itestJar') as Jar
+    def hiveItestJar = project(':elasticsearch-hadoop-hive').tasks.getByName('itestJar') as Jar
+    def pigItestJar = project(':elasticsearch-hadoop-pig').tasks.getByName('itestJar') as Jar
+    def sparkItestJar = project(':elasticsearch-spark-20').tasks.getByName('itestJar') as Jar
+    def stormItestJar = project(':elasticsearch-storm').tasks.getByName('itestJar') as Jar
+
     // Need these for SSL items, test data, and scripts
     File resourceDir = project.sourceSets.main.resources.getSrcDirs().head()
     File mrItestResourceDir = project(":elasticsearch-hadoop-mr").sourceSets.itest.resources.getSrcDirs().head()
@@ -330,7 +336,7 @@ if (disableTests) {
         // Add the ES-Hadoop jar to the resource manager classpath so that it can load the token renewer implementation
         // for ES tokens. Otherwise, tokens may not be cancelled at the end of the job.
         s.role('resourcemanager') { RoleConfiguration r ->
-            r.addEnvironmentVariable('YARN_USER_CLASSPATH', testingJar.archivePath.toString())
+            r.addEnvironmentVariable('YARN_USER_CLASSPATH', mrJar.archivePath.toString())
             r.settingsFile('yarn-site.xml') { SettingsContainer.FileSettings f ->
                 // Add settings specifically for ES Node to allow for cancelling the tokens
                 f.addSetting('es.nodes', esAddress)
@@ -359,7 +365,13 @@ if (disableTests) {
         s.addSetting('es.nodes', esAddress)
     }
     config.addDependency(jar)
-    config.addDependency(testingJar)
+    config.addDependency(kerberosItestJar)
+    config.addDependency(mrJar)
+    config.addDependency(mrItestJar)
+    config.addDependency(hiveItestJar)
+    config.addDependency(pigItestJar)
+    config.addDependency(sparkItestJar)
+    config.addDependency(stormItestJar)
 
     // We need to create a tmp directory in hadoop before history server does, because history server will set permissions
     // wrong.
@@ -435,7 +447,7 @@ if (disableTests) {
         useCluster(testClusters.integTest)
         dependsOn(copyData, setupUsers)
         jobJar = jar.archivePath
-        libJars(testingJar.archivePath)
+        libJars(kerberosItestJar.archivePath, mrItestJar.archivePath)
         jobClass = 'org.elasticsearch.hadoop.qa.kerberos.mr.LoadToES'
         jobSettings([
                 'es.resource': 'qa_kerberos_mr_data',
@@ -462,7 +474,7 @@ if (disableTests) {
         useCluster(testClusters.integTest)
         dependsOn(mrLoadData)
         jobJar = jar.archivePath
-        libJars(testingJar.archivePath)
+        libJars(kerberosItestJar.archivePath, mrItestJar.archivePath)
         jobClass = 'org.elasticsearch.hadoop.qa.kerberos.mr.ReadFromES'
         jobSettings([
                 'es.resource': 'qa_kerberos_mr_data',
@@ -495,7 +507,7 @@ if (disableTests) {
     //    principal = clientPrincipal + realm
     //    keytab = clientKeytab.toString()
         jobJar = jar.archivePath
-        libJars(testingJar.archivePath)
+        libJars(kerberosItestJar.archivePath, sparkItestJar.archivePath)
         jobClass = 'org.elasticsearch.hadoop.qa.kerberos.spark.LoadToES'
         jobSettings([
                 'spark.es.resource': 'qa_kerberos_spark_data',
@@ -523,7 +535,7 @@ if (disableTests) {
     //    principal = clientPrincipal + realm
     //    keytab = clientKeytab.toString()
         jobJar = jar.archivePath
-        libJars(testingJar.archivePath)
+        libJars(kerberosItestJar.archivePath, sparkItestJar.archivePath)
         jobClass = 'org.elasticsearch.hadoop.qa.kerberos.spark.ReadFromES'
         jobSettings([
                 'spark.es.resource': 'qa_kerberos_spark_data',
@@ -565,7 +577,7 @@ if (disableTests) {
         dependsOn(jar, setupUsers, copyData, patchBeeline)
         hivePrincipal = hivePrincipalName + realm
         script = new File(resourceDir, 'hive/load_to_es.sql')
-        libJars(testingJar.archivePath)
+        libJars(kerberosItestJar.archivePath, hiveItestJar.archivePath)
         environmentVariables.putAll([
                 'HADOOP_CLIENT_OPTS':
                         "-Djava.security.krb5.conf=${krb5Conf.toString()} " +
@@ -582,7 +594,7 @@ if (disableTests) {
         dependsOn(hiveLoadData)
         hivePrincipal = hivePrincipalName + realm
         script = new File(resourceDir, 'hive/read_from_es.sql')
-        libJars(testingJar.archivePath)
+        libJars(kerberosItestJar.archivePath, hiveItestJar.archivePath)
         environmentVariables.putAll([
                 'HADOOP_CLIENT_OPTS':
                         "-Djava.security.krb5.conf=${krb5Conf.toString()} " +
@@ -602,7 +614,7 @@ if (disableTests) {
         useCluster(testClusters.integTest)
         dependsOn(jar, setupUsers, copyData)
         script = new File(resourceDir, 'pig/load_to_es.pig')
-        libJars(testingJar.archivePath)
+        libJars(kerberosItestJar.archivePath, pigItestJar.archivePath)
         environmentVariables.putAll([
                 'PIG_OPTS': "-Djava.security.krb5.conf=${krb5Conf.toString()}"
         ])
@@ -614,7 +626,7 @@ if (disableTests) {
         useCluster(testClusters.integTest)
         dependsOn(pigLoadData)
         script = new File(resourceDir, 'pig/read_from_es.pig')
-        libJars(testingJar.archivePath)
+        libJars(kerberosItestJar.archivePath, pigItestJar.archivePath)
         environmentVariables.putAll([
                 'PIG_OPTS': "-Djava.security.krb5.conf=${krb5Conf.toString()}"
         ])

--- a/spark/core/itest/java/org/elasticsearch/spark/integration/SparkUtils.java
+++ b/spark/core/itest/java/org/elasticsearch/spark/integration/SparkUtils.java
@@ -38,7 +38,7 @@ public abstract class SparkUtils {
         // init ES-Hadoop JAR
         // expect the jar under build\libs
         try {
-            File folder = new File(".." + File.separator + ".." + File.separator + "build" + File.separator + "libs" + File.separator).getCanonicalFile();
+            File folder = new File("build" + File.separator + "libs" + File.separator).getCanonicalFile();
             System.out.println(folder.getAbsolutePath());
             // find proper jar
             File[] files = folder.listFiles(new FileFilter() {

--- a/spark/sql-13/build.gradle
+++ b/spark/sql-13/build.gradle
@@ -145,6 +145,14 @@ jar {
     }
 }
 
+itestJar {
+    from(zipTree(project(":elasticsearch-hadoop-mr").jar.archivePath)) {
+        include "org/elasticsearch/hadoop/**"
+        include "esh-build.properties"
+        include "META-INF/services/*"
+    }
+}
+
 javadoc {
     dependsOn compileScala
     source += project(":elasticsearch-hadoop-mr").sourceSets.main.allJava

--- a/spark/sql-20/build.gradle
+++ b/spark/sql-20/build.gradle
@@ -159,6 +159,14 @@ jar {
     }
 }
 
+itestJar {
+    from(zipTree(project(":elasticsearch-hadoop-mr").jar.archivePath)) {
+        include "org/elasticsearch/hadoop/**"
+        include "esh-build.properties"
+        include "META-INF/services/*"
+    }
+}
+
 javadoc {
     dependsOn compileScala
     source += project(":elasticsearch-hadoop-mr").sourceSets.main.allJava

--- a/storm/build.gradle
+++ b/storm/build.gradle
@@ -20,6 +20,14 @@ jar {
     }
 }
 
+itestJar {
+    from(zipTree(project(":elasticsearch-hadoop-mr").jar.archivePath)) {
+        include "org/elasticsearch/hadoop/**"
+        include "esh-build.properties"
+        include "META-INF/services/*"
+    }
+}
+
 javadoc {
     source += project(":elasticsearch-hadoop-mr").sourceSets.main.allJava
     classpath += files(project(":elasticsearch-hadoop-mr").sourceSets.main.compileClasspath)


### PR DESCRIPTION
ES-Hadoop currently relies on its integration test code to be jar'd up before the tests are executed since many of the integrations rely on a jar being provided in order to run test code. We have a decent amount of shared code in the integration test projects, so we package it all up into one big jar on the root project, which makes configuring tests very confusing.

This PR removes that root testing jar and instead builds an itest jar in each project that needs it. We still have an issue with the shared code between integration tests, but there will be a follow up PR to address that.