### PR TITLE
Return developers tag to pom generation

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/BuildPlugin.groovy
@@ -462,6 +462,12 @@ class BuildPlugin implements Plugin<Project>  {
                     connection = 'scm:git:git://github.com/elastic/elasticsearch-hadoop'
                     developerConnection = 'scm:git:git://github.com/elastic/elasticsearch-hadoop'
                 }
+                developers {
+                    developer {
+                        name = 'Elastic'
+                        url = 'https://www.elastic.co'
+                    }
+                }
             }
 
             groupId = "org.elasticsearch"


### PR DESCRIPTION
The developers tag was removed from the pom file of all artifacts, but is required for release on nexus. Re-add the tag back in but with generic developer content.