### PR TITLE
Update references to internal precommit plugins

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/BuildPlugin.groovy
@@ -2,9 +2,9 @@ package org.elasticsearch.hadoop.gradle
 
 import org.elasticsearch.gradle.DependenciesInfoPlugin
 import org.elasticsearch.gradle.info.BuildParams
-import org.elasticsearch.gradle.precommit.DependencyLicensesTask
-import org.elasticsearch.gradle.precommit.LicenseHeadersTask
-import org.elasticsearch.gradle.precommit.UpdateShasTask
+import org.elasticsearch.gradle.internal.precommit.DependencyLicensesTask
+import org.elasticsearch.gradle.internal.precommit.LicenseHeadersTask
+import org.elasticsearch.gradle.internal.precommit.UpdateShasTask
 import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask
 import org.elasticsearch.hadoop.gradle.scala.SparkVariantPlugin
 import org.gradle.api.Plugin


### PR DESCRIPTION
This pull request updates some references to refactored tasks in build-tools. Ironically, the cause here is that we are undergoing an effort in Elasticsearch to make better separation between "internal" and "external" build logic, specifically to minimize fallout to external users, such as es-hadoop. The root cause PR is https://github.com/elastic/elasticsearch/pull/65102.

@jbaiera essentially the new contract is that if you use stuff in an `internal` package we make no breaking changes guarantees. The preferred approach here would be to remove to dependencies on anything `internal` in build-tools. In fact, we eventually intend to remove that stuff entirely and simply not include them in the published build-tools jar.