### PR TITLE
[7.x] [DOCS] Fix links to Hadoop docs (#1564)

### DIFF
--- a/docs/src/reference/asciidoc/core/metrics.adoc
+++ b/docs/src/reference/asciidoc/core/metrics.adoc
@@ -1,7 +1,7 @@
 [[metrics]]
 == Hadoop Metrics
 
-The Hadoop system records a set of metric counters for each job that it runs. {eh} extends on that and provides metrics about its activity for each job run by leveraging the Hadoop http://hadoop.apache.org/docs/r2.2.0/api/org/apache/hadoop/mapred/Counters.html[Counters] infrastructure. During each run, {eh} sends statistics from each task instance, as it is running, which get aggregated by the {mr} infrastructure and are available through the standard Hadoop APIs.
+The Hadoop system records a set of metric counters for each job that it runs. {eh} extends on that and provides metrics about its activity for each job run by leveraging the Hadoop http://hadoop.apache.org/docs/r{hadoop-docs-v}/api/org/apache/hadoop/mapred/Counters.html[Counters] infrastructure. During each run, {eh} sends statistics from each task instance, as it is running, which get aggregated by the {mr} infrastructure and are available through the standard Hadoop APIs.
 
 {eh} provides the following counters, available under `org.elasticsearch.hadoop.mr.Counter` enum:
 
@@ -42,7 +42,7 @@ The Hadoop system records a set of metric counters for each job that it runs. {e
 
 |===
 
-One can use the counters programatically, depending on the API used, through http://hadoop.apache.org/docs/r2.2.0/api/index.html?org/apache/hadoop/mapred/Counters.html[mapred] or http://hadoop.apache.org/docs/r2.2.0/api/index.html?org/apache/hadoop/mapreduce/Counter.html[mapreduce]. Whatever the choice, {eh} performs automatic reports without any user intervention. In fact, when using {eh} one will see the stats reported at the end of the job run, for example:
+One can use the counters programatically, depending on the API used, through http://hadoop.apache.org/docs/r{hadoop-docs-v}/api/index.html?org/apache/hadoop/mapred/Counters.html[mapred] or http://hadoop.apache.org/docs/r{hadoop-docs-v}/api/index.html?org/apache/hadoop/mapreduce/Counter.html[mapreduce]. Whatever the choice, {eh} performs automatic reports without any user intervention. In fact, when using {eh} one will see the stats reported at the end of the job run, for example:
 
 [source, bash]
 ----

--- a/docs/src/reference/asciidoc/index.adoc
+++ b/docs/src/reference/asciidoc/index.adoc
@@ -15,6 +15,7 @@
 :pg-v:	0.15.0
 :hv-v:	1.2.1
 :cs-v:	2.6.3
+:hadoop-docs-v: 2.7.6
 
 include::{asciidoc-dir}/../../shared/versions/stack/{source_branch}.asciidoc[]
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Fix links to Hadoop docs (#1564)