### PR TITLE
[7.x] Distinguish core Spark artifacts from each other (#1586)

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/BuildPlugin.groovy
@@ -729,10 +729,13 @@ class BuildPlugin implements Plugin<Project> {
     }
 
     private static void updateVariantPomLocationAndArtifactId(Project project, MavenPublication publication, SparkVariant variant) {
+        // Add variant classifier to the pom file name if required
+        String classifier = variant.shouldClassifySparkVersion() && variant.isDefaultVariant() == false ? "-${variant.getName()}" : ''
+        String filename = "${project.archivesBaseName}_${variant.scalaMajorVersion}-${project.getVersion()}${classifier}"
         // Fix the pom name
         project.tasks.withType(GenerateMavenPom).all { GenerateMavenPom pom ->
             if (pom.name == "generatePomFileFor${publication.name.capitalize()}Publication") {
-                pom.destination = project.provider({"${project.buildDir}/distributions/${project.archivesBaseName}_${variant.scalaMajorVersion}-${project.getVersion()}.pom"})
+                pom.destination = project.provider({"${project.buildDir}/distributions/${filename}.pom"})
             }
         }
         // Fix the artifactId. Note: The publishing task does not like this happening. Hence it is disabled.

--- a/spark/core/build.gradle
+++ b/spark/core/build.gradle
@@ -9,10 +9,10 @@ apply plugin: 'spark.variants'
 
 sparkVariants {
     capabilityGroup 'org.elasticsearch.spark.variant'
-    setDefaultVariant "spark20scala211", spark24Version, scala211Version
-    addFeatureVariant "spark20scala210", spark22Version, scala210Version
-    addFeatureVariant "spark13scala211", spark13Version, scala211Version
-    addFeatureVariant "spark13scala210", spark13Version, scala210Version
+    setCoreDefaultVariant "spark20scala211", spark24Version, scala211Version
+    addCoreFeatureVariant "spark20scala210", spark22Version, scala210Version
+    addCoreFeatureVariant "spark13scala211", spark13Version, scala211Version
+    addCoreFeatureVariant "spark13scala210", spark13Version, scala210Version
 
     all { SparkVariantPlugin.SparkVariant variant ->
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Distinguish core Spark artifacts from each other (#1586)