### PR TITLE
Distinguish core Spark artifacts from each other

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/BuildPlugin.groovy
@@ -729,10 +729,13 @@ class BuildPlugin implements Plugin<Project>  {
     }
 
     private static void updateVariantPomLocationAndArtifactId(Project project, MavenPublication publication, SparkVariant variant) {
+        // Add variant classifier to the pom file name if required
+        String classifier = variant.shouldClassifySparkVersion() && variant.isDefaultVariant() == false ? "-${variant.getName()}" : ''
+        String filename = "${project.archivesBaseName}_${variant.scalaMajorVersion}-${project.getVersion()}${classifier}"
         // Fix the pom name
         project.tasks.withType(GenerateMavenPom).all { GenerateMavenPom pom ->
             if (pom.name == "generatePomFileFor${publication.name.capitalize()}Publication") {
-                pom.destination = project.provider({"${project.buildDir}/distributions/${project.archivesBaseName}_${variant.scalaMajorVersion}-${project.getVersion()}.pom"})
+                pom.destination = project.provider({"${project.buildDir}/distributions/${filename}.pom"})
             }
         }
         // Fix the artifactId. Note: The publishing task does not like this happening. Hence it is disabled.

--- a/spark/core/build.gradle
+++ b/spark/core/build.gradle
@@ -122,6 +122,23 @@ sparkVariants {
         scaladoc {
             title = "${rootProject.description} ${version} API"
         }
+
+        // The core project is strange since there are multiple variants with the same scala version present. They
+        // should be differentiated so they don't over write each other
+        def correctScalaJarClassifiers = { Jar jar ->
+            String classifier = jar.getArchiveClassifier().get()
+            if (classifier == null || classifier.isEmpty()) {
+                classifier = variant.name
+            } else {
+                classifier = "${variant.name}-${classifier}"
+            }
+            jar.getArchiveClassifier().set(classifier)
+        }
+
+        TaskCollection<Jar> jars = project.getTasks().withType(Jar.class)
+        correctScalaJarClassifiers(jars.getByName(variant.taskName("jar")))
+        correctScalaJarClassifiers(jars.getByName(variant.taskName("javadocJar")))
+        correctScalaJarClassifiers(jars.getByName(variant.taskName("sourcesJar")))
     }
 }
 

--- a/spark/core/build.gradle
+++ b/spark/core/build.gradle
@@ -9,10 +9,10 @@ apply plugin: 'spark.variants'
 
 sparkVariants {
     capabilityGroup 'org.elasticsearch.spark.variant'
-    setDefaultVariant "spark20scala211", spark24Version, scala211Version
-    addFeatureVariant "spark20scala210", spark22Version, scala210Version
-    addFeatureVariant "spark13scala211", spark13Version, scala211Version
-    addFeatureVariant "spark13scala210", spark13Version, scala210Version
+    setCoreDefaultVariant "spark20scala211", spark24Version, scala211Version
+    addCoreFeatureVariant "spark20scala210", spark22Version, scala210Version
+    addCoreFeatureVariant "spark13scala211", spark13Version, scala211Version
+    addCoreFeatureVariant "spark13scala210", spark13Version, scala210Version
 
     all { SparkVariantPlugin.SparkVariant variant ->
 
@@ -122,23 +122,6 @@ sparkVariants {
         scaladoc {
             title = "${rootProject.description} ${version} API"
         }
-
-        // The core project is strange since there are multiple variants with the same scala version present. They
-        // should be differentiated so they don't over write each other
-        def correctScalaJarClassifiers = { Jar jar ->
-            String classifier = jar.getArchiveClassifier().get()
-            if (classifier == null || classifier.isEmpty()) {
-                classifier = variant.name
-            } else {
-                classifier = "${variant.name}-${classifier}"
-            }
-            jar.getArchiveClassifier().set(classifier)
-        }
-
-        TaskCollection<Jar> jars = project.getTasks().withType(Jar.class)
-        correctScalaJarClassifiers(jars.getByName(variant.taskName("jar")))
-        correctScalaJarClassifiers(jars.getByName(variant.taskName("javadocJar")))
-        correctScalaJarClassifiers(jars.getByName(variant.taskName("sourcesJar")))
     }
 }
 


### PR DESCRIPTION
The new tooling for building Spark/Scala variants seems to have an issue with the core Spark project. This project contains multiple versions of Scala _and_ Spark. The artifacts produced from here are differentiated in name only by the version of Scala. This means that building for Spark 2.0 on 2.11 and Spark 1.6 on 2.11 would produce the same artifact name. Luckily, the core code does not change between these versions and no compatibility issues have yet been raised because of this bug.

This PR updates the Spark integration's core project to prepend the Spark version of its variant to the artifacts classifier as it normally would (we strip this out in the plugin code since the classifier is unneeded for the final products).