### PR TITLE
Set explicit duplicatesStrategy for all Copy and Archive Gradle tasks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,9 @@ defaultTasks 'build'
 
 allprojects {
     group = "org.elasticsearch"
+    tasks.withType(AbstractCopyTask) {
+      duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+    }
 }
 
 // Simple utility task to help with downloading artifacts and jars


### PR DESCRIPTION
Gradle 7.0 changed the default duplicates Strategy to error when duplicates for
a copy or archive operations are detected. This leads to the build to fail
as the elasticsearch hadoop project relied on ignoring duplicates. With this change
we set the duplicatesStrategy for every related task to EXCLUDE

This unblocks the unified release process that currently fails with an error caused by 
duplicates entries for javadocJar.

- [X ] I have signed the [Contributor License Agreement (CLA)][]

[Contributor License Agreement (CLA)]: https://www.elastic.co/contributor-agreement/
