### PR TITLE
bugfix: when array value is not set, the default value contains one element - null value.

### DIFF
--- a/mr/src/main/java/org/elasticsearch/hadoop/serialization/ScrollReader.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/serialization/ScrollReader.java
@@ -981,7 +981,9 @@ public class ScrollReader implements Closeable {
         Object array = reader.createArray(mapping(fieldMapping, parser));
         // create only one element since with fields, we always get arrays which create unneeded allocations
         List<Object> content = new ArrayList<Object>(1);
-        content.add(value);
+        if (null != value) {
+            content.add(value);
+        }
         array = reader.addToArray(array, content);
         return array;
     }


### PR DESCRIPTION
bugfix：https://github.com/elastic/elasticsearch-hadoop/issues/1527

Thank you for submitting a pull request! 

Please make sure you have signed our [Contributor License Agreement (CLA)][].  
We are not asking you to assign copyright to us, but to give us the right to distribute your code without restriction. We ask this of all contributors in order to assure our users of the origin and continuing existence of the code.  
You only need to sign the CLA once.

- I have signed the [Contributor License Agreement (CLA)][]

[Contributor License Agreement (CLA)]: https://www.elastic.co/contributor-agreement/
