### PR TITLE
Update Spark tests that use wildcard query

### DIFF
--- a/spark/sql-13/src/itest/scala/org/elasticsearch/spark/integration/AbstractScalaEsSparkSQL.scala
+++ b/spark/sql-13/src/itest/scala/org/elasticsearch/spark/integration/AbstractScalaEsSparkSQL.scala
@@ -998,11 +998,6 @@ class AbstractScalaEsScalaSparkSQL(prefix: String, readMetadata: jl.Boolean, pus
     val df = esDataSource("pd_starts_with")
     var filter = df.filter(df("airport").startsWith("O"))
 
-    if (strictPushDown) {
-      assertEquals(0, filter.count())
-      return
-    }
-
     if (!keepHandledFilters) {
       // term query pick field with multi values
       assertEquals(2, filter.count())
@@ -1018,11 +1013,6 @@ class AbstractScalaEsScalaSparkSQL(prefix: String, readMetadata: jl.Boolean, pus
   def testDataSourcePushDown10EndsWith() {
     val df = esDataSource("pd_ends_with")
     var filter = df.filter(df("airport").endsWith("O"))
-
-    if (strictPushDown) {
-      assertEquals(0, filter.count())
-      return
-    }
 
     if (!keepHandledFilters) {
       // term query pick field with multi values
@@ -1047,11 +1037,6 @@ class AbstractScalaEsScalaSparkSQL(prefix: String, readMetadata: jl.Boolean, pus
   def testDataSourcePushDown12And() {
     val df = esDataSource("pd_and")
     var filter = df.filter(df("reason").isNotNull.and(df("airport").endsWith("O")))
-
-    if (strictPushDown) {
-      assertEquals(0, filter.count())
-      return
-    }
 
     assertEquals(1, filter.count())
     assertEquals("jan", filter.select("tag").take(1)(0)(0))

--- a/spark/sql-20/src/itest/scala/org/elasticsearch/spark/integration/AbstractScalaEsSparkSQL.scala
+++ b/spark/sql-20/src/itest/scala/org/elasticsearch/spark/integration/AbstractScalaEsSparkSQL.scala
@@ -1055,11 +1055,6 @@ class AbstractScalaEsScalaSparkSQL(prefix: String, readMetadata: jl.Boolean, pus
     val df = esDataSource("pd_starts_with")
     var filter = df.filter(df("airport").startsWith("O"))
 
-    if (strictPushDown) {
-      assertEquals(0, filter.count())
-      return
-    }
-
     if (!keepHandledFilters) {
       // term query pick field with multi values
       assertEquals(2, filter.count())
@@ -1075,11 +1070,6 @@ class AbstractScalaEsScalaSparkSQL(prefix: String, readMetadata: jl.Boolean, pus
   def testDataSourcePushDown10EndsWith() {
     val df = esDataSource("pd_ends_with")
     var filter = df.filter(df("airport").endsWith("O"))
-
-    if (strictPushDown) {
-      assertEquals(0, filter.count())
-      return
-    }
 
     if (!keepHandledFilters) {
       // term query pick field with multi values
@@ -1104,11 +1094,6 @@ class AbstractScalaEsScalaSparkSQL(prefix: String, readMetadata: jl.Boolean, pus
   def testDataSourcePushDown12And() {
     val df = esDataSource("pd_and")
     var filter = df.filter(df("reason").isNotNull.and(df("airport").endsWith("O")))
-
-    if (strictPushDown) {
-      assertEquals(0, filter.count())
-      return
-    }
 
     assertEquals(1, filter.count())
     assertEquals("jan", filter.select("tag").take(1)(0)(0))


### PR DESCRIPTION
There were some issues fixed with the Wildcard query in https://github.com/elastic/elasticsearch/pull/53127 that now cause a few tests to fail in ES-Hadoop. Looking through the logic, it seems that the tests were originally written with the incorrect behavior in mind. This PR updates them to run again.