### PR TITLE
[7.x] [DOCS] Add 7.12.1 release notes (#1645)

### DIFF
--- a/docs/src/reference/asciidoc/appendix/release-notes/7.12.1.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/7.12.1.adoc
@@ -1,0 +1,7 @@
+[[eshadoop-7.12.1]]
+== Elasticsearch for Apache Hadoop version 7.12.1
+
+coming::[7.12.1]
+
+ES-Hadoop 7.12.1 is a version compatibility release, tested specifically against
+Elasticsearch 7.12.1.

--- a/docs/src/reference/asciidoc/appendix/release.adoc
+++ b/docs/src/reference/asciidoc/appendix/release.adoc
@@ -9,6 +9,7 @@ This section summarizes the changes in each release.
 [[release-notes-7]]
 ===== 7.x
 
+* <<eshadoop-7.12.1>>
 * <<eshadoop-7.12.0>>
 * <<eshadoop-7.11.2>>
 * <<eshadoop-7.11.1>>
@@ -96,6 +97,7 @@ http://github.com/elastic/elasticsearch-hadoop/issues/XXX[#XXX]
 
 ////////////////////////
 
+include::release-notes/7.12.1.adoc[]
 include::release-notes/7.12.0.adoc[]
 include::release-notes/7.11.2.adoc[]
 include::release-notes/7.11.1.adoc[]


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Add 7.12.1 release notes (#1645)