### PR TITLE
Share serialized settings and mappings between partition definitions

### DIFF
--- a/mr/src/main/java/org/elasticsearch/hadoop/rest/RestService.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/rest/RestService.java
@@ -285,6 +285,7 @@ public abstract class RestService implements Serializable {
                                                          List<List<Map<String, Object>>> shards, Log log) {
         Mapping resolvedMapping = mappingSet == null ? null : mappingSet.getResolvedView();
         List<PartitionDefinition> partitions = new ArrayList<PartitionDefinition>(shards.size());
+        PartitionDefinition.PartitionDefinitionBuilder partitionBuilder = PartitionDefinition.builder(settings, resolvedMapping);
         for (List<Map<String, Object>> group : shards) {
             String index = null;
             int shardId = -1;
@@ -308,8 +309,7 @@ public abstract class RestService implements Serializable {
                             "Check your cluster status to see if it is unstable!");
                 }
             } else {
-                PartitionDefinition partition = new PartitionDefinition(settings, resolvedMapping, index, shardId,
-                        locationList.toArray(new String[0]));
+                PartitionDefinition partition = partitionBuilder.build(index, shardId, locationList.toArray(new String[0]));
                 partitions.add(partition);
             }
         }
@@ -326,6 +326,7 @@ public abstract class RestService implements Serializable {
         Assert.notNull(maxDocsPerPartition, "Attempting to find slice partitions but maximum documents per partition is not set.");
         Resource readResource = new Resource(settings, true);
         Mapping resolvedMapping = mappingSet == null ? null : mappingSet.getResolvedView();
+        PartitionDefinition.PartitionDefinitionBuilder partitionBuilder = PartitionDefinition.builder(settings, resolvedMapping);
 
         List<PartitionDefinition> partitions = new ArrayList<PartitionDefinition>(shards.size());
         for (List<Map<String, Object>> group : shards) {
@@ -362,7 +363,7 @@ public abstract class RestService implements Serializable {
                 int numPartitions = (int) Math.max(1, numDocs / maxDocsPerPartition);
                 for (int i = 0; i < numPartitions; i++) {
                     PartitionDefinition.Slice slice = new PartitionDefinition.Slice(i, numPartitions);
-                    partitions.add(new PartitionDefinition(settings, resolvedMapping, index, shardId, slice, locations));
+                    partitions.add(partitionBuilder.build(index, shardId, slice, locations));
                 }
             }
         }

--- a/mr/src/test/java/org/elasticsearch/hadoop/rest/FindPartitionsTest.java
+++ b/mr/src/test/java/org/elasticsearch/hadoop/rest/FindPartitionsTest.java
@@ -51,16 +51,17 @@ public class FindPartitionsTest {
 
     private static final PartitionDefinition[] EXPECTED_SHARDS_PARTITIONS;
     static {
+        PartitionDefinition.PartitionDefinitionBuilder partitionBuilder = PartitionDefinition.builder(null, null);
         List<PartitionDefinition> expected =
                 new ArrayList<PartitionDefinition>();
         for (int i = 0; i < 15; i++) {
-            expected.add(new PartitionDefinition(null, null, "index1", i));
+            expected.add(partitionBuilder.build("index1", i));
         }
         for (int i = 0; i < 18; i++) {
-            expected.add(new PartitionDefinition(null, null, "index2", i));
+            expected.add(partitionBuilder.build("index2", i));
         }
         for (int i = 0; i < 1; i++) {
-            expected.add(new PartitionDefinition(null, null, "index3", i));
+            expected.add(partitionBuilder.build("index3", i));
         }
         Collections.sort(expected);
         EXPECTED_SHARDS_PARTITIONS = expected.toArray(new PartitionDefinition[0]);

--- a/mr/src/test/java/org/elasticsearch/hadoop/rest/RestServiceTest.java
+++ b/mr/src/test/java/org/elasticsearch/hadoop/rest/RestServiceTest.java
@@ -75,12 +75,13 @@ public class RestServiceTest {
 
         ShardInfo sh6 = new ShardInfo(info);
 
-        pd1 = new PartitionDefinition(null, null, sh1.getIndex(), sh1.getName());
-        pd2 = new PartitionDefinition(null, null, sh2.getIndex(), sh2.getName());
-        pd3 = new PartitionDefinition(null, null, sh3.getIndex(), sh3.getName());
-        pd4 = new PartitionDefinition(null, null, sh4.getIndex(), sh4.getName());
-        pd5 = new PartitionDefinition(null, null, sh5.getIndex(), sh5.getName());
-        pd6 = new PartitionDefinition(null, null, sh6.getIndex(), sh6.getName());
+        PartitionDefinition.PartitionDefinitionBuilder bldr = PartitionDefinition.builder(null, null);
+        pd1 = bldr.build(sh1.getIndex(), sh1.getName());
+        pd2 = bldr.build(sh2.getIndex(), sh2.getName());
+        pd3 = bldr.build(sh3.getIndex(), sh3.getName());
+        pd4 = bldr.build(sh4.getIndex(), sh4.getName());
+        pd5 = bldr.build(sh5.getIndex(), sh5.getName());
+        pd6 = bldr.build(sh6.getIndex(), sh6.getName());
 
         pds = Arrays.asList(pd1, pd2, pd3, pd4, pd5, pd6);
     }


### PR DESCRIPTION
In situations where large pushdown queries, large mappings, and indices with many shards are combined, we can inflate the driver program memory very quickly as we duplicate the settings and mappings data for each ParititionDefinition we create. This change serializes the settings and mapping data once and shares the immutable state between all PartitionDefinition instances to avoid ballooning memory.

Closes #1476 