### PR TITLE
Fix Scala test compile Java home usage

### DIFF
--- a/spark/sql-13/build.gradle
+++ b/spark/sql-13/build.gradle
@@ -55,10 +55,10 @@ configurations.all { Configuration conf ->
 tasks.withType(ScalaCompile) { ScalaCompile task ->
     task.sourceCompatibility = project.ext.minimumRuntimeVersion
     task.targetCompatibility = project.ext.minimumRuntimeVersion
+    task.options.forkOptions.executable = new File(project.ext.runtimeJavaHome, 'bin/java').canonicalPath
 }
 
 compileScala {
-    options.forkOptions.executable = new File(project.ext.runtimeJavaHome, 'bin/java').canonicalPath
     configure(scalaCompileOptions.forkOptions) {
         memoryMaximumSize = '1g'
         jvmArgs = ['-XX:MaxPermSize=512m']

--- a/spark/sql-20/build.gradle
+++ b/spark/sql-20/build.gradle
@@ -41,10 +41,10 @@ if (project.ext.scalaMajorVersion == '2.10') {
 tasks.withType(ScalaCompile) { ScalaCompile task ->
     task.sourceCompatibility = project.ext.minimumRuntimeVersion
     task.targetCompatibility = project.ext.minimumRuntimeVersion
+    task.options.forkOptions.executable = new File(project.ext.runtimeJavaHome, 'bin/java').canonicalPath
 }
 
 compileScala {
-    options.forkOptions.executable = new File(project.ext.runtimeJavaHome, 'bin/java').canonicalPath
     configure(scalaCompileOptions.forkOptions) {
         memoryMaximumSize = '1g'
         jvmArgs = ['-XX:MaxPermSize=512m']


### PR DESCRIPTION
Setting the java home property was only done on the regular Scala compile task. It should be set on all Scala compile tasks instead.