### PR TITLE
Update references to renamed Gradle task

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/BuildPlugin.groovy
@@ -5,7 +5,7 @@ import org.elasticsearch.gradle.info.BuildParams
 import org.elasticsearch.gradle.precommit.DependencyLicensesTask
 import org.elasticsearch.gradle.precommit.LicenseHeadersTask
 import org.elasticsearch.gradle.precommit.UpdateShasTask
-import org.elasticsearch.gradle.testclusters.RestTestRunnerTask
+import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
@@ -493,7 +493,7 @@ class BuildPlugin implements Plugin<Project>  {
                 itestJar.from(project.sourceSets.itest.output)
             }
 
-            Test integrationTest = project.tasks.create('integrationTest', RestTestRunnerTask.class)
+            Test integrationTest = project.tasks.create('integrationTest', StandaloneRestIntegTestTask.class)
             integrationTest.dependsOn(itestJar)
 
             itestJar.configure { Jar jar ->

--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/fixture/ElasticsearchFixturePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/fixture/ElasticsearchFixturePlugin.groovy
@@ -1,7 +1,7 @@
 package org.elasticsearch.hadoop.gradle.fixture
 
 import org.elasticsearch.gradle.testclusters.ElasticsearchCluster
-import org.elasticsearch.gradle.testclusters.RestTestRunnerTask
+import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask
 import org.elasticsearch.gradle.testclusters.TestClustersPlugin
 import org.elasticsearch.gradle.testclusters.TestDistribution
 import org.gradle.api.NamedDomainObjectContainer
@@ -29,7 +29,7 @@ class ElasticsearchFixturePlugin implements Plugin<Project> {
         // Optionally allow user to disable the fixture
         def useFixture = Boolean.parseBoolean(project.findProperty("tests.fixture.es.enable") ?: "true")
 
-        def integrationTestTask = project.tasks.getByName("integrationTest") as RestTestRunnerTask
+        def integrationTestTask = project.tasks.getByName("integrationTest") as StandaloneRestIntegTestTask
         if (useFixture) {
             // Depends on project already containing an "integrationTest"
             // task, as well as javaHome+runtimeJavaHome configured
@@ -39,7 +39,7 @@ class ElasticsearchFixturePlugin implements Plugin<Project> {
         }
     }
 
-    private static void createClusterFor(RestTestRunnerTask integrationTest, Project project, String version) {
+    private static void createClusterFor(StandaloneRestIntegTestTask integrationTest, Project project, String version) {
         def clustersContainer = project.extensions.getByName(TestClustersPlugin.EXTENSION_NAME) as NamedDomainObjectContainer<ElasticsearchCluster>
         def integTestCluster = clustersContainer.create("integTest") { ElasticsearchCluster cluster ->
             cluster.version = version


### PR DESCRIPTION
Some of our rest testing tasks were renamed as part of the refactoring done in https://github.com/elastic/elasticsearch/pull/60261. This broke the hadoop build as it still contains references to those old tasks. Right now this is only failing in our release builds due to the new `build-tools` jar not being published yet but we need to get those builds green to get the updated artifact published.