### PR TITLE
Fix Gradle deprecation warnings

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -66,16 +66,16 @@ repositories {
 }
 
 dependencies {
-    compile gradleApi()
-    compile localGroovy()
+    compileOnly gradleApi()
+    compileOnly localGroovy()
 
     if (localRepo) {
-        compile name: "build-tools-${buildToolsVersion}"
+        implementation name: "build-tools-${buildToolsVersion}"
         // Required for dependency licenses task (explicitly added in case of localRepo missing transitive dependencies)
-        compile group: 'commons-codec', name: 'commons-codec', version: '1.12'
-        compile group: 'org.apache.rat', name: 'apache-rat', version: '0.11'
+        implementation group: 'commons-codec', name: 'commons-codec', version: '1.12'
+        implementation group: 'org.apache.rat', name: 'apache-rat', version: '0.11'
     } else {
-        compile group: 'org.elasticsearch.gradle', name: 'build-tools', version: buildToolsVersion
+        implementation group: 'org.elasticsearch.gradle', name: 'build-tools', version: buildToolsVersion
     }
 }
 

--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/BaseBuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/BaseBuildPlugin.groovy
@@ -175,7 +175,7 @@ class BaseBuildPlugin implements Plugin<Project> {
         for (String repo : ['snapshots', 'artifacts']) {
             project.repositories.ivy {
                 url "https://${repo}.elastic.co/downloads"
-                layout "pattern", {
+                patternLayout {
                     artifact "elasticsearch/[module]-[revision](-[classifier]).[ext]"
                 }
             }

--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/RootBuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/RootBuildPlugin.groovy
@@ -68,13 +68,13 @@ class RootBuildPlugin implements Plugin<Project> {
         Zip distZip = project.getTasks().create('distZip', Zip.class)
         distZip.dependsOn(project.getTasks().getByName('pack'))
         distZip.setGroup('Distribution')
-        distZip.setDescription("Builds -${distZip.getClassifier()} archive, containing all jars and docs, suitable for download page.")
+        distZip.setDescription("Builds -${distZip.archiveClassifier.get()} archive, containing all jars and docs, suitable for download page.")
 
         Task distribution = project.getTasks().getByName('distribution')
         distribution.dependsOn(distZip)
 
         // Location of the zip dir
-        project.rootProject.ext.folderName = "${distZip.baseName}" + "-" + "${project.version}"
+        project.rootProject.ext.folderName = "${distZip.archiveBaseName.get()}" + "-" + "${project.version}"
 
         // Copy root directory files to zip
         distZip.from(project.rootDir) { CopySpec spec ->

--- a/buildSrc/src/main/java/org/elasticsearch/hadoop/gradle/scala/SparkVariantPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/hadoop/gradle/scala/SparkVariantPlugin.java
@@ -60,10 +60,10 @@ import static org.gradle.api.plugins.JavaBasePlugin.DOCUMENTATION_GROUP;
 import static org.gradle.api.plugins.JavaBasePlugin.VERIFICATION_GROUP;
 import static org.gradle.api.plugins.JavaPlugin.API_ELEMENTS_CONFIGURATION_NAME;
 import static org.gradle.api.plugins.JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME;
-import static org.gradle.api.plugins.JavaPlugin.COMPILE_CONFIGURATION_NAME;
+// import static org.gradle.api.plugins.JavaPlugin.COMPILE_CONFIGURATION_NAME;
 import static org.gradle.api.plugins.JavaPlugin.IMPLEMENTATION_CONFIGURATION_NAME;
 import static org.gradle.api.plugins.JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME;
-import static org.gradle.api.plugins.JavaPlugin.RUNTIME_CONFIGURATION_NAME;
+// import static org.gradle.api.plugins.JavaPlugin.RUNTIME_CONFIGURATION_NAME;
 import static org.gradle.api.plugins.JavaPlugin.RUNTIME_ELEMENTS_CONFIGURATION_NAME;
 import static org.gradle.api.plugins.JavaPlugin.RUNTIME_ONLY_CONFIGURATION_NAME;
 import static org.gradle.api.plugins.JavaPlugin.TEST_TASK_NAME;
@@ -282,9 +282,9 @@ public class SparkVariantPlugin implements Plugin<Project> {
 
     // TODO: address deprecated configuration names
     private static List<String> TEST_CONFIGURATIONS_EXTENDED = Arrays.asList(
-            COMPILE_CONFIGURATION_NAME,
+           // TODO compile only
             IMPLEMENTATION_CONFIGURATION_NAME,
-            RUNTIME_CONFIGURATION_NAME,
+            // RUNTIME_CONFIGURATION_NAME,
             RUNTIME_ONLY_CONFIGURATION_NAME
     );
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,6 @@
+# Enforce the build to fail on deprecated gradle api usage
+systemProp.org.gradle.warning.mode=fail
+
 ## Settings
 org.gradle.daemon=false
 


### PR DESCRIPTION
This PR is fixing a few gradle deprecation warnings as preparation for migrating the build to Gradle 7.0.
We plan to migrate the elasticsearch build to Gradle 7.0 as soon as it is released and to keep elasticsearch-hadoop close 
we have to ensure this project works well with Gradle 7.0.

 
- [ X] I have signed the [Contributor License Agreement (CLA)][]

[Contributor License Agreement (CLA)]: https://www.elastic.co/contributor-agreement/
