### PR TITLE
Import sources for javadoc through a dependency

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/BuildPlugin.groovy
@@ -91,7 +91,7 @@ class BuildPlugin implements Plugin<Project>  {
         if (project != project.rootProject) {
             // Set up avenues for sharing source files between projects in order to create embedded Javadocs
             // Import source configuration
-            Configuration sources = project.configurations.create("sources")
+            Configuration sources = project.configurations.create("additionalSources")
             sources.canBeConsumed = false
             sources.canBeResolved = true
             sources.attributes {
@@ -276,7 +276,7 @@ class BuildPlugin implements Plugin<Project>  {
         sourcesJar.from(project.sourceSets.main.allSource)
         // TODO: Remove when root project does not handle distribution
         if (project != project.rootProject) {
-            sourcesJar.from(project.configurations.sources)
+            sourcesJar.from(project.configurations.additionalSources)
         }
 
         // Configure javadoc
@@ -291,7 +291,7 @@ class BuildPlugin implements Plugin<Project>  {
         ]
         // TODO: Remove when root project does not handle distribution
         if (project != project.rootProject) {
-            javadoc.source += project.configurations.sources
+            javadoc.source = project.files(project.configurations.additionalSources)
         }
         // Set javadoc executable to runtime Java (1.8)
         javadoc.executable = new File(project.ext.runtimeJavaHome, 'bin/javadoc')

--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/BuildPlugin.groovy
@@ -17,11 +17,15 @@ import org.gradle.api.artifacts.ProjectDependency
 import org.gradle.api.artifacts.ResolutionStrategy
 import org.gradle.api.artifacts.maven.MavenPom
 import org.gradle.api.artifacts.maven.MavenResolver
+import org.gradle.api.attributes.LibraryElements
+import org.gradle.api.attributes.Usage
 import org.gradle.api.file.CopySpec
+import org.gradle.api.file.FileCollection
 import org.gradle.api.java.archives.Manifest
 import org.gradle.api.plugins.JavaPlugin
 import org.gradle.api.plugins.MavenPlugin
 import org.gradle.api.plugins.MavenPluginConvention
+import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.SourceSetContainer
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.api.tasks.Upload
@@ -84,6 +88,37 @@ class BuildPlugin implements Plugin<Project>  {
     }
 
     private static void configureConfigurations(Project project) {
+        if (project != project.rootProject) {
+            // Set up avenues for sharing source files between projects in order to create embedded Javadocs
+            // Import source configuration
+            Configuration sources = project.configurations.create("sources")
+            sources.canBeConsumed = false
+            sources.canBeResolved = true
+            sources.attributes {
+                // Changing USAGE is required when working with Scala projects, otherwise the source dirs get pulled
+                // into incremental compilation analysis.
+                attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage, 'java-source'))
+                attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, project.objects.named(LibraryElements, 'sources'))
+            }
+
+            // Export source configuration
+            Configuration sourceElements = project.configurations.create("sourceElements")
+            sourceElements.canBeConsumed = true
+            sourceElements.canBeResolved = false
+            sourceElements.extendsFrom(sources)
+            sourceElements.attributes {
+                // Changing USAGE is required when working with Scala projects, otherwise the source dirs get pulled
+                // into incremental compilation analysis.
+                attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage, 'java-source'))
+                attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, project.objects.named(LibraryElements, 'sources'))
+            }
+
+            // Should this just be implementation?
+            Configuration javadoc = project.configurations.create("javadoc")
+            javadoc.canBeConsumed = false
+            javadoc.canBeResolved = true
+        }
+
         if (project.path.startsWith(":qa")) {
             return
         }
