### PR TITLE
[DOCS] Update breaking changes

### DIFF
--- a/docs/src/reference/asciidoc/appendix/breaking.adoc
+++ b/docs/src/reference/asciidoc/appendix/breaking.adoc
@@ -12,9 +12,13 @@ For clarity, we always list any breaking changes at the top of the
 
 //NOTE: The notable-breaking-changes tagged regions are re-used in the
 //Installation and Upgrade Guide
+////
 // tag::notable-v7-breaking-changes[]
 
+There are no breaking changes in {minor-version}.
+
 // end::notable-v7-breaking-changes[]
+////
 
 [[breaking-changes-7.0]]
 === Breaking Changes in 7.0


### PR DESCRIPTION
This PR adds a sentence to the breaking changes, such that it's clear there are no breaking changes in the current release. This information can then be pulled into the Installation and Upgrade Guide (https://www.elastic.co/guide/en/elastic-stack/7.12/elasticsearch-hadoop-breaking-changes.html).
