### PR TITLE
New Data Tiers role support

### DIFF
--- a/mr/src/main/java/org/elasticsearch/hadoop/serialization/dto/NodeInfo.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/serialization/dto/NodeInfo.java
@@ -58,8 +58,8 @@ public class NodeInfo implements Serializable {
             this.isIngest = false;
         } else {
             List<String> roles = (List<String>) map.get("roles");
-            this.isClient = roles.contains("data") == false;
-            this.isData = roles.contains("data");
+            this.isData = roles.stream().anyMatch(role -> role.contains("data"));
+            this.isClient = !this.isData;
             this.isIngest = roles.contains("ingest");
         }
         Map<String, Object> httpMap = (Map<String, Object>) map.get("http");


### PR DESCRIPTION
Should adress https://github.com/elastic/elasticsearch-hadoop/issues/1612

I am just proposing this PR, but feel free to trash it and be more explicit (introduce a list of valid `data` roles).

It's missing unit tests.