### PR TITLE
Delete operation backport to 7.4.2

### DIFF
--- a/mr/src/main/java/org/elasticsearch/hadoop/cfg/Settings.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/cfg/Settings.java
@@ -221,6 +221,7 @@ public abstract class Settings {
         return getProperty(ES_SERIALIZATION_WRITER_VALUE_CLASS);
     }
 
+
     public String getSerializerBytesConverterClassName() {
         return getProperty(ES_SERIALIZATION_WRITER_BYTES_CLASS);
     }
@@ -765,3 +766,4 @@ public abstract class Settings {
 
     public abstract Properties asProperties();
 }
+

--- a/mr/src/main/java/org/elasticsearch/hadoop/serialization/bulk/BulkCommands.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/serialization/bulk/BulkCommands.java
@@ -45,8 +45,11 @@ public abstract class BulkCommands {
         else if (ConfigurationOptions.ES_OPERATION_UPSERT.equals(operation)) {
             factory = new UpdateBulkFactory(settings, true, metaExtractor, version);
         }
+        else if (ConfigurationOptions.ES_OPERATION_DELETE.equals(operation)) {
+            factory = new DeleteBulkFactory(settings, metaExtractor, version);
+        }
         else {
-            throw new EsHadoopIllegalArgumentException("Unknown operation " + operation);
+            throw new EsHadoopIllegalArgumentException("Unsupported bulk operation " + operation);
         }
 
         return factory.createBulk();

--- a/mr/src/main/java/org/elasticsearch/hadoop/serialization/bulk/DeleteBulkFactory.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/serialization/bulk/DeleteBulkFactory.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.hadoop.serialization.bulk;
+
+import org.apache.hadoop.io.BooleanWritable;
+import org.apache.hadoop.io.ByteWritable;
+import org.apache.hadoop.io.BytesWritable;
+import org.apache.hadoop.io.DoubleWritable;
+import org.apache.hadoop.io.FloatWritable;
+import org.apache.hadoop.io.IntWritable;
+import org.apache.hadoop.io.LongWritable;
+import org.apache.hadoop.io.MD5Hash;
+import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.io.UTF8;
+import org.apache.hadoop.io.VIntWritable;
+import org.apache.hadoop.io.VLongWritable;
+import org.elasticsearch.hadoop.cfg.ConfigurationOptions;
+import org.elasticsearch.hadoop.cfg.Settings;
+import org.elasticsearch.hadoop.serialization.Generator;
+import org.elasticsearch.hadoop.serialization.builder.ValueWriter;
+import org.elasticsearch.hadoop.util.EsMajorVersion;
+import org.elasticsearch.hadoop.util.StringUtils;
+
+import java.util.List;
+
+public class DeleteBulkFactory extends AbstractBulkFactory {
+
+
+    public DeleteBulkFactory(Settings settings, MetadataExtractor metaExtractor, EsMajorVersion version) {
+        super(settings, metaExtractor, version);
+    }
+
+    @Override
+    protected String getOperation() {
+        return ConfigurationOptions.ES_OPERATION_DELETE;
+    }
+
+    @Override
+    protected void writeObjectEnd(List<Object> list) {
+        // skip adding new-line for each entity as delete doesn't need entity output
+        list.add(StringUtils.EMPTY);
+    }
+}
+

--- a/mr/src/main/java/org/elasticsearch/hadoop/serialization/bulk/DeleteTemplatedBulk.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/serialization/bulk/DeleteTemplatedBulk.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.hadoop.serialization.bulk;
+
+import org.elasticsearch.hadoop.util.BytesRef;
+
+import java.util.Collection;
+
+public class DeleteTemplatedBulk extends TemplatedBulk {
+
+    DeleteTemplatedBulk(Collection<Object> beforeObject, Collection<Object> afterObject) {
+        super(beforeObject, afterObject, null);
+    }
+
+    @Override
+    public BytesRef write(Object object) {
+        ref.reset();
+        scratchPad.reset();
+        Object processed = preProcess(object, scratchPad);
+        writeTemplate(beforeObject, processed);
+        writeTemplate(afterObject, processed);
+        return ref;
+    }
+}
+

--- a/mr/src/main/java/org/elasticsearch/hadoop/serialization/bulk/TemplatedBulk.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/serialization/bulk/TemplatedBulk.java
@@ -32,11 +32,11 @@ import org.elasticsearch.hadoop.util.FastByteArrayOutputStream;
 
 class TemplatedBulk implements BulkCommand {
 
-    private final Collection<Object> beforeObject;
-    private final Collection<Object> afterObject;
+    protected final Collection<Object> beforeObject;
+    protected final Collection<Object> afterObject;
 
-    private BytesArray scratchPad = new BytesArray(1024);
-    private BytesRef ref = new BytesRef();
+    protected BytesArray scratchPad = new BytesArray(1024);
+    protected BytesRef ref = new BytesRef();
 
     private final ValueWriter valueWriter;
 
@@ -71,7 +71,7 @@ class TemplatedBulk implements BulkCommand {
         ContentBuilder.generate(bos, writer).value(object).flush().close();
     }
 
-    private void writeTemplate(Collection<Object> template, Object object) {
+    protected void writeTemplate(Collection<Object> template, Object object) {
         for (Object item : template) {
             if (item instanceof BytesArray) {
                 ref.add((BytesArray) item);

--- a/mr/src/test/java/org/elasticsearch/hadoop/rest/InitializationUtilsTest.java
+++ b/mr/src/test/java/org/elasticsearch/hadoop/rest/InitializationUtilsTest.java
@@ -136,4 +136,43 @@ public class InitializationUtilsTest {
         set.setProperty(ES_MAPPING_TIMESTAMP, "1000");
         validateSettingsForWriting(set);
     }
+
+    @Test(expected = EsHadoopIllegalArgumentException.class)
+    public void testValidateDeleteOperationVsInputAsJson() {
+        Settings set = new TestSettings();
+        set.setProperty(ES_WRITE_OPERATION, "delete");
+        set.setProperty(ES_INPUT_JSON, "true");
+        validateSettings(set);
+    }
+
+    @Test(expected = EsHadoopIllegalArgumentException.class)
+    public void testValidateDeleteOperationVsIncludeFields() {
+        Settings set = new TestSettings();
+        set.setProperty(ES_WRITE_OPERATION, "delete");
+        set.setProperty(ES_MAPPING_INCLUDE, "field");
+        validateSettings(set);
+    }
+
+    @Test(expected = EsHadoopIllegalArgumentException.class)
+    public void testValidateDeleteOperationVsExcludeFields() {
+        Settings set = new TestSettings();
+        set.setProperty(ES_WRITE_OPERATION, "delete");
+        set.setProperty(ES_MAPPING_EXCLUDE, "field");
+        validateSettings(set);
+    }
+
+    @Test(expected = EsHadoopIllegalArgumentException.class)
+    public void testValidateDeleteOperationVsIdNotSet() {
+        Settings set = new TestSettings();
+        set.setProperty(ES_WRITE_OPERATION, "delete");
+        validateSettings(set);
+    }
+
+    @Test(expected = EsHadoopIllegalArgumentException.class)
+    public void testValidateDeleteOperationVsEmptyId() {
+        Settings set = new TestSettings();
+        set.setProperty(ES_WRITE_OPERATION, "delete");
+        set.setProperty(ES_MAPPING_ID, "");
+        validateSettings(set);
+    }
 }

--- a/mr/src/test/java/org/elasticsearch/hadoop/serialization/CommandTest.java
+++ b/mr/src/test/java/org/elasticsearch/hadoop/serialization/CommandTest.java
@@ -18,11 +18,6 @@
  */
 package org.elasticsearch.hadoop.serialization;
 
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.LinkedHashMap;
-import java.util.Map;
-
 import org.elasticsearch.hadoop.EsHadoopIllegalArgumentException;
 import org.elasticsearch.hadoop.cfg.ConfigurationOptions;
 import org.elasticsearch.hadoop.cfg.Settings;
@@ -41,8 +36,12 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
-import static org.junit.Assert.assertEquals;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assume.assumeFalse;
 import static org.junit.Assume.assumeTrue;
 
@@ -64,38 +63,28 @@ public class CommandTest {
             throw new IllegalStateException("CommandTest needs new version updates.");
         }
 
-        return Arrays.asList(new Object[][] {
-                { ConfigurationOptions.ES_OPERATION_INDEX, false, EsMajorVersion.V_1_X },
-                { ConfigurationOptions.ES_OPERATION_CREATE, false, EsMajorVersion.V_1_X },
-                { ConfigurationOptions.ES_OPERATION_UPDATE, false, EsMajorVersion.V_1_X },
-                { ConfigurationOptions.ES_OPERATION_INDEX, true, EsMajorVersion.V_1_X },
-                { ConfigurationOptions.ES_OPERATION_CREATE, true, EsMajorVersion.V_1_X },
-                { ConfigurationOptions.ES_OPERATION_UPDATE, true, EsMajorVersion.V_1_X },
-                { ConfigurationOptions.ES_OPERATION_INDEX, false, EsMajorVersion.V_2_X },
-                { ConfigurationOptions.ES_OPERATION_CREATE, false, EsMajorVersion.V_2_X },
-                { ConfigurationOptions.ES_OPERATION_UPDATE, false, EsMajorVersion.V_2_X },
-                { ConfigurationOptions.ES_OPERATION_INDEX, true, EsMajorVersion.V_2_X },
-                { ConfigurationOptions.ES_OPERATION_CREATE, true, EsMajorVersion.V_2_X },
-                { ConfigurationOptions.ES_OPERATION_UPDATE, true, EsMajorVersion.V_2_X },
-                { ConfigurationOptions.ES_OPERATION_INDEX, false, EsMajorVersion.V_5_X },
-                { ConfigurationOptions.ES_OPERATION_CREATE, false, EsMajorVersion.V_5_X },
-                { ConfigurationOptions.ES_OPERATION_UPDATE, false, EsMajorVersion.V_5_X },
-                { ConfigurationOptions.ES_OPERATION_INDEX, true, EsMajorVersion.V_5_X },
-                { ConfigurationOptions.ES_OPERATION_CREATE, true, EsMajorVersion.V_5_X },
-                { ConfigurationOptions.ES_OPERATION_UPDATE, true, EsMajorVersion.V_5_X },
-                { ConfigurationOptions.ES_OPERATION_INDEX, false, EsMajorVersion.V_6_X },
-                { ConfigurationOptions.ES_OPERATION_CREATE, false, EsMajorVersion.V_6_X },
-                { ConfigurationOptions.ES_OPERATION_UPDATE, false, EsMajorVersion.V_6_X },
-                { ConfigurationOptions.ES_OPERATION_INDEX, true, EsMajorVersion.V_6_X },
-                { ConfigurationOptions.ES_OPERATION_CREATE, true, EsMajorVersion.V_6_X },
-                { ConfigurationOptions.ES_OPERATION_UPDATE, true, EsMajorVersion.V_6_X },
-                { ConfigurationOptions.ES_OPERATION_INDEX, false, EsMajorVersion.V_7_X },
-                { ConfigurationOptions.ES_OPERATION_CREATE, false, EsMajorVersion.V_7_X },
-                { ConfigurationOptions.ES_OPERATION_UPDATE, false, EsMajorVersion.V_7_X },
-                { ConfigurationOptions.ES_OPERATION_INDEX, true, EsMajorVersion.V_7_X },
-                { ConfigurationOptions.ES_OPERATION_CREATE, true, EsMajorVersion.V_7_X },
-                { ConfigurationOptions.ES_OPERATION_UPDATE, true, EsMajorVersion.V_7_X },
-        });
+        Collection<Object[]> result = new ArrayList<>();
+
+        String[] operations = new String[]{ConfigurationOptions.ES_OPERATION_INDEX,
+                ConfigurationOptions.ES_OPERATION_CREATE,
+                ConfigurationOptions.ES_OPERATION_UPDATE,
+                ConfigurationOptions.ES_OPERATION_DELETE};
+        boolean[] asJsons = new boolean[]{false, true};
+        EsMajorVersion[] versions = new EsMajorVersion[]{EsMajorVersion.V_1_X,
+                EsMajorVersion.V_2_X,
+                EsMajorVersion.V_5_X,
+                EsMajorVersion.V_6_X,
+                EsMajorVersion.V_7_X};
+
+        for (EsMajorVersion version : versions) {
+            for (boolean asJson : asJsons) {
+                for (String operation : operations) {
+                    result.add(new Object[]{operation, asJson, version});
+                }
+            }
+        }
+
+        return result;
     }
 
     public CommandTest(String operation, boolean jsonInput, EsMajorVersion version) {
@@ -112,8 +101,7 @@ public class CommandTest {
             map.put("n", 1);
             map.put("s", "v");
             data = map;
-        }
-        else {
+        } else {
             data = "{\"n\":1,\"s\":\"v\"}";
         }
     }
@@ -121,6 +109,7 @@ public class CommandTest {
     @Test
     public void testNoHeader() throws Exception {
         assumeFalse(ConfigurationOptions.ES_OPERATION_UPDATE.equals(operation));
+        assumeFalse(ConfigurationOptions.ES_OPERATION_DELETE.equals(operation));
         create(settings()).write(data).copyTo(ba);
         String result = prefix() + "}}" + map();
         assertEquals(result, ba.toString());
@@ -129,6 +118,7 @@ public class CommandTest {
     @Test
     // check user friendliness and escape the string if needed
     public void testConstantId() throws Exception {
+        assumeFalse(isDeleteOP() && jsonInput);
         Settings settings = settings();
         noId = true;
         settings.setProperty(ConfigurationOptions.ES_MAPPING_ID, "<foobar>");
@@ -142,6 +132,7 @@ public class CommandTest {
     @Test
     public void testParent() throws Exception {
         assumeTrue(version.onOrBefore(EsMajorVersion.V_6_X));
+        assumeFalse(isDeleteOP() && jsonInput);
         Settings settings = settings();
         settings.setProperty(ConfigurationOptions.ES_MAPPING_PARENT, "<5>");
 
@@ -153,6 +144,7 @@ public class CommandTest {
     @Test
     public void testParent7X() throws Exception {
         assumeTrue(version.onOrAfter(EsMajorVersion.V_7_X));
+        assumeFalse(isDeleteOP() && jsonInput);
         Settings settings = settings();
         settings.setProperty(ConfigurationOptions.ES_MAPPING_PARENT, "<5>");
 
@@ -164,6 +156,7 @@ public class CommandTest {
     @Test
     public void testVersion() throws Exception {
         assumeTrue(version.onOrBefore(EsMajorVersion.V_6_X));
+        assumeFalse(isDeleteOP() && jsonInput);
         Settings settings = settings();
         settings.setProperty(ConfigurationOptions.ES_MAPPING_VERSION, "<3>");
 
@@ -175,6 +168,7 @@ public class CommandTest {
     @Test
     public void testVersion7X() throws Exception {
         assumeTrue(version.onOrAfter(EsMajorVersion.V_7_X));
+        assumeFalse(isDeleteOP() && jsonInput);
         Settings settings = settings();
         settings.setProperty(ConfigurationOptions.ES_MAPPING_VERSION, "<3>");
 
@@ -185,6 +179,7 @@ public class CommandTest {
 
     @Test
     public void testTtl() throws Exception {
+        assumeFalse(isDeleteOP() && jsonInput);
         Settings settings = settings();
         settings.setProperty(ConfigurationOptions.ES_MAPPING_TTL, "<2>");
 
@@ -195,6 +190,7 @@ public class CommandTest {
 
     @Test
     public void testTimestamp() throws Exception {
+        assumeFalse(isDeleteOP() && jsonInput);
         Settings settings = settings();
         settings.setProperty(ConfigurationOptions.ES_MAPPING_TIMESTAMP, "<3>");
         create(settings).write(data).copyTo(ba);
@@ -205,6 +201,7 @@ public class CommandTest {
     @Test
     public void testRouting() throws Exception {
         assumeTrue(version.onOrBefore(EsMajorVersion.V_6_X));
+        assumeFalse(isDeleteOP() && jsonInput);
         Settings settings = settings();
         settings.setProperty(ConfigurationOptions.ES_MAPPING_ROUTING, "<4>");
 
@@ -216,6 +213,7 @@ public class CommandTest {
     @Test
     public void testRouting7X() throws Exception {
         assumeTrue(version.onOrAfter(EsMajorVersion.V_7_X));
+        assumeFalse(isDeleteOP() && jsonInput);
         Settings settings = settings();
         settings.setProperty(ConfigurationOptions.ES_MAPPING_ROUTING, "<4>");
 
@@ -227,6 +225,7 @@ public class CommandTest {
     @Test
     public void testAll() throws Exception {
         assumeTrue(version.onOrBefore(EsMajorVersion.V_6_X));
+        assumeFalse(isDeleteOP() && jsonInput);
         Settings settings = settings();
         settings.setProperty(ConfigurationOptions.ES_MAPPING_ID, "n");
         settings.setProperty(ConfigurationOptions.ES_MAPPING_TTL, "<2>");
@@ -240,6 +239,7 @@ public class CommandTest {
     @Test
     public void testAll7X() throws Exception {
         assumeTrue(version.onOrAfter(EsMajorVersion.V_7_X));
+        assumeFalse(isDeleteOP() && jsonInput);
         Settings settings = settings();
         settings.setProperty(ConfigurationOptions.ES_MAPPING_ID, "n");
         settings.setProperty(ConfigurationOptions.ES_MAPPING_TTL, "<2>");
@@ -252,6 +252,7 @@ public class CommandTest {
 
     @Test
     public void testIdPattern() throws Exception {
+        assumeFalse(isDeleteOP() && jsonInput);
         Settings settings = settings();
         settings.setResourceWrite("foo/{n}");
 
@@ -301,7 +302,7 @@ public class CommandTest {
         create(set).write(data).copyTo(ba);
         String result =
                 "{\"" + operation + "\":{\"_id\":2,\"_retry_on_conflict\":3}}\n" +
-                "{\"script\":{\"inline\":\"counter = 3\",\"lang\":\"groovy\"}}\n";
+                        "{\"script\":{\"inline\":\"counter = 3\",\"lang\":\"groovy\"}}\n";
         assertEquals(result, ba.toString());
     }
 
@@ -431,7 +432,7 @@ public class CommandTest {
 
         String result =
                 "{\"" + operation + "\":{\"_id\":1}}\n" +
-                "{\"script\":{\"inline\":\"counter = param1; anothercounter = param2\",\"lang\":\"groovy\",\"params\":{\"param1\":1,\"param2\":1}}}\n";
+                        "{\"script\":{\"inline\":\"counter = param1; anothercounter = param2\",\"lang\":\"groovy\",\"params\":{\"param1\":1,\"param2\":1}}}\n";
 
         assertEquals(result, ba.toString());
     }
@@ -507,7 +508,6 @@ public class CommandTest {
 
         set.setInternalVersion(version);
         set.setProperty(ConfigurationOptions.ES_INPUT_JSON, Boolean.toString(jsonInput));
-
         InitializationUtils.setValueWriterIfNotSet(set, JdkValueWriter.class, null);
         InitializationUtils.setFieldExtractorIfNotSet(set, MapFieldExtractor.class, null);
         InitializationUtils.setBytesConverterIfNeeded(set, JdkBytesConverter.class, null);
@@ -530,6 +530,9 @@ public class CommandTest {
     }
 
     private String map() {
+        if (isDeleteOP()) {
+            return "\n";
+        }
         StringBuilder sb = new StringBuilder("\n{");
         if (isUpdateOp()) {
             sb.append("\"doc\":{");
@@ -546,4 +549,9 @@ public class CommandTest {
     private boolean isUpdateOp() {
         return ConfigurationOptions.ES_OPERATION_UPDATE.equals(operation);
     }
+
+    private boolean isDeleteOP() {
+        return ConfigurationOptions.ES_OPERATION_DELETE.equals(operation);
+    }
 }
+


### PR DESCRIPTION
This PR is to backport delete support on version 7.4.2. Cherry-picked https://github.com/elastic/elasticsearch-hadoop/pull/1324 on top of 7.4.2 branch.


Thank you for submitting a pull request! 

Please make sure you have signed our [Contributor License Agreement (CLA)][].  
We are not asking you to assign copyright to us, but to give us the right to distribute your code without restriction. We ask this of all contributors in order to assure our users of the origin and continuing existence of the code.  
You only need to sign the CLA once.

- [x] I have signed the [Contributor License Agreement (CLA)][]

[Contributor License Agreement (CLA)]: https://www.elastic.co/contributor-agreement/
