### PR TITLE
Move dependency report logic to the dist project

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,8 +41,9 @@ if (project.hasProperty("find-artifact")) {
     }
 }
 
-// Add a task in the root project that collects all the dependencyReport data for each project
+// Add a task in the project that collects all the dependencyReport data for each project
 // Concatenates the dependencies CSV files into a single file
+// usage: ./gradlew :dist:generateDependenciesReport -Dcsv=/tmp/deps.csv
 task generateDependenciesReport(type: ConcatFilesTask) {
     files = fileTree(dir: project.rootDir,  include: '**/dependencies.csv' )
     headerLine = "name,version,url,license"

--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,10 @@ apply plugin: 'es.hadoop.build.root'
 
 defaultTasks 'build'
 
+allprojects {
+    group = "org.elasticsearch"
+}
+
 // Simple utility task to help with downloading artifacts and jars
 if (project.hasProperty("find-artifact")) {
     String artifact = project.getProperty("find-artifact")

--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/BuildPlugin.groovy
@@ -1,6 +1,6 @@
 package org.elasticsearch.hadoop.gradle
 
-import org.elasticsearch.gradle.DependenciesInfoTask
+import org.elasticsearch.gradle.DependenciesInfoPlugin
 import org.elasticsearch.gradle.info.BuildParams
 import org.elasticsearch.gradle.precommit.DependencyLicensesTask
 import org.elasticsearch.gradle.precommit.LicenseHeadersTask
@@ -12,7 +12,6 @@ import org.gradle.api.Task
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.Dependency
 import org.gradle.api.artifacts.DependencyResolveDetails
-import org.gradle.api.artifacts.DependencySubstitutions
 import org.gradle.api.artifacts.ModuleDependency
 import org.gradle.api.artifacts.ProjectDependency
 import org.gradle.api.artifacts.ResolutionStrategy
@@ -24,7 +23,6 @@ import org.gradle.api.file.CopySpec
 import org.gradle.api.file.FileCollection
 import org.gradle.api.java.archives.Manifest
 import org.gradle.api.plugins.JavaLibraryPlugin
-import org.gradle.api.plugins.JavaPlugin
 import org.gradle.api.plugins.MavenPlugin
 import org.gradle.api.plugins.MavenPluginConvention
 import org.gradle.api.plugins.scala.ScalaPlugin
@@ -559,14 +557,7 @@ class BuildPlugin implements Plugin<Project>  {
 
     private static void configureDependenciesInfo(Project project) {
         if (!project.path.startsWith(":qa")) {
-            project.tasks.register("dependenciesInfo", DependenciesInfoTask) { DependenciesInfoTask task ->
-                task.runtimeConfiguration = project.configurations.getByName(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME)
-                task.compileOnlyConfiguration = project.configurations.getByName(JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME)
-                // Create a property called mappings that points to the same mappings in the dependency licenses task.
-                task.getConventionMapping().map('mappings') {
-                    (project.tasks.getByName('dependencyLicenses') as DependencyLicensesTask).mappings
-                }
-            }
+            project.getPluginManager().apply(DependenciesInfoPlugin.class)
         }
     }
 }

--- a/dist/build.gradle
+++ b/dist/build.gradle
@@ -1,3 +1,5 @@
+import org.elasticsearch.gradle.ConcatFilesTask
+import org.elasticsearch.gradle.DependenciesInfoTask
 
 apply plugin: 'es.hadoop.build'
 
@@ -9,6 +11,13 @@ configurations {
         canBeResolved = true
         canBeConsumed = false
         transitive = false
+    }
+    javadocDependencies {
+        canBeResolved = true
+        canBeConsumed = false
+    }
+    compileClasspath {
+        extendsFrom javadocDependencies
     }
     dist {
         canBeResolved = true
@@ -26,7 +35,7 @@ distProjects.each { distProject ->
         // This is only going to pull in each project's regular jar to create the project-wide uberjar.
         embedded(project(distProject))
         // To squash Javadoc warnings.
-        compileOnly(project(distProject))
+        javadocDependencies(project(distProject))
         // This will pull all java sources (including generated) for the project-wide javadoc.
         javadocSources(project(distProject))
         // This will pull all non-generated sources for the project-wide source jar.
@@ -127,4 +136,13 @@ task('distZip', type: Zip) {
 
 distribution {
     dependsOn(distZip)
+}
+
+// Add a task in the root project that collects all the dependencyReport data for each project
+// Concatenates the dependencies CSV files into a single file
+task generateDependenciesReport(type: ConcatFilesTask) {
+    dependsOn rootProject.allprojects.collect { it.tasks.withType(DependenciesInfoTask) }
+    files = fileTree(dir: project.rootDir,  include: '**/dependencies.csv' )
+    headerLine = "name,version,url,license"
+    target = new File(System.getProperty('csv')?: "${project.buildDir}/reports/dependencies/es-hadoop-dependencies.csv")
 }


### PR DESCRIPTION
This PR moves the dependency report generation logic to the dist subproject, and makes some changes to get the project wide dependency report to generate correctly.