### PR TITLE
[7.x] Return developers tag to pom generation (#1499)

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/BuildPlugin.groovy
@@ -462,6 +462,12 @@ class BuildPlugin implements Plugin<Project> {
                     connection = 'scm:git:git://github.com/elastic/elasticsearch-hadoop'
                     developerConnection = 'scm:git:git://github.com/elastic/elasticsearch-hadoop'
                 }
+                developers {
+                    developer {
+                        name = 'Elastic'
+                        url = 'https://www.elastic.co'
+                    }
+                }
             }
 
             groupId = "org.elasticsearch"


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Return developers tag to pom generation (#1499)