### PR TITLE
Use build tools to read git revision

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/BaseBuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/BaseBuildPlugin.groovy
@@ -147,14 +147,8 @@ class BaseBuildPlugin implements Plugin<Project> {
         if (!project.rootProject.ext.has('settingsConfigured')) {
             // Force any Elasticsearch test clusters to use packaged java versions if they have them available
             project.rootProject.ext.isRuntimeJavaHomeSet = false
-
-            File gitHead = gitBranch(project)
-            project.rootProject.ext.gitHead = gitHead
-            project.rootProject.ext.revHash = gitHash(gitHead)
             project.rootProject.ext.settingsConfigured = true
         }
-        project.ext.gitHead = project.rootProject.ext.gitHead
-        project.ext.revHash = project.rootProject.ext.revHash
         project.ext.javaVersions = BuildParams.javaVersions
         project.ext.isRuntimeJavaHomeSet = project.rootProject.ext.isRuntimeJavaHomeSet
     }
@@ -196,45 +190,5 @@ class BaseBuildPlugin implements Plugin<Project> {
                 url "https://s3.amazonaws.com/download.elasticsearch.org/lucenesnapshots/${revision}"
             }
         }
-    }
-
-    /**
-     * @param project that belongs to a git repo
-     * @return the file containing the hash for the current branch
-     */
-    private static File gitBranch(Project project) {
-        // parse the git files to find out the revision
-        File gitHead =  project.file("${project.rootDir}/.git/HEAD")
-        if (gitHead != null && !gitHead.exists()) {
-            // Try as a sub module
-            File subModuleGit = project.file("${project.rootDir}/.git")
-            if (subModuleGit != null && subModuleGit.exists()) {
-                String content = subModuleGit.text.trim()
-                if (content.startsWith("gitdir:")) {
-                    gitHead = project.file("${project.rootDir}/" + content.replace('gitdir: ','') + "/HEAD")
-                }
-            }
-        }
-
-        if (gitHead != null && gitHead.exists()) {
-            String content = gitHead.text.trim()
-            if (content.startsWith("ref:")) {
-                return project.file("${project.rootDir}/.git/" + content.replace('ref: ',''))
-            }
-            return gitHead
-        }
-        return null
-    }
-
-    /**
-     * @param gitHead file containing the the currently checked out ref
-     * @return the current commit version hash
-     */
-    private static String gitHash(File gitHead) {
-        String rev = "unknown"
-        if (gitHead != null && gitHead.exists()) {
-            rev = gitHead.text.trim()
-        }
-        return rev
     }
 }

--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/BuildPlugin.groovy
@@ -1,6 +1,7 @@
 package org.elasticsearch.hadoop.gradle
 
 import org.elasticsearch.gradle.DependenciesInfoTask
+import org.elasticsearch.gradle.info.BuildParams
 import org.elasticsearch.gradle.precommit.DependencyLicensesTask
 import org.elasticsearch.gradle.precommit.LicenseHeadersTask
 import org.elasticsearch.gradle.precommit.UpdateShasTask
@@ -245,7 +246,7 @@ class BuildPlugin implements Plugin<Project>  {
         manifest.attributes['Implementation-URL'] = "https://github.com/elastic/elasticsearch-hadoop"
         manifest.attributes['Implementation-Vendor'] = "Elastic"
         manifest.attributes['Implementation-Vendor-Id'] = "org.elasticsearch.hadoop"
-        manifest.attributes['Repository-Revision'] = project.ext.revHash
+        manifest.attributes['Repository-Revision'] = BuildParams.gitRevision
         String build = System.env['ESHDP.BUILD']
         if (build != null) {
             manifest.attributes['Build'] = build

--- a/mr/build.gradle
+++ b/mr/build.gradle
@@ -1,3 +1,4 @@
+import org.elasticsearch.gradle.info.BuildParams
 
 apply plugin: 'es.hadoop.build.integration'
 
@@ -36,13 +37,13 @@ sourceSets {
 }
 
 task generateGitHash {
-    inputs.file project.ext.gitHead
+    inputs.property "revision", BuildParams.gitRevision
     outputs.dir generatedResources
 
     doLast {
         Properties props = new Properties()
         props.put("version", version)
-        props.put("hash", project.ext.revHash)
+        props.put("hash", BuildParams.gitRevision)
         File output = new File(generatedResources, "esh-build.properties")
         new File(generatedResources).mkdirs()
         output.createNewFile()


### PR DESCRIPTION
Remove our git revision parsing code and replace it with the parsing logic from build tools since that handles git worktrees correctly.