### PR TITLE
[master] [DOCS] Remove 7.11.0 coming tag (#1579)

### DIFF
--- a/docs/src/reference/asciidoc/appendix/release-notes/7.11.0.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/7.11.0.adoc
@@ -1,7 +1,5 @@
 [[eshadoop-7.11.0]]
 == Elasticsearch for Apache Hadoop version 7.11.0
 
-coming::[7.11.0]
-
 ES-Hadoop 7.11.0 is a version compatibility release, tested specifically against
 Elasticsearch 7.11.0.


### PR DESCRIPTION
Backports the following commits to master:
 - [DOCS] Remove 7.11.0 coming tag (#1579)