### PR TITLE
Fix usage of the GlobalBuildInfoPlugin

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/BaseBuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/BaseBuildPlugin.groovy
@@ -20,7 +20,6 @@
 package org.elasticsearch.hadoop.gradle
 
 import org.elasticsearch.gradle.info.BuildParams
-import org.elasticsearch.gradle.info.GenerateGlobalBuildInfoTask
 import org.elasticsearch.gradle.info.GlobalBuildInfoPlugin
 import org.elasticsearch.gradle.info.JavaHome
 import org.elasticsearch.hadoop.gradle.util.Resources
@@ -64,6 +63,7 @@ class BaseBuildPlugin implements Plugin<Project> {
         if (!project.rootProject.ext.has('buildInfoConfigured')) {
 
             JavaVersion minimumRuntimeVersion = JavaVersion.toVersion(Resources.getResourceContents("/minimumRuntimeVersion"))
+            println "Min runtime: ${minimumRuntimeVersion}"
 
             // We snap the runtime to java 8 since Hadoop needs to see some significant
             // upgrades to support any runtime higher than that
@@ -77,12 +77,14 @@ class BaseBuildPlugin implements Plugin<Project> {
             }
 
             // Set on global build info
-            GenerateGlobalBuildInfoTask generateTask = project.getTasks().getByName("generateGlobalBuildInfo") as GenerateGlobalBuildInfoTask
-            generateTask.setMinimumRuntimeVersion(minimumRuntimeVersion)
-            generateTask.setRuntimeJavaHome(esHadoopRuntimeJava.javaHome.getAbsoluteFile())
+            BuildParams.init { params ->
+                params.setMinimumRuntimeVersion(minimumRuntimeVersion)
+                params.setRuntimeJavaVersion(minimumRuntimeVersion)
+                params.setRuntimeJavaHome(esHadoopRuntimeJava.javaHome.get())
+            }
 
             // Set on build settings
-            project.rootProject.ext.runtimeJavaHome = esHadoopRuntimeJava.javaHome.getAbsoluteFile()
+            project.rootProject.ext.runtimeJavaHome = esHadoopRuntimeJava.javaHome.get()
             project.rootProject.ext.minimumRuntimeVersion = minimumRuntimeVersion
 
             project.rootProject.ext.buildInfoConfigured = true


### PR DESCRIPTION
This PR updates the project build plugin to use BuildParams instead of the now removed GenerateGlobalBuildInfoTask.