### PR TITLE
[7.9] [DOCS] Add 7.9.3 release notes (#1545)

### DIFF
--- a/docs/src/reference/asciidoc/appendix/release-notes/7.9.3.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/7.9.3.adoc
@@ -1,0 +1,5 @@
+[[eshadoop-7.9.3]]
+== Elasticsearch for Apache Hadoop version 7.9.3
+
+ES-Hadoop 7.9.3 is a version compatibility release, tested specifically against 
+Elasticsearch 7.9.3.

--- a/docs/src/reference/asciidoc/appendix/release.adoc
+++ b/docs/src/reference/asciidoc/appendix/release.adoc
@@ -9,6 +9,7 @@ This section summarizes the changes in each release.
 [[release-notes-7]]
 ===== 7.x
 
+* <<eshadoop-7.9.3>>
 * <<eshadoop-7.9.2>>
 * <<eshadoop-7.9.1>>
 * <<eshadoop-7.9.0>>
@@ -88,6 +89,7 @@ http://github.com/elastic/elasticsearch-hadoop/issues/XXX[#XXX]
 
 ////////////////////////
 
+include::release-notes/7.9.3.adoc[]
 include::release-notes/7.9.2.adoc[]
 include::release-notes/7.9.1.adoc[]
 include::release-notes/7.9.0.adoc[]


### PR DESCRIPTION
Backports the following commits to 7.9:
 - [DOCS] Add 7.9.3 release notes (#1545)