### PR TITLE
[7.x] [DOCS] Add 7.11.0 release notes (#1569)

### DIFF
--- a/docs/src/reference/asciidoc/appendix/release-notes/7.11.0.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/7.11.0.adoc
@@ -1,0 +1,7 @@
+[[eshadoop-7.11.0]]
+== Elasticsearch for Apache Hadoop version 7.11.0
+
+coming::[7.11.0]
+
+ES-Hadoop 7.11.0 is a version compatibility release, tested specifically against
+Elasticsearch 7.11.0.

--- a/docs/src/reference/asciidoc/appendix/release.adoc
+++ b/docs/src/reference/asciidoc/appendix/release.adoc
@@ -9,6 +9,7 @@ This section summarizes the changes in each release.
 [[release-notes-7]]
 ===== 7.x
 
+* <<eshadoop-7.11.0>>
 * <<eshadoop-7.10.2>>
 * <<eshadoop-7.10.1>>
 * <<eshadoop-7.10.0>>
@@ -92,6 +93,7 @@ http://github.com/elastic/elasticsearch-hadoop/issues/XXX[#XXX]
 
 ////////////////////////
 
+include::release-notes/7.11.0.adoc[]
 include::release-notes/7.10.2.adoc[]
 include::release-notes/7.10.1.adoc[]
 include::release-notes/7.10.0.adoc[]


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Add 7.11.0 release notes (#1569)