### PR TITLE
[7.x] Add properties for pulling java versions from the environment variables (#1584)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,10 @@
 ## Settings
 org.gradle.daemon=false
 
+# java homes resolved by environment variables
+org.gradle.java.installations.auto-detect=false
+org.gradle.java.installations.fromEnv=JAVA_HOME,RUNTIME_JAVA_HOME,JAVA15_HOME,JAVA14_HOME,JAVA13_HOME,JAVA12_HOME,JAVA11_HOME,JAVA8_HOME
+
 ## Dependecies Version
 # Logging
 log4jVersion = 2.6.2


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Add properties for pulling java versions from the environment variables (#1584)