### PR TITLE
Remove obsolete artifact substitution rules

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/BuildPlugin.groovy
@@ -194,20 +194,6 @@ class BuildPlugin implements Plugin<Project>  {
                 }
             }
         }
-
-        // Do substitutions for ES fixture downloads
-        project.configurations.all { Configuration configuration ->
-            configuration.resolutionStrategy.dependencySubstitution { DependencySubstitutions subs ->
-                // TODO: Build tools requests a version format that does not match the version id of the distribution.
-                // Fix this when it is fixed in the mainline
-                subs.substitute(subs.module("dnm:elasticsearch:${project.ext.elasticsearchVersion}linux-x86_64"))
-                        .with(subs.module("dnm:elasticsearch:${project.ext.elasticsearchVersion}-linux-x86_64"))
-                subs.substitute(subs.module("dnm:elasticsearch:${project.ext.elasticsearchVersion}windows-x86_64"))
-                        .with(subs.module("dnm:elasticsearch:${project.ext.elasticsearchVersion}-windows-x86_64"))
-                subs.substitute(subs.module("dnm:elasticsearch:${project.ext.elasticsearchVersion}darwin-x86_64"))
-                        .with(subs.module("dnm:elasticsearch:${project.ext.elasticsearchVersion}-darwin-x86_64"))
-            }
-        }
     }
 
     /**


### PR DESCRIPTION
Removes some artifact substitution rules for downloading Elasticsearch distributions for testing that are no longer needed.