### PR TITLE
Version bump to 7.10.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Available through any Maven-compatible tool:
 <dependency>
   <groupId>org.elasticsearch</groupId>
   <artifactId>elasticsearch-hadoop</artifactId>
-  <version>7.10.0</version>
+  <version>7.10.3</version>
 </dependency>
 ```
 or as a stand-alone [ZIP](http://www.elastic.co/downloads/hadoop).
@@ -38,7 +38,7 @@ Grab the latest nightly build from the [repository](http://oss.sonatype.org/cont
 <dependency>
   <groupId>org.elasticsearch</groupId>
   <artifactId>elasticsearch-hadoop</artifactId>
-  <version>7.10.2-SNAPSHOT</version>
+  <version>7.10.3-SNAPSHOT</version>
 </dependency>
 ```
 

--- a/buildSrc/esh-version.properties
+++ b/buildSrc/esh-version.properties
@@ -1,3 +1,3 @@
-eshadoop        = 7.10.2
-elasticsearch   = 7.10.2
-build-tools     = 7.10.2
+eshadoop        = 7.10.3
+elasticsearch   = 7.10.3
+build-tools     = 7.10.3


### PR DESCRIPTION
This makes the version bump to 7.10.3 as 7.10.2 was released just yesterday. Sorry for the delay