### PR TITLE
Fix BlockAwareJsonParser level accounting

### DIFF
--- a/mr/src/main/java/org/elasticsearch/hadoop/serialization/json/BlockAwareJsonParser.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/serialization/json/BlockAwareJsonParser.java
@@ -105,6 +105,7 @@ public class BlockAwareJsonParser implements Parser {
     @Override
     public void skipChildren() {
         delegate.skipChildren();
+        updateLevelBasedOn(delegate.currentToken());
     }
 
     @Override


### PR DESCRIPTION
The BlockAwareJsonParser is used to set a checkpoint on a JSON stream
and exit the current blocks that the cursor is in back to the same
level of the content that it was created at. If skipChildren is called
to skip over an open array or object, the internal level counter will
not be updated to account for the array or object that was skipped over.

This PR updates the skipChildren method to check the currentToken and
conditionally decrement the internal nested level counter if we ended
up at an end of an array or object.