@@ -200,6 +235,15 @@ class BuildPlugin implements Plugin<Project>  {
         project.sourceCompatibility = '1.8'
         project.targetCompatibility = '1.8'
 
+        // TODO: Remove all root project distribution logic. It should exist in a separate dist project.
+        if (project != project.rootProject) {
+            SourceSet mainSourceSet = project.sourceSets.main
+            FileCollection javaSourceDirs = mainSourceSet.java.sourceDirectories
+            javaSourceDirs.each { File srcDir ->
+                project.getArtifacts().add('sourceElements', srcDir)
+            }
+        }
+
         JavaCompile compileJava = project.tasks.getByName('compileJava') as JavaCompile
         compileJava.getOptions().setCompilerArgs(['-Xlint:unchecked', '-Xlint:options'])
 
@@ -235,6 +279,10 @@ class BuildPlugin implements Plugin<Project>  {
         sourcesJar.dependsOn(project.tasks.classes)
         sourcesJar.classifier = 'sources'
         sourcesJar.from(project.sourceSets.main.allSource)
+        // TODO: Remove when root project does not handle distribution
+        if (project != project.rootProject) {
+            sourcesJar.from(project.configurations.sources)
+        }
 
         // Configure javadoc
         Javadoc javadoc = project.tasks.getByName('javadoc') as Javadoc
@@ -246,6 +294,11 @@ class BuildPlugin implements Plugin<Project>  {
                 "org/elasticsearch/hadoop/util/**",
                 "org/apache/hadoop/hive/**"
         ]
+        // TODO: Remove when root project does not handle distribution
+        if (project != project.rootProject) {
+            javadoc.source += project.configurations.sources
+            javadoc.classpath += project.configurations.javadoc
+        }
         // Set javadoc executable to runtime Java (1.8)
         javadoc.executable = new File(project.ext.runtimeJavaHome, 'bin/javadoc')
 

--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/BuildPlugin.groovy
@@ -112,11 +112,6 @@ class BuildPlugin implements Plugin<Project>  {
                 attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage, 'java-source'))
                 attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, project.objects.named(LibraryElements, 'sources'))
             }
