### PR TITLE
[master] [DOCS] Remove 7.12.0 coming tag (#1627)

### DIFF
--- a/docs/src/reference/asciidoc/appendix/release-notes/7.12.0.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/7.12.0.adoc
@@ -1,8 +1,6 @@
 [[eshadoop-7.12.0]]
 == Elasticsearch for Apache Hadoop version 7.12.0
 
-coming::[7.12.0]
-
 [[new-7.12.0]]
 === Enhancements
 


### PR DESCRIPTION
Backports the following commits to master:
 - [DOCS] Remove 7.12.0 coming tag (#1627)