### PR TITLE
Fix attempt to apply property to task collection

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/fixture/ElasticsearchFixturePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/fixture/ElasticsearchFixturePlugin.groovy
@@ -37,7 +37,7 @@ class ElasticsearchFixturePlugin implements Plugin<Project> {
             // task, as well as javaHome+runtimeJavaHome configured
             createClusterFor(integrationTestTasks, project, version)
         } else {
-            integrationTestTasks.systemProperty("test.disable.local.es", "true")
+            integrationTestTasks.all { systemProperty("test.disable.local.es", "true") }
         }
     }
 


### PR DESCRIPTION
When running the hadoop build with `-PlocalRepo` as we do for release builds, it seems the integration test cluster tests are configured a bit differently. We are trying to call `systemProperty()` on a task _collection_ which of course won't work. I'm not sure how this ever worked or when this issue was introduced but in any case this sorts the problem out by just nesting the configuration in a call to `.all()`.

The issue was initially discovered in `7.x`, thus this PR but looking it seems the same problem exists in `master` so we'll likely need to port this there as well.