### PR TITLE
[7.x] [DOCS] Add 7.12.0 release notes (#1610)

### DIFF
--- a/docs/src/reference/asciidoc/appendix/release-notes/7.12.0.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/7.12.0.adoc
@@ -1,0 +1,24 @@
+[[eshadoop-7.12.0]]
+== Elasticsearch for Apache Hadoop version 7.12.0
+
+coming::[7.12.0]
+
+[[new-7.12.0]]
+=== Enhancements
+
+Build::
+- Update Gradle wrapper to version 6.8
+https://github.com/elastic/elasticsearch-hadoop/pull/1578[#1578]
+
+Spark::
+- Add support for Spark 3.0 
+https://github.com/elastic/elasticsearch-hadoop/pull/1592[#1592]
+- Add support for Spark integration on Scala 2.12
+https://github.com/elastic/elasticsearch-hadoop/pull/1589[#1589]
+
+[[bugs-7.12.0]]
+=== Bug Fixes
+
+Build::
+- Add properties for pulling Java versions from the environment variables
+https://github.com/elastic/elasticsearch-hadoop/pull/1584[#1584]

--- a/docs/src/reference/asciidoc/appendix/release.adoc
+++ b/docs/src/reference/asciidoc/appendix/release.adoc
@@ -9,6 +9,7 @@ This section summarizes the changes in each release.
 [[release-notes-7]]
 ===== 7.x
 
+* <<eshadoop-7.12.0>>
 * <<eshadoop-7.11.2>>
 * <<eshadoop-7.11.1>>
 * <<eshadoop-7.11.0>>
@@ -95,6 +96,7 @@ http://github.com/elastic/elasticsearch-hadoop/issues/XXX[#XXX]
 
 ////////////////////////
 
+include::release-notes/7.12.0.adoc[]
 include::release-notes/7.11.2.adoc[]
 include::release-notes/7.11.1.adoc[]
 include::release-notes/7.11.0.adoc[]


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Add 7.12.0 release notes (#1610)