### PR TITLE
bugfix: when array value is not set, the default value contains one element - null value.

### DIFF
--- a/mr/src/main/java/org/elasticsearch/hadoop/serialization/ScrollReader.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/serialization/ScrollReader.java
@@ -981,7 +981,9 @@ public class ScrollReader implements Closeable {
         Object array = reader.createArray(mapping(fieldMapping, parser));
         // create only one element since with fields, we always get arrays which create unneeded allocations
         List<Object> content = new ArrayList<Object>(1);
-        content.add(value);
+        if (null != value) {
+            content.add(value);
+        }
         array = reader.addToArray(array, content);
         return array;
     }


### PR DESCRIPTION
bugfix ： https://github.com/elastic/elasticsearch-hadoop/issues/1527

- [x] I have signed the [Contributor License Agreement (CLA)][]