### PR TITLE
Update Gradle wrapper to 7.0

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -53,9 +53,8 @@ props.put("elasticsearch", esVersion)
 props.put("build-tools", buildToolsVersion)
 
 repositories {
-    jcenter()
+    gradlePluginPortal()
     mavenCentral()
-
     // For Elasticsearch snapshots.
     if (localRepo) {
         // For some reason the root dirs all point to the buildSrc folder. The local Repo will be one above that.

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/qa/build.gradle
+++ b/qa/build.gradle
@@ -33,7 +33,7 @@ subprojects {
     buildscript {
         boolean localRepo = project.getProperties().containsKey("localRepo")
         repositories {
-            jcenter()
+            gradlePluginPortal()
             mavenCentral()
             if (localRepo) {
                 // For some reason the root dirs all point to the buildSrc folder. The local Repo will be one above that.


### PR DESCRIPTION
This updates this build to use Gradle 7.0 and stay compliant with the latest build-tool changes done to make build tools 7.0 compliant. This PR will pass as soon as https://github.com/elastic/elasticsearch/pull/68506 is merged into master as Gradle 7.0 introduced a breaking change on Gradle JVM resolve logic used by the `GlobalBuildInfoPlugin`.


- [x ] I have signed the [Contributor License Agreement (CLA)][]

[Contributor License Agreement (CLA)]: https://www.elastic.co/contributor-agreement/
