### PR TITLE
Add java-versions.properties file for CI

### DIFF
--- a/.ci/java-versions.properties
+++ b/.ci/java-versions.properties
@@ -7,4 +7,4 @@
 # are 'java' or 'openjdk' followed by the major release number.
 
 ESH_BUILD_JAVA=openjdk14
-ESH_RUNTIME_JAVA=openjdk11
+ESH_RUNTIME_JAVA=java11

--- a/.ci/java-versions.properties
+++ b/.ci/java-versions.properties
@@ -1,0 +1,10 @@
+# This file is used with all of the non-matrix tests in Jenkins,
+# and is based on how the Elasticsearch project configures java
+# versions.
+
+# This .properties file defines the versions of Java with which to
+# build and test Elasticsearch for this branch. Valid Java versions
+# are 'java' or 'openjdk' followed by the major release number.
+
+ESH_BUILD_JAVA=openjdk14
+ESH_RUNTIME_JAVA=openjdk11


### PR DESCRIPTION
This PR adds a configuration file that the CI system will pick up to determine which version of Java is expected for running tests and builds for the current branch. This will backported to all active development branches.