-
-            // Should this just be implementation?
-            Configuration javadoc = project.configurations.create("javadoc")
-            javadoc.canBeConsumed = false
-            javadoc.canBeResolved = true
         }
 
         if (project.path.startsWith(":qa")) {
@@ -297,7 +292,6 @@ class BuildPlugin implements Plugin<Project>  {
         // TODO: Remove when root project does not handle distribution
         if (project != project.rootProject) {
             javadoc.source += project.configurations.sources
-            javadoc.classpath += project.configurations.javadoc
         }
         // Set javadoc executable to runtime Java (1.8)
         javadoc.executable = new File(project.ext.runtimeJavaHome, 'bin/javadoc')

--- a/hive/build.gradle
+++ b/hive/build.gradle
@@ -33,6 +33,9 @@ dependencies {
     itestImplementation("org.apache.hive:hive-jdbc:$hiveVersion") {
         exclude module: "log4j-slf4j-impl"
     }
+
+    sources(project(":elasticsearch-hadoop-mr"))
+    javadoc(project(":elasticsearch-hadoop-mr"))
 }
 
 jar {
@@ -41,13 +44,4 @@ jar {
         include "esh-build.properties"
         include "META-INF/services/*"
     }
-}
-
-javadoc {
-    source += project(":elasticsearch-hadoop-mr").sourceSets.main.allJava
-    classpath += files(project(":elasticsearch-hadoop-mr").sourceSets.main.compileClasspath)
-}
-
-sourcesJar {
-    from project(":elasticsearch-hadoop-mr").sourceSets.main.allJava.srcDirs
 }

--- a/hive/build.gradle
+++ b/hive/build.gradle
@@ -34,7 +34,7 @@ dependencies {
         exclude module: "log4j-slf4j-impl"
     }
 
-    sources(project(":elasticsearch-hadoop-mr"))
+    additionalSources(project(":elasticsearch-hadoop-mr"))
 }
 
 jar {

--- a/hive/build.gradle
+++ b/hive/build.gradle
@@ -35,7 +35,6 @@ dependencies {
     }
 
     sources(project(":elasticsearch-hadoop-mr"))
-    javadoc(project(":elasticsearch-hadoop-mr"))
 }
 
 jar {

--- a/pig/build.gradle
+++ b/pig/build.gradle
@@ -31,6 +31,9 @@ dependencies {
 
     itestImplementation(project(":test:shared"))
     itestImplementation("dk.brics.automaton:automaton:1.11-8")
+    
+    sources(project(":elasticsearch-hadoop-mr"))
+    javadoc(project(":elasticsearch-hadoop-mr"))
 }
 
 jar {
@@ -39,13 +42,4 @@ jar {
         include "esh-build.properties"
         include "META-INF/services/*"
     }
-}
-
-javadoc {
-    source += project(":elasticsearch-hadoop-mr").sourceSets.main.allJava
-    classpath += files(project(":elasticsearch-hadoop-mr").sourceSets.main.compileClasspath)
-}
-
-sourcesJar {
-    from project(":elasticsearch-hadoop-mr").sourceSets.main.allJava.srcDirs
 }

--- a/pig/build.gradle
+++ b/pig/build.gradle
@@ -33,7 +33,6 @@ dependencies {
     itestImplementation("dk.brics.automaton:automaton:1.11-8")
     
     sources(project(":elasticsearch-hadoop-mr"))
-    javadoc(project(":elasticsearch-hadoop-mr"))
 }
 
 jar {

--- a/pig/build.gradle
+++ b/pig/build.gradle
@@ -31,8 +31,8 @@ dependencies {
 
     itestImplementation(project(":test:shared"))
     itestImplementation("dk.brics.automaton:automaton:1.11-8")
-    
-    sources(project(":elasticsearch-hadoop-mr"))
+
+    additionalSources(project(":elasticsearch-hadoop-mr"))
 }
 
 jar {

--- a/spark/sql-13/build.gradle
+++ b/spark/sql-13/build.gradle
@@ -161,6 +161,16 @@ dependencies {
     testImplementation("org.apache.spark:spark-sql_${project.ext.scalaMajorVersion}:$sparkVersion") {
         exclude group: 'org.apache.hadoop'
     }
+    
+    sources(project(":elasticsearch-hadoop-mr"))
+    javadoc(project(":elasticsearch-hadoop-mr"))
+}
+
+// Export generated Java code from the genjavadoc compiler plugin
+artifacts {
+    sourceElements(project.file("$buildDir/generated/java")) {
+        builtBy compileScala
+    }
 }
 
 jar {
@@ -173,13 +183,7 @@ jar {
 
 javadoc {
     dependsOn compileScala
-    source += project(":elasticsearch-hadoop-mr").sourceSets.main.allJava
     source += "$buildDir/generated/java"
-    classpath += files(project(":elasticsearch-hadoop-mr").sourceSets.main.compileClasspath)
-}
-
-sourcesJar {
-    from project(":elasticsearch-hadoop-mr").sourceSets.main.allJava.srcDirs
 }
 
 scaladoc {

--- a/spark/sql-13/build.gradle
+++ b/spark/sql-13/build.gradle
@@ -163,7 +163,6 @@ dependencies {
     }
     
     sources(project(":elasticsearch-hadoop-mr"))
-    javadoc(project(":elasticsearch-hadoop-mr"))
 }
 
 // Export generated Java code from the genjavadoc compiler plugin

--- a/spark/sql-13/build.gradle
+++ b/spark/sql-13/build.gradle
@@ -161,8 +161,8 @@ dependencies {
     testImplementation("org.apache.spark:spark-sql_${project.ext.scalaMajorVersion}:$sparkVersion") {
         exclude group: 'org.apache.hadoop'
     }
-    
-    sources(project(":elasticsearch-hadoop-mr"))
+
+    additionalSources(project(":elasticsearch-hadoop-mr"))
 }
 
 // Export generated Java code from the genjavadoc compiler plugin

--- a/spark/sql-20/build.gradle
+++ b/spark/sql-20/build.gradle
@@ -157,7 +157,7 @@ dependencies {
         exclude group: 'org.apache.hadoop'
     }
 
-    sources(project(":elasticsearch-hadoop-mr"))
+    additionalSources(project(":elasticsearch-hadoop-mr"))
 }
 
 // Export generated Java code from the genjavadoc compiler plugin

--- a/spark/sql-20/build.gradle
+++ b/spark/sql-20/build.gradle
@@ -156,6 +156,16 @@ dependencies {
     itestImplementation("org.apache.spark:spark-streaming_${project.ext.scalaMajorVersion}:$sparkVersion") {
         exclude group: 'org.apache.hadoop'
     }
+
+    sources(project(":elasticsearch-hadoop-mr"))
+    javadoc(project(":elasticsearch-hadoop-mr"))
+}
+
+// Export generated Java code from the genjavadoc compiler plugin
+artifacts {
+    sourceElements(project.file("$buildDir/generated/java")) {
+        builtBy compileScala
+    }
 }
 
 jar {
@@ -168,13 +178,7 @@ jar {
 
 javadoc {
     dependsOn compileScala
-    source += project(":elasticsearch-hadoop-mr").sourceSets.main.allJava
     source += "$buildDir/generated/java"
-    classpath += files(project(":elasticsearch-hadoop-mr").sourceSets.main.compileClasspath)
-}
-
-sourcesJar {
-    from project(":elasticsearch-hadoop-mr").sourceSets.main.allJava.srcDirs
 }
 
 scaladoc {

--- a/spark/sql-20/build.gradle
+++ b/spark/sql-20/build.gradle
@@ -158,7 +158,6 @@ dependencies {
     }
 
     sources(project(":elasticsearch-hadoop-mr"))
-    javadoc(project(":elasticsearch-hadoop-mr"))
 }
 
 // Export generated Java code from the genjavadoc compiler plugin

--- a/storm/build.gradle
+++ b/storm/build.gradle
@@ -27,6 +27,9 @@ dependencies {
     itestImplementation(project(":test:shared"))
     itestImplementation("com.google.guava:guava:16.0.1")
     itestImplementation("com.twitter:carbonite:1.4.0")
+    
+    sources(project(":elasticsearch-hadoop-mr"))
+    javadoc(project(":elasticsearch-hadoop-mr"))
 }
 
 jar {
@@ -35,15 +38,6 @@ jar {
         include "esh-build.properties"
         include "META-INF/services/*"
     }
-}
-
-javadoc {
-    source += project(":elasticsearch-hadoop-mr").sourceSets.main.allJava
-    classpath += files(project(":elasticsearch-hadoop-mr").sourceSets.main.compileClasspath)
-}
-
-sourcesJar {
-    from project(":elasticsearch-hadoop-mr").sourceSets.main.allJava.srcDirs
 }
 
 tasks.getByName('integrationTest').enabled = false

--- a/storm/build.gradle
+++ b/storm/build.gradle
@@ -27,8 +27,8 @@ dependencies {
     itestImplementation(project(":test:shared"))
     itestImplementation("com.google.guava:guava:16.0.1")
     itestImplementation("com.twitter:carbonite:1.4.0")
-    
-    sources(project(":elasticsearch-hadoop-mr"))
+
+    additionalSources(project(":elasticsearch-hadoop-mr"))
 }
 
 jar {

--- a/storm/build.gradle
+++ b/storm/build.gradle
@@ -29,7 +29,6 @@ dependencies {
     itestImplementation("com.twitter:carbonite:1.4.0")
     
     sources(project(":elasticsearch-hadoop-mr"))
-    javadoc(project(":elasticsearch-hadoop-mr"))
 }
 
 jar {


### PR DESCRIPTION
We embed project code from the MR project into each and every integration Project in ES-Hadoop. When generating javadocs, we directly reference the mr project's source sets to pull their contents into the javadoc tool as an input. 

This becomes a problem when a downstream project depends on java source code that is generated by a task. A specific instance of this problem arises when splitting the Spark core and SQL projects apart. The Spark projects take advantage of a compiler plugin to generate java sources specifically to be used with the Javadoc tool. These generated sources must be transmitted from the Spark core projects to the Spark SQL projects so that they may be bundled together in the same documentation package.

This PR adds configurations for importing and exporting source directories. It adds a `sourceElements` configuration that can be consumed by other projects. The build plugin then registers the main java source directories in the project with this configuration through the artifacts handler. The PR also adds a `sources` configuration that can be resolved. Projects use this configuration to denote source code directories from other projects that are needed to generate the Javadocs and Sources jar.
