### PR TITLE
Do not rely on internal build tool logic

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-import org.elasticsearch.gradle.ConcatFilesTask
+import org.elasticsearch.hadoop.gradle.buildtools.ConcatFilesTask
 
 description = 'Elasticsearch for Apache Hadoop'
 

--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/BaseBuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/BaseBuildPlugin.groovy
@@ -19,9 +19,9 @@
 
 package org.elasticsearch.hadoop.gradle
 
-import org.elasticsearch.gradle.info.BuildParams
-import org.elasticsearch.gradle.info.GlobalBuildInfoPlugin
-import org.elasticsearch.gradle.info.JavaHome
+import org.elasticsearch.hadoop.gradle.buildtools.info.BuildParams
+import org.elasticsearch.hadoop.gradle.buildtools.info.GlobalBuildInfoPlugin
+import org.elasticsearch.hadoop.gradle.buildtools.info.JavaHome
 import org.elasticsearch.hadoop.gradle.util.Resources
 import org.gradle.api.GradleException
 import org.gradle.api.JavaVersion

--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/BuildPlugin.groovy
@@ -1,3 +1,22 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.elasticsearch.hadoop.gradle
 
 import org.elasticsearch.hadoop.gradle.buildtools.DependenciesInfoPlugin

--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/BuildPlugin.groovy
@@ -1,11 +1,11 @@
 package org.elasticsearch.hadoop.gradle
 
-import org.elasticsearch.gradle.DependenciesInfoPlugin
-import org.elasticsearch.gradle.info.BuildParams
-import org.elasticsearch.gradle.internal.precommit.DependencyLicensesTask
-import org.elasticsearch.gradle.internal.precommit.LicenseHeadersTask
-import org.elasticsearch.gradle.internal.precommit.UpdateShasTask
-import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask
+import org.elasticsearch.hadoop.gradle.buildtools.DependenciesInfoPlugin
+import org.elasticsearch.hadoop.gradle.buildtools.DependencyLicensesTask
+import org.elasticsearch.hadoop.gradle.buildtools.LicenseHeadersTask
+import org.elasticsearch.hadoop.gradle.buildtools.StandaloneRestIntegTestTask
+import org.elasticsearch.hadoop.gradle.buildtools.UpdateShasTask
+import org.elasticsearch.hadoop.gradle.buildtools.info.BuildParams
 import org.elasticsearch.hadoop.gradle.scala.SparkVariantPlugin
 import org.gradle.api.Plugin
 import org.gradle.api.Project

--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/EshVersionProperties.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/EshVersionProperties.groovy
@@ -1,3 +1,22 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.elasticsearch.hadoop.gradle
 
 /**

--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/IntegrationBuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/IntegrationBuildPlugin.groovy
@@ -1,3 +1,22 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.elasticsearch.hadoop.gradle
 
 import org.gradle.api.Plugin

--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/RootBuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/RootBuildPlugin.groovy
@@ -1,3 +1,22 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.elasticsearch.hadoop.gradle
 
 import org.gradle.api.GradleException

--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/buildtools/AntFixture.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/buildtools/AntFixture.groovy
@@ -1,0 +1,281 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.hadoop.gradle.buildtools
+
+import org.apache.tools.ant.taskdefs.condition.Os
+import org.gradle.api.GradleException
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.TaskProvider
+
+/**
+ * A fixture for integration tests which runs in a separate process launched by Ant.
+ */
+class AntFixture extends AntTask implements Fixture {
+
+    /** The path to the executable that starts the fixture. */
+    @Internal
+    String executable
+
+    private final List<Object> arguments = new ArrayList<>()
+
+    void args(Object... args) {
+        arguments.addAll(args)
+    }
+
+    /**
+     * Environment variables for the fixture process. The value can be any object, which
+     * will have toString() called at execution time.
+     */
+    private final Map<String, Object> environment = new HashMap<>()
+
+    void env(String key, Object value) {
+        environment.put(key, value)
+    }
+
+    /** A flag to indicate whether the command should be executed from a shell. */
+    @Internal
+    boolean useShell = false
+
+    @Internal
+    int maxWaitInSeconds = 30
+
+    /**
+     * A flag to indicate whether the fixture should be run in the foreground, or spawned.
+     * It is protected so subclasses can override (eg RunTask).
+     */
+    protected boolean spawn = true
+
+    /**
+     * A closure to call before the fixture is considered ready. The closure is passed the fixture object,
+     * as well as a groovy AntBuilder, to enable running ant condition checks. The default wait
+     * condition is for http on the http port.
+     */
+    @Internal
+    Closure waitCondition = { AntFixture fixture, AntBuilder ant ->
+        File tmpFile = new File(fixture.cwd, 'wait.success')
+        ant.get(src: "http://${fixture.addressAndPort}",
+                dest: tmpFile.toString(),
+                ignoreerrors: true, // do not fail on error, so logging information can be flushed
+                retries: 10)
+        return tmpFile.exists()
+    }
+
+    private final TaskProvider<AntFixtureStop> stopTask
+
+    AntFixture() {
+        stopTask = createStopTask()
+        finalizedBy(stopTask)
+    }
+
+    @Override
+    @Internal
+    TaskProvider<AntFixtureStop> getStopTask() {
+        return stopTask
+    }
+
+    @Override
+    protected void runAnt(AntBuilder ant) {
+        // reset everything
+        getFileSystemOperations().delete {
+            it.delete(baseDir)
+        }
+        cwd.mkdirs()
+        final String realExecutable
+        final List<Object> realArgs = new ArrayList<>()
+        final Map<String, Object> realEnv = environment
+        // We need to choose which executable we are using. In shell mode, or when we
+        // are spawning and thus using the wrapper script, the executable is the shell.
+        if (useShell || spawn) {
+            if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+                realExecutable = 'cmd'
+                realArgs.add('/C')
+                realArgs.add('"') // quote the entire command
+            } else {
+                realExecutable = 'sh'
+            }
+        } else {
+            realExecutable = executable
+            realArgs.addAll(arguments)
+        }
+        if (spawn) {
+            writeWrapperScript(executable)
+            realArgs.add(wrapperScript)
+            realArgs.addAll(arguments)
+        }
+        if (Os.isFamily(Os.FAMILY_WINDOWS) && (useShell || spawn)) {
+            realArgs.add('"')
+        }
+        commandString.eachLine { line -> logger.info(line) }
+
+        ant.exec(executable: realExecutable, spawn: spawn, dir: cwd, taskname: name) {
+            realEnv.each { key, value -> env(key: key, value: value) }
+            realArgs.each { arg(value: it) }
+        }
+
+        String failedProp = "failed${name}"
+        // first wait for resources, or the failure marker from the wrapper script
+        ant.waitfor(maxwait: maxWaitInSeconds, maxwaitunit: 'second', checkevery: '500', checkeveryunit: 'millisecond', timeoutproperty: failedProp) {
+            or {
+                resourceexists {
+                    file(file: failureMarker.toString())
+                }
+                and {
+                    resourceexists {
+                        file(file: pidFile.toString())
+                    }
+                    resourceexists {
+                        file(file: portsFile.toString())
+                    }
+                }
+            }
+        }
+
+        if (ant.project.getProperty(failedProp) || failureMarker.exists()) {
+            fail("Failed to start ${name}")
+        }
+
+        // the process is started (has a pid) and is bound to a network interface
+        // so now evaluates if the waitCondition is successful
+        // TODO: change this to a loop?
+        boolean success
+        try {
+            success = waitCondition(this, ant)
+        } catch (Exception e) {
+            String msg = "Wait condition caught exception for ${name}"
+            logger.error(msg, e)
+            fail(msg, e)
+        }
+        if (success == false) {
+            fail("Wait condition failed for ${name}")
+        }
+    }
+
+    /** Returns a debug string used to log information about how the fixture was run. */
+    @Internal
+    protected String getCommandString() {
+        String commandString = "\n${name} configuration:\n"
+        commandString += "-----------------------------------------\n"
+        commandString += "  cwd: ${cwd}\n"
+        commandString += "  command: ${executable} ${arguments.join(' ')}\n"
+        commandString += '  environment:\n'
+        environment.each { k, v -> commandString += "    ${k}: ${v}\n" }
+        if (spawn) {
+            commandString += "\n  [${wrapperScript.name}]\n"
+            wrapperScript.eachLine('UTF-8', { line -> commandString += "    ${line}\n"})
+        }
+        return commandString
+    }
+
+    /**
+     * Writes a script to run the real executable, so that stdout/stderr can be captured.
+     * TODO: this could be removed if we do use our own ProcessBuilder and pump output from the process
+     */
+    private void writeWrapperScript(String executable) {
+        wrapperScript.parentFile.mkdirs()
+        String argsPasser = '"$@"'
+        String exitMarker = "; if [ \$? != 0 ]; then touch run.failed; fi"
+        if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+            argsPasser = '%*'
+            exitMarker = "\r\n if \"%errorlevel%\" neq \"0\" ( type nul >> run.failed )"
+        }
+        wrapperScript.setText("\"${executable}\" ${argsPasser} > run.log 2>&1 ${exitMarker}", 'UTF-8')
+    }
+
+    /** Fail the build with the given message, and logging relevant info*/
+    private void fail(String msg, Exception... suppressed) {
+        if (logger.isInfoEnabled() == false) {
+            // We already log the command at info level. No need to do it twice.
+            commandString.eachLine { line -> logger.error(line) }
+        }
+        logger.error("${name} output:")
+        logger.error("-----------------------------------------")
+        logger.error("  failure marker exists: ${failureMarker.exists()}")
+        logger.error("  pid file exists: ${pidFile.exists()}")
+        logger.error("  ports file exists: ${portsFile.exists()}")
+        // also dump the log file for the startup script (which will include ES logging output to stdout)
+        if (runLog.exists()) {
+            logger.error("\n  [log]")
+            runLog.eachLine { line -> logger.error("    ${line}") }
+        }
+        logger.error("-----------------------------------------")
+        GradleException toThrow = new GradleException(msg)
+        for (Exception e : suppressed) {
+            toThrow.addSuppressed(e)
+        }
+        throw toThrow
+    }
+
+    /** Adds a task to kill an elasticsearch node with the given pidfile */
+    private TaskProvider<AntFixtureStop> createStopTask() {
+        final AntFixture fixture = this
+        TaskProvider<AntFixtureStop> stop = project.tasks.register("${name}#stop", AntFixtureStop)
+        stop.configure {
+            it.fixture = fixture
+        }
+        fixture.finalizedBy(stop)
+        return stop
+    }
+
+    /**
+     * A path relative to the build dir that all configuration and runtime files
+     * will live in for this fixture
+     */
+    @Internal
+    protected File getBaseDir() {
+        return new File(project.buildDir, "fixtures/${name}")
+    }
+
+    /** Returns the working directory for the process. Defaults to "cwd" inside baseDir. */
+    @Internal
+    protected File getCwd() {
+        return new File(baseDir, 'cwd')
+    }
+
+    /** Returns the file the process writes its pid to. Defaults to "pid" inside baseDir. */
+    @Internal
+    protected File getPidFile() {
+        return new File(baseDir, 'pid')
+    }
+
+    /** Reads the pid file and returns the process' pid */
+    @Internal
+    int getPid() {
+        return Integer.parseInt(pidFile.getText('UTF-8').trim())
+    }
+
+    /** Returns the file the process writes its bound ports to. Defaults to "ports" inside baseDir. */
+    @Internal
+    protected File getPortsFile() {
+        return new File(baseDir, 'ports')
+    }
+
+    /** Returns an address and port suitable for a uri to connect to this node over http */
+    @Internal
+    String getAddressAndPort() {
+        return portsFile.readLines("UTF-8").get(0)
+    }
+
+    /** Returns a file that wraps around the actual command when {@code spawn == true}. */
+    @Internal
+    protected File getWrapperScript() {
+        return new File(cwd, Os.isFamily(Os.FAMILY_WINDOWS) ? 'run.bat' : 'run')
+    }
+
+    /** Returns a file that the wrapper script writes when the command failed. */
+    @Internal
+    protected File getFailureMarker() {
+        return new File(cwd, 'run.failed')
+    }
+
+    /** Returns a file that the wrapper script writes when the command failed. */
+    @Internal
+    protected File getRunLog() {
+        return new File(cwd, 'run.log')
+    }
+}

--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/buildtools/AntFixture.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/buildtools/AntFixture.groovy
@@ -1,9 +1,20 @@
 /*
- * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License
- * 2.0 and the Server Side Public License, v 1; you may not use this file except
- * in compliance with, at your election, the Elastic License 2.0 or the Server
- * Side Public License, v 1.
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.elasticsearch.hadoop.gradle.buildtools

--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/buildtools/AntFixtureStop.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/buildtools/AntFixtureStop.groovy
@@ -1,9 +1,20 @@
 /*
- * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License
- * 2.0 and the Server Side Public License, v 1; you may not use this file except
- * in compliance with, at your election, the Elastic License 2.0 or the Server
- * Side Public License, v 1.
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.elasticsearch.hadoop.gradle.buildtools

--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/buildtools/AntFixtureStop.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/buildtools/AntFixtureStop.groovy
@@ -1,0 +1,54 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.hadoop.gradle.buildtools
+
+import org.apache.tools.ant.taskdefs.condition.Os
+import org.gradle.api.file.FileSystemOperations
+import org.gradle.api.tasks.Internal
+
+import javax.inject.Inject
+
+class AntFixtureStop extends LoggedExec {
+
+    @Internal
+    AntFixture fixture
+
+    @Internal
+    FileSystemOperations fileSystemOperations
+
+    @Inject
+    AntFixtureStop(FileSystemOperations fileSystemOperations) {
+        super(fileSystemOperations)
+        this.fileSystemOperations = fileSystemOperations
+    }
+
+    void setFixture(AntFixture fixture) {
+        assert this.fixture == null
+        this.fixture = fixture;
+        final Object pid = "${ -> this.fixture.pid }"
+        onlyIf { fixture.pidFile.exists() }
+        doFirst {
+            logger.info("Shutting down ${fixture.name} with pid ${pid}")
+        }
+
+        if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+            executable = 'Taskkill'
+            args('/PID', pid, '/F')
+        } else {
+            executable = 'kill'
+            args('-9', pid)
+        }
+        doLast {
+            fileSystemOperations.delete {
+                it.delete(fixture.pidFile)
+            }
+        }
+        this.fixture = fixture
+    }
+}

--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/buildtools/AntTask.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/buildtools/AntTask.groovy
@@ -1,0 +1,95 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.hadoop.gradle.buildtools
+
+import org.apache.tools.ant.BuildListener
+import org.apache.tools.ant.BuildLogger
+import org.apache.tools.ant.DefaultLogger
+import org.apache.tools.ant.Project
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.FileSystemOperations
+import org.gradle.api.tasks.TaskAction
+
+import javax.inject.Inject
+import java.nio.charset.Charset
+
+/**
+ * A task which will run ant commands.
+ *
+ * Logging for the task is customizable for subclasses by overriding makeLogger.
+ */
+abstract class AntTask extends DefaultTask {
+
+    /**
+     * A buffer that will contain the output of the ant code run,
+     * if the output was not already written directly to stdout.
+     */
+    public final ByteArrayOutputStream outputBuffer = new ByteArrayOutputStream()
+
+    @Inject
+    protected FileSystemOperations getFileSystemOperations() {
+        throw new UnsupportedOperationException();
+    }
+
+    @TaskAction
+    final void executeTask() {
+        AntBuilder ant = new AntBuilder()
+
+        // remove existing loggers, we add our own
+        List<BuildLogger> toRemove = new ArrayList<>();
+        for (BuildListener listener : ant.project.getBuildListeners()) {
+            if (listener instanceof BuildLogger) {
+                toRemove.add(listener);
+            }
+        }
+        for (BuildLogger listener : toRemove) {
+            ant.project.removeBuildListener(listener)
+        }
+
+        // otherwise groovy replaces System.out, and you have no chance to debug
+        // ant.saveStreams = false
+
+        final int outputLevel = logger.isDebugEnabled() ? Project.MSG_DEBUG : Project.MSG_INFO
+        final PrintStream stream = useStdout() ? System.out : new PrintStream(outputBuffer, true, Charset.defaultCharset().name())
+        BuildLogger antLogger = makeLogger(stream, outputLevel)
+
+        ant.project.addBuildListener(antLogger)
+        try {
+            runAnt(ant)
+        } catch (Exception e) {
+            // ant failed, so see if we have buffered output to emit, then rethrow the failure
+            String buffer = outputBuffer.toString()
+            if (buffer.isEmpty() == false) {
+                logger.error("=== Ant output ===\n${buffer}")
+            }
+            throw e
+        }
+    }
+
+    /** Runs the doAnt closure. This can be overridden by subclasses instead of having to set a closure. */
+    protected abstract void runAnt(AntBuilder ant)
+
+    /** Create the logger the ant runner will use, with the given stream for error/output. */
+    protected BuildLogger makeLogger(PrintStream stream, int outputLevel) {
+        return new DefaultLogger(
+            errorPrintStream: stream,
+            outputPrintStream: stream,
+            messageOutputLevel: outputLevel)
+    }
+
+    /**
+     * Returns true if the ant logger should write to stdout, or false if to the buffer.
+     * The default implementation writes to the buffer when gradle info logging is disabled.
+     */
+    protected boolean useStdout() {
+        return logger.isInfoEnabled()
+    }
+
+
+}

--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/buildtools/AntTask.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/buildtools/AntTask.groovy
@@ -1,9 +1,20 @@
 /*
- * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License
- * 2.0 and the Server Side Public License, v 1; you may not use this file except
- * in compliance with, at your election, the Elastic License 2.0 or the Server
- * Side Public License, v 1.
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.elasticsearch.hadoop.gradle.buildtools

--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/fixture/ElasticsearchFixturePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/fixture/ElasticsearchFixturePlugin.groovy
@@ -1,3 +1,22 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.elasticsearch.hadoop.gradle.fixture
 
 import org.elasticsearch.gradle.testclusters.ElasticsearchCluster

--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/fixture/hadoop/HadoopClusterFormationTasks.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/fixture/hadoop/HadoopClusterFormationTasks.groovy
@@ -20,10 +20,10 @@
 package org.elasticsearch.hadoop.gradle.fixture.hadoop
 
 import org.apache.tools.ant.DefaultLogger
-import org.elasticsearch.gradle.LoggedExec
 import org.elasticsearch.gradle.Version
-import org.elasticsearch.gradle.test.Fixture
 import org.elasticsearch.gradle.testclusters.DefaultTestClustersTask
+import org.elasticsearch.hadoop.gradle.buildtools.Fixture
+import org.elasticsearch.hadoop.gradle.buildtools.LoggedExec
 import org.elasticsearch.hadoop.gradle.fixture.hadoop.conf.HadoopClusterConfiguration
 import org.elasticsearch.hadoop.gradle.fixture.hadoop.conf.InstanceConfiguration
 import org.elasticsearch.hadoop.gradle.fixture.hadoop.conf.RoleConfiguration

--- a/buildSrc/src/main/java/org/elasticsearch/hadoop/gradle/buildtools/ConcatFilesTask.java
+++ b/buildSrc/src/main/java/org/elasticsearch/hadoop/gradle/buildtools/ConcatFilesTask.java
@@ -1,9 +1,20 @@
 /*
- * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License
- * 2.0 and the Server Side Public License, v 1; you may not use this file except
- * in compliance with, at your election, the Elastic License 2.0 or the Server
- * Side Public License, v 1.
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 package org.elasticsearch.hadoop.gradle.buildtools;
 

--- a/buildSrc/src/main/java/org/elasticsearch/hadoop/gradle/buildtools/ConcatFilesTask.java
+++ b/buildSrc/src/main/java/org/elasticsearch/hadoop/gradle/buildtools/ConcatFilesTask.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+package org.elasticsearch.hadoop.gradle.buildtools;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.file.FileTree;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.InputFiles;
+import org.gradle.api.tasks.Optional;
+import org.gradle.api.tasks.OutputFile;
+import org.gradle.api.tasks.TaskAction;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+
+/**
+ * Concatenates a list of files into one and removes duplicate lines.
+ */
+public class ConcatFilesTask extends DefaultTask {
+
+    public ConcatFilesTask() {
+        setDescription("Concat a list of files into one.");
+    }
+
+    /** List of files to concatenate */
+    private FileTree files;
+
+    /** line to add at the top of the target file */
+    private String headerLine;
+
+    private File target;
+
+    private List<String> additionalLines = new ArrayList<>();
+
+    public void setFiles(FileTree files) {
+        this.files = files;
+    }
+
+    @InputFiles
+    public FileTree getFiles() {
+        return files;
+    }
+
+    public void setHeaderLine(String headerLine) {
+        this.headerLine = headerLine;
+    }
+
+    @Input
+    @Optional
+    public String getHeaderLine() {
+        return headerLine;
+    }
+
+    public void setTarget(File target) {
+        this.target = target;
+    }
+
+    @OutputFile
+    public File getTarget() {
+        return target;
+    }
+
+    @Input
+    public List<String> getAdditionalLines() {
+        return additionalLines;
+    }
+
+    public void setAdditionalLines(List<String> additionalLines) {
+        this.additionalLines = additionalLines;
+    }
+
+    @TaskAction
+    public void concatFiles() throws IOException {
+        if (getHeaderLine() != null) {
+            Files.write(getTarget().toPath(), (getHeaderLine() + '\n').getBytes(StandardCharsets.UTF_8));
+        }
+
+        // To remove duplicate lines
+        LinkedHashSet<String> uniqueLines = new LinkedHashSet<>();
+        for (File f : getFiles()) {
+            uniqueLines.addAll(Files.readAllLines(f.toPath(), StandardCharsets.UTF_8));
+        }
+        Files.write(getTarget().toPath(), uniqueLines, StandardCharsets.UTF_8, StandardOpenOption.APPEND);
+
+        for (String additionalLine : additionalLines) {
+            Files.write(getTarget().toPath(), (additionalLine + '\n').getBytes(StandardCharsets.UTF_8), StandardOpenOption.APPEND);
+        }
+    }
+
+}

--- a/buildSrc/src/main/java/org/elasticsearch/hadoop/gradle/buildtools/DependenciesInfoPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/hadoop/gradle/buildtools/DependenciesInfoPlugin.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.hadoop.gradle.buildtools;
+
+import org.elasticsearch.gradle.dependencies.CompileOnlyResolvePlugin;
+import org.elasticsearch.gradle.internal.precommit.DependencyLicensesTask;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.plugins.JavaPlugin;
+
+public class DependenciesInfoPlugin implements Plugin<Project> {
+    @Override
+    public void apply(final Project project) {
+        project.getPlugins().apply(CompileOnlyResolvePlugin.class);
+        var depsInfo = project.getTasks().register("dependenciesInfo", DependenciesInfoTask.class);
+        depsInfo.configure(t -> {
+            t.setRuntimeConfiguration(project.getConfigurations().getByName(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME));
+            t.setCompileOnlyConfiguration(
+                project.getConfigurations().getByName(CompileOnlyResolvePlugin.RESOLVEABLE_COMPILE_ONLY_CONFIGURATION_NAME)
+            );
+            t.getConventionMapping().map("mappings", () -> {
+                var depLic = project.getTasks().named("dependencyLicenses", DependencyLicensesTask.class);
+                return depLic.get().getMappings();
+            });
+        });
+    }
+
+}

--- a/buildSrc/src/main/java/org/elasticsearch/hadoop/gradle/buildtools/DependenciesInfoPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/hadoop/gradle/buildtools/DependenciesInfoPlugin.java
@@ -1,9 +1,20 @@
 /*
- * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License
- * 2.0 and the Server Side Public License, v 1; you may not use this file except
- * in compliance with, at your election, the Elastic License 2.0 or the Server
- * Side Public License, v 1.
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.elasticsearch.hadoop.gradle.buildtools;

--- a/buildSrc/src/main/java/org/elasticsearch/hadoop/gradle/buildtools/DependenciesInfoTask.java
+++ b/buildSrc/src/main/java/org/elasticsearch/hadoop/gradle/buildtools/DependenciesInfoTask.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.hadoop.gradle.buildtools;
+
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.Dependency;
+import org.gradle.api.artifacts.DependencySet;
+import org.gradle.api.artifacts.ModuleVersionIdentifier;
+import org.gradle.api.artifacts.ProjectDependency;
+import org.gradle.api.internal.ConventionTask;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.InputDirectory;
+import org.gradle.api.tasks.InputFiles;
+import org.gradle.api.tasks.Optional;
+import org.gradle.api.tasks.OutputFile;
+import org.gradle.api.tasks.TaskAction;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * A task to gather information about the dependencies and export them into a csv file.
+ * <p>
+ * The following information is gathered:
+ * <ul>
+ *     <li>name: name that identifies the library (groupId:artifactId)</li>
+ *     <li>version</li>
+ *     <li>URL: link to have more information about the dependency.</li>
+ *     <li>license: <a href="https://spdx.org/licenses/">SPDX license</a> identifier, custom license or UNKNOWN.</li>
+ * </ul>
+ */
+public class DependenciesInfoTask extends ConventionTask {
+    /**
+     * Directory to read license files
+     */
+    @Optional
+    @InputDirectory
+    private File licensesDir = new File(getProject().getProjectDir(), "licenses").exists()
+        ? new File(getProject().getProjectDir(), "licenses")
+        : null;
+
+    @OutputFile
+    private File outputFile = new File(getProject().getBuildDir(), "reports/dependencies/dependencies.csv");
+    private LinkedHashMap<String, String> mappings;
+
+    public Configuration getRuntimeConfiguration() {
+        return runtimeConfiguration;
+    }
+
+    public void setRuntimeConfiguration(Configuration runtimeConfiguration) {
+        this.runtimeConfiguration = runtimeConfiguration;
+    }
+
+    public Configuration getCompileOnlyConfiguration() {
+        return compileOnlyConfiguration;
+    }
+
+    public void setCompileOnlyConfiguration(Configuration compileOnlyConfiguration) {
+        this.compileOnlyConfiguration = compileOnlyConfiguration;
+    }
+
+    public File getLicensesDir() {
+        return licensesDir;
+    }
+
+    public void setLicensesDir(File licensesDir) {
+        this.licensesDir = licensesDir;
+    }
+
+    public File getOutputFile() {
+        return outputFile;
+    }
+
+    public void setOutputFile(File outputFile) {
+        this.outputFile = outputFile;
+    }
+
+    /**
+     * Dependencies to gather information from.
+     */
+    @InputFiles
+    private Configuration runtimeConfiguration;
+    /**
+     * We subtract compile-only dependencies.
+     */
+    @InputFiles
+    private Configuration compileOnlyConfiguration;
+
+    public DependenciesInfoTask() {
+        setDescription("Create a CSV file with dependencies information.");
+    }
+
+    @TaskAction
+    public void generateDependenciesInfo() throws IOException {
+
+        final DependencySet runtimeDependencies = runtimeConfiguration.getAllDependencies();
+        // we have to resolve the transitive dependencies and create a group:artifactId:version map
+
+        final Set<String> compileOnlyArtifacts = compileOnlyConfiguration.getResolvedConfiguration()
+            .getResolvedArtifacts()
+            .stream()
+            .map(r -> {
+                ModuleVersionIdentifier id = r.getModuleVersion().getId();
+                return id.getGroup() + ":" + id.getName() + ":" + id.getVersion();
+            })
+            .collect(Collectors.toSet());
+
+        final StringBuilder output = new StringBuilder();
+        for (final Dependency dep : runtimeDependencies) {
+            // we do not need compile-only dependencies here
+            if (compileOnlyArtifacts.contains(dep.getGroup() + ":" + dep.getName() + ":" + dep.getVersion())) {
+                continue;
+            }
+
+            // only external dependencies are checked
+            if (dep instanceof ProjectDependency) {
+                continue;
+            }
+
+            final String url = createURL(dep.getGroup(), dep.getName(), dep.getVersion());
+            final String dependencyName = DependencyLicensesTask.getDependencyName(getMappings(), dep.getName());
+            getLogger().info("mapped dependency " + dep.getGroup() + ":" + dep.getName() + " to " + dependencyName + " for license info");
+
+            final String licenseType = getLicenseType(dep.getGroup(), dependencyName);
+            output.append(dep.getGroup() + ":" + dep.getName() + "," + dep.getVersion() + "," + url + "," + licenseType + "\n");
+        }
+
+        Files.write(outputFile.toPath(), output.toString().getBytes("UTF-8"), StandardOpenOption.CREATE);
+    }
+
+    @Input
+    public LinkedHashMap<String, String> getMappings() {
+        return mappings;
+    }
+
+    public void setMappings(LinkedHashMap<String, String> mappings) {
+        this.mappings = mappings;
+    }
+
+    /**
+     * Create an URL on <a href="https://repo1.maven.org/maven2/">Maven Central</a>
+     * based on dependency coordinates.
+     */
+    protected String createURL(final String group, final String name, final String version) {
+        final String baseURL = "https://repo1.maven.org/maven2";
+        return baseURL + "/" + group.replaceAll("\\.", "/") + "/" + name + "/" + version;
+    }
+
+    /**
+     * Read the LICENSE file associated with the dependency and determine a license type.
+     * <p>
+     * The license type is one of the following values:
+     * <ul>
+     * <li><em>UNKNOWN</em> if LICENSE file is not present for this dependency.</li>
+     * <li><em>one SPDX identifier</em> if the LICENSE content matches with an SPDX license.</li>
+     * <li><em>Custom;URL</em> if it's not an SPDX license,
+     * URL is the Github URL to the LICENSE file in elasticsearch repository.</li>
+     * </ul>
+     *
+     * @param group dependency group
+     * @param name  dependency name
+     * @return SPDX identifier, UNKNOWN or a Custom license
+     */
+    protected String getLicenseType(final String group, final String name) throws IOException {
+        final File license = getDependencyInfoFile(group, name, "LICENSE");
+        String licenseType;
+
+        final LicenseAnalyzer.LicenseInfo licenseInfo = LicenseAnalyzer.licenseType(license);
+        if (licenseInfo.isSpdxLicense() == false) {
+            // License has not be identified as SPDX.
+            // As we have the license file, we create a Custom entry with the URL to this license file.
+            final String gitBranch = System.getProperty("build.branch", "master");
+            final String githubBaseURL = "https://raw.githubusercontent.com/elastic/elasticsearch/" + gitBranch + "/";
+            licenseType = licenseInfo.getIdentifier()
+                + ";"
+                + license.getCanonicalPath().replaceFirst(".*/elasticsearch/", githubBaseURL)
+                + ",";
+        } else {
+            licenseType = licenseInfo.getIdentifier() + ",";
+        }
+
+        if (licenseInfo.isSourceRedistributionRequired()) {
+            final File sources = getDependencyInfoFile(group, name, "SOURCES");
+            licenseType += Files.readString(sources.toPath()).trim();
+        }
+
+        return licenseType;
+    }
+
+    protected File getDependencyInfoFile(final String group, final String name, final String infoFileSuffix) {
+        java.util.Optional<File> license = licensesDir != null
+            ? Arrays.stream(licensesDir.listFiles((dir, fileName) -> Pattern.matches(".*-" + infoFileSuffix + ".*", fileName)))
+                .filter(file -> {
+                    String prefix = file.getName().split("-" + infoFileSuffix + ".*")[0];
+                    return group.contains(prefix) || name.contains(prefix);
+                })
+                .findFirst()
+            : java.util.Optional.empty();
+
+        return license.orElseThrow(
+            () -> new IllegalStateException(
+                "Unable to find "
+                    + infoFileSuffix
+                    + " file for dependency "
+                    + group
+                    + ":"
+                    + name
+                    + " in "
+                    + getLicensesDir().getAbsolutePath()
+            )
+        );
+    }
+}

--- a/buildSrc/src/main/java/org/elasticsearch/hadoop/gradle/buildtools/DependenciesInfoTask.java
+++ b/buildSrc/src/main/java/org/elasticsearch/hadoop/gradle/buildtools/DependenciesInfoTask.java
@@ -1,9 +1,20 @@
 /*
- * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License
- * 2.0 and the Server Side Public License, v 1; you may not use this file except
- * in compliance with, at your election, the Elastic License 2.0 or the Server
- * Side Public License, v 1.
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.elasticsearch.hadoop.gradle.buildtools;

--- a/buildSrc/src/main/java/org/elasticsearch/hadoop/gradle/buildtools/DependencyLicensesTask.java
+++ b/buildSrc/src/main/java/org/elasticsearch/hadoop/gradle/buildtools/DependencyLicensesTask.java
@@ -1,9 +1,20 @@
 /*
- * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License
- * 2.0 and the Server Side Public License, v 1; you may not use this file except
- * in compliance with, at your election, the Elastic License 2.0 or the Server
- * Side Public License, v 1.
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 package org.elasticsearch.hadoop.gradle.buildtools;
 

--- a/buildSrc/src/main/java/org/elasticsearch/hadoop/gradle/buildtools/DependencyLicensesTask.java
+++ b/buildSrc/src/main/java/org/elasticsearch/hadoop/gradle/buildtools/DependencyLicensesTask.java
@@ -1,0 +1,367 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+package org.elasticsearch.hadoop.gradle.buildtools;
+
+import org.apache.commons.codec.binary.Hex;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.GradleException;
+import org.gradle.api.InvalidUserDataException;
+import org.gradle.api.file.FileCollection;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.InputDirectory;
+import org.gradle.api.tasks.InputFiles;
+import org.gradle.api.tasks.Internal;
+import org.gradle.api.tasks.Optional;
+import org.gradle.api.tasks.OutputDirectory;
+import org.gradle.api.tasks.TaskAction;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * A task to check licenses for dependencies.
+ * <p>
+ * There are two parts to the check:
+ * <ul>
+ *   <li>LICENSE, NOTICE and SOURCES files</li>
+ *   <li>SHA checksums for each dependency jar</li>
+ * </ul>
+ * <p>
+ * The directory to find the license and sha files in defaults to the dir @{code licenses}
+ * in the project directory for this task. You can override this directory:
+ * <pre>
+ *   dependencyLicenses {
+ *     licensesDir = getProject().file("mybetterlicensedir")
+ *   }
+ * </pre>
+ * <p>
+ * The jar files to check default to the dependencies from the default configuration. You
+ * can override this, for example, to only check compile dependencies:
+ * <pre>
+ *   dependencyLicenses {
+ *     dependencies = getProject().configurations.compile
+ *   }
+ * </pre>
+ * <p>
+ * Every jar must have a {@code .sha1} file in the licenses dir. These can be managed
+ * automatically using the {@code updateShas} helper task that is created along
+ * with this task. It will add {@code .sha1} files for new jars that are in dependencies
+ * and remove old {@code .sha1} files that are no longer needed.
+ * <p>
+ * Every jar must also have a LICENSE and NOTICE file. However, multiple jars can share
+ * LICENSE and NOTICE files by mapping a pattern to the same name.
+ * <pre>
+ *   dependencyLicenses {
+ *     mapping from: &#47;lucene-.*&#47;, to: "lucene"
+ *   }
+ * </pre>
+ * Dependencies using licenses with stricter distribution requirements (such as LGPL)
+ * require a SOURCES file as well. The file should include a URL to a source distribution
+ * for the dependency. This artifact will be redistributed by us with the release to
+ * comply with the license terms.
+ */
+public class DependencyLicensesTask extends DefaultTask {
+
+    private final Pattern regex = Pattern.compile("-v?\\d+.*");
+
+    private final Logger logger = Logging.getLogger(getClass());
+
+    private static final String SHA_EXTENSION = ".sha1";
+
+    // TODO: we should be able to default this to eg compile deps, but we need to move the licenses
+    // check from distribution to core (ie this should only be run on java projects)
+    /**
+     * A collection of jar files that should be checked.
+     */
+    private FileCollection dependencies;
+
+    /**
+     * The directory to find the license and sha files in.
+     */
+    private File licensesDir = new File(getProject().getProjectDir(), "licenses");
+
+    /**
+     * A map of patterns to prefix, used to find the LICENSE and NOTICE file.
+     */
+    private Map<String, String> mappings = new LinkedHashMap<>();
+
+    /**
+     * Names of dependencies whose shas should not exist.
+     */
+    private Set<String> ignoreShas = new HashSet<>();
+
+    /**
+     * Add a mapping from a regex pattern for the jar name, to a prefix to find
+     * the LICENSE and NOTICE file for that jar.
+     */
+    public void mapping(Map<String, String> props) {
+        String from = props.get("from");
+        if (from == null) {
+            throw new InvalidUserDataException("Missing \"from\" setting for license name mapping");
+        }
+        String to = props.get("to");
+        if (to == null) {
+            throw new InvalidUserDataException("Missing \"to\" setting for license name mapping");
+        }
+        if (props.size() > 2) {
+            throw new InvalidUserDataException("Unknown properties for mapping on dependencyLicenses: " + props.keySet());
+        }
+        mappings.put(from, to);
+    }
+
+    @InputFiles
+    public FileCollection getDependencies() {
+        return dependencies;
+    }
+
+    public void setDependencies(FileCollection dependencies) {
+        this.dependencies = dependencies;
+    }
+
+    @Optional
+    @InputDirectory
+    public File getLicensesDir() {
+        if (licensesDir.exists()) {
+            return licensesDir;
+        }
+
+        return null;
+    }
+
+    public void setLicensesDir(File licensesDir) {
+        this.licensesDir = licensesDir;
+    }
+
+    /**
+     * Add a rule which will skip SHA checking for the given dependency name. This should be used for
+     * locally build dependencies, which cause the sha to change constantly.
+     */
+    public void ignoreSha(String dep) {
+        ignoreShas.add(dep);
+    }
+
+    @TaskAction
+    public void checkDependencies() throws IOException, NoSuchAlgorithmException {
+        if (dependencies == null) {
+            throw new GradleException("No dependencies variable defined.");
+        }
+
+        if (dependencies.isEmpty()) {
+            if (licensesDir.exists()) {
+                throw new GradleException("Licenses dir " + licensesDir + " exists, but there are no dependencies");
+            }
+            return; // no dependencies to check
+        } else if (licensesDir.exists() == false) {
+            String deps = "";
+            for (File file : dependencies) {
+                deps += file.getName() + "\n";
+            }
+            throw new GradleException("Licences dir " + licensesDir + " does not exist, but there are dependencies: " + deps);
+        }
+
+        Map<String, Boolean> licenses = new HashMap<>();
+        Map<String, Boolean> notices = new HashMap<>();
+        Map<String, Boolean> sources = new HashMap<>();
+        Set<File> shaFiles = new HashSet<>();
+
+        for (File file : licensesDir.listFiles()) {
+            String name = file.getName();
+            if (name.endsWith(SHA_EXTENSION)) {
+                shaFiles.add(file);
+            } else if (name.endsWith("-LICENSE") || name.endsWith("-LICENSE.txt")) {
+                // TODO: why do we support suffix of LICENSE *and* LICENSE.txt??
+                licenses.put(name, false);
+            } else if (name.contains("-NOTICE") || name.contains("-NOTICE.txt")) {
+                notices.put(name, false);
+            } else if (name.contains("-SOURCES") || name.contains("-SOURCES.txt")) {
+                sources.put(name, false);
+            }
+        }
+
+        checkDependencies(licenses, notices, sources, shaFiles);
+
+        licenses.forEach((item, exists) -> failIfAnyMissing(item, exists, "license"));
+
+        notices.forEach((item, exists) -> failIfAnyMissing(item, exists, "notice"));
+
+        sources.forEach((item, exists) -> failIfAnyMissing(item, exists, "sources"));
+
+        if (shaFiles.isEmpty() == false) {
+            throw new GradleException("Unused sha files found: \n" + joinFilenames(shaFiles));
+        }
+
+    }
+
+    // This is just a marker output folder to allow this task being up-to-date.
+    // The check logic is exception driven so a failed tasks will not be defined
+    // by this output but when successful we can safely mark the task as up-to-date.
+    @OutputDirectory
+    public File getOutputMarker() {
+        return new File(getProject().getBuildDir(), "dependencyLicense");
+    }
+
+    private void failIfAnyMissing(String item, Boolean exists, String type) {
+        if (exists == false) {
+            throw new GradleException("Unused " + type + " " + item);
+        }
+    }
+
+    private void checkDependencies(
+        Map<String, Boolean> licenses,
+        Map<String, Boolean> notices,
+        Map<String, Boolean> sources,
+        Set<File> shaFiles
+    ) throws NoSuchAlgorithmException, IOException {
+        for (File dependency : dependencies) {
+            String jarName = dependency.getName();
+            String depName = regex.matcher(jarName).replaceFirst("");
+
+            validateSha(shaFiles, dependency, jarName, depName);
+
+            String dependencyName = getDependencyName(mappings, depName);
+            logger.info("mapped dependency name {} to {} for license/notice check", depName, dependencyName);
+            checkFile(dependencyName, jarName, licenses, "LICENSE");
+            checkFile(dependencyName, jarName, notices, "NOTICE");
+
+            File licenseFile = new File(licensesDir, getFileName(dependencyName, licenses, "LICENSE"));
+            LicenseAnalyzer.LicenseInfo licenseInfo = LicenseAnalyzer.licenseType(licenseFile);
+            if (licenseInfo.isSourceRedistributionRequired()) {
+                checkFile(dependencyName, jarName, sources, "SOURCES");
+            }
+        }
+    }
+
+    private void validateSha(Set<File> shaFiles, File dependency, String jarName, String depName) throws NoSuchAlgorithmException,
+        IOException {
+        if (ignoreShas.contains(depName)) {
+            // local deps should not have sha files!
+            if (getShaFile(jarName).exists()) {
+                throw new GradleException("SHA file " + getShaFile(jarName) + " exists for ignored dependency " + depName);
+            }
+        } else {
+            logger.info("Checking sha for {}", jarName);
+            checkSha(dependency, jarName, shaFiles);
+        }
+    }
+
+    private String joinFilenames(Set<File> shaFiles) {
+        List<String> names = shaFiles.stream().map(File::getName).collect(Collectors.toList());
+        return String.join("\n", names);
+    }
+
+    public static String getDependencyName(Map<String, String> mappings, String dependencyName) {
+        // order is the same for keys and values iteration since we use a linked hashmap
+        List<String> mapped = new ArrayList<>(mappings.values());
+        Pattern mappingsPattern = Pattern.compile("(" + String.join(")|(", mappings.keySet()) + ")");
+        Matcher match = mappingsPattern.matcher(dependencyName);
+        if (match.matches()) {
+            int i = 0;
+            while (i < match.groupCount() && match.group(i + 1) == null) {
+                ++i;
+            }
+            return mapped.get(i);
+        }
+        return dependencyName;
+    }
+
+    private void checkSha(File jar, String jarName, Set<File> shaFiles) throws NoSuchAlgorithmException, IOException {
+        File shaFile = getShaFile(jarName);
+        if (shaFile.exists() == false) {
+            throw new GradleException("Missing SHA for " + jarName + ". Run \"gradle updateSHAs\" to create them");
+        }
+
+        // TODO: shouldn't have to trim, sha files should not have trailing newline
+        byte[] fileBytes = Files.readAllBytes(shaFile.toPath());
+        String expectedSha = new String(fileBytes, StandardCharsets.UTF_8).trim();
+
+        String sha = getSha1(jar);
+
+        if (expectedSha.equals(sha) == false) {
+            final String exceptionMessage = String.format(
+                Locale.ROOT,
+                "SHA has changed! Expected %s for %s but got %s."
+                    + "\nThis usually indicates a corrupt dependency cache or artifacts changed upstream."
+                    + "\nEither wipe your cache, fix the upstream artifact, or delete %s and run updateShas",
+                expectedSha,
+                jarName,
+                sha,
+                shaFile
+            );
+
+            throw new GradleException(exceptionMessage);
+        }
+        shaFiles.remove(shaFile);
+    }
+
+    private void checkFile(String name, String jarName, Map<String, Boolean> counters, String type) {
+        String fileName = getFileName(name, counters, type);
+
+        if (counters.containsKey(fileName) == false) {
+            throw new GradleException("Missing " + type + " for " + jarName + ", expected in " + fileName);
+        }
+
+        counters.put(fileName, true);
+    }
+
+    private String getFileName(String name, Map<String, ?> counters, String type) {
+        String fileName = name + "-" + type;
+
+        if (counters.containsKey(fileName) == false) {
+            // try the other suffix...TODO: get rid of this, just support ending in .txt
+            return fileName + ".txt";
+        }
+
+        return fileName;
+    }
+
+    @Input
+    public LinkedHashMap<String, String> getMappings() {
+        return new LinkedHashMap<>(mappings);
+    }
+
+    File getShaFile(String jarName) {
+        return new File(licensesDir, jarName + SHA_EXTENSION);
+    }
+
+    @Internal
+    Set<File> getShaFiles() {
+        File[] array = licensesDir.listFiles();
+        if (array == null) {
+            throw new GradleException("\"" + licensesDir.getPath() + "\" isn't a valid directory");
+        }
+
+        return Arrays.stream(array).filter(file -> file.getName().endsWith(SHA_EXTENSION)).collect(Collectors.toSet());
+    }
+
+    String getSha1(File file) throws IOException, NoSuchAlgorithmException {
+        byte[] bytes = Files.readAllBytes(file.toPath());
+
+        MessageDigest digest = MessageDigest.getInstance("SHA-1");
+        char[] encoded = Hex.encodeHex(digest.digest(bytes));
+        return String.copyValueOf(encoded);
+    }
+
+}

--- a/buildSrc/src/main/java/org/elasticsearch/hadoop/gradle/buildtools/Fixture.java
+++ b/buildSrc/src/main/java/org/elasticsearch/hadoop/gradle/buildtools/Fixture.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.hadoop.gradle.buildtools;
+
+/**
+ * Any object that can produce an accompanying stop task, meant to tear down
+ * a previously instantiated service.
+ */
+public interface Fixture {
+
+    /** A task which will stop this fixture. This should be used as a finalizedBy for any tasks that use the fixture. */
+    Object getStopTask();
+
+}

--- a/buildSrc/src/main/java/org/elasticsearch/hadoop/gradle/buildtools/Fixture.java
+++ b/buildSrc/src/main/java/org/elasticsearch/hadoop/gradle/buildtools/Fixture.java
@@ -1,9 +1,20 @@
 /*
- * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License
- * 2.0 and the Server Side Public License, v 1; you may not use this file except
- * in compliance with, at your election, the Elastic License 2.0 or the Server
- * Side Public License, v 1.
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.elasticsearch.hadoop.gradle.buildtools;

--- a/buildSrc/src/main/java/org/elasticsearch/hadoop/gradle/buildtools/LazyFileOutputStream.java
+++ b/buildSrc/src/main/java/org/elasticsearch/hadoop/gradle/buildtools/LazyFileOutputStream.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.hadoop.gradle.buildtools;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * An outputstream to a File that is lazily opened on the first write.
+ */
+class LazyFileOutputStream extends OutputStream {
+    private OutputStream delegate;
+
+    LazyFileOutputStream(File file) {
+        // use an initial dummy delegate to avoid doing a conditional on every write
+        this.delegate = new OutputStream() {
+            private void bootstrap() throws IOException {
+                file.getParentFile().mkdirs();
+                delegate = new FileOutputStream(file);
+            }
+
+            @Override
+            public void write(int b) throws IOException {
+                bootstrap();
+                delegate.write(b);
+            }
+
+            @Override
+            public void write(byte b[], int off, int len) throws IOException {
+                bootstrap();
+                delegate.write(b, off, len);
+            }
+        };
+    }
+
+    @Override
+    public void write(int b) throws IOException {
+        delegate.write(b);
+    }
+
+    @Override
+    public void write(byte b[], int off, int len) throws IOException {
+        delegate.write(b, off, len);
+    }
+
+    @Override
+    public void close() throws IOException {
+        delegate.close();
+    }
+}

--- a/buildSrc/src/main/java/org/elasticsearch/hadoop/gradle/buildtools/LazyFileOutputStream.java
+++ b/buildSrc/src/main/java/org/elasticsearch/hadoop/gradle/buildtools/LazyFileOutputStream.java
@@ -1,9 +1,20 @@
 /*
- * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License
- * 2.0 and the Server Side Public License, v 1; you may not use this file except
- * in compliance with, at your election, the Elastic License 2.0 or the Server
- * Side Public License, v 1.
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.elasticsearch.hadoop.gradle.buildtools;

--- a/buildSrc/src/main/java/org/elasticsearch/hadoop/gradle/buildtools/LicenseAnalyzer.java
+++ b/buildSrc/src/main/java/org/elasticsearch/hadoop/gradle/buildtools/LicenseAnalyzer.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.hadoop.gradle.buildtools;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.util.regex.Pattern;
+
+public class LicenseAnalyzer {
+    /*
+     * Order here matters. License files can often contain multiple licenses for which the particular piece of software may by used under.
+     * We should order these in order of most permissive to least permissive such that we identify the license as the most permissive for
+     * purposes of redistribution. Search order is as defined below so the license will be identified as the first pattern to match.
+     */
+    private static final LicenseMatcher[] matchers = new LicenseMatcher[] {
+        new LicenseMatcher("Apache-2.0", true, false, Pattern.compile("Apache.*License.*[vV]ersion.*2\\.0", Pattern.DOTALL)),
+        new LicenseMatcher(
+            "BSD-2-Clause",
+            true,
+            false,
+            Pattern.compile(
+                ("Redistribution and use in source and binary forms, with or without\n"
+                    + "modification, are permitted provided that the following conditions\n"
+                    + "are met:\n"
+                    + "\n"
+                    + " 1\\. Redistributions of source code must retain the above copyright\n"
+                    + "    notice, this list of conditions and the following disclaimer\\.\n"
+                    + " 2\\. Redistributions in binary form must reproduce the above copyright\n"
+                    + "    notice, this list of conditions and the following disclaimer in the\n"
+                    + "    documentation and/or other materials provided with the distribution\\.\n"
+                    + "\n"
+                    + "THIS SOFTWARE IS PROVIDED BY .+ (``|''|\")AS IS(''|\") AND ANY EXPRESS OR\n"
+                    + "IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\n"
+                    + "OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED\\.\n"
+                    + "IN NO EVENT SHALL .+ BE LIABLE FOR ANY DIRECT, INDIRECT,\n"
+                    + "INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES \\(INCLUDING, BUT\n"
+                    + "NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,\n"
+                    + "DATA, OR PROFITS; OR BUSINESS INTERRUPTION\\) HOWEVER CAUSED AND ON ANY\n"
+                    + "THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT\n"
+                    + "\\(INCLUDING NEGLIGENCE OR OTHERWISE\\) ARISING IN ANY WAY OUT OF THE USE OF\n"
+                    + "THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE\\.").replaceAll("\\s+", "\\\\s*"),
+                Pattern.DOTALL
+            )
+        ),
+        new LicenseMatcher(
+            "BSD-3-Clause",
+            true,
+            false,
+            Pattern.compile(
+                ("\n"
+                    + "Redistribution and use in source and binary forms, with or without\n"
+                    + "modification, are permitted provided that the following conditions\n"
+                    + "are met:\n"
+                    + "\n"
+                    + " (1\\.)? Redistributions of source code must retain the above copyright\n"
+                    + "    notice, this list of conditions and the following disclaimer\\.\n"
+                    + " (2\\.)? Redistributions in binary form must reproduce the above copyright\n"
+                    + "    notice, this list of conditions and the following disclaimer in the\n"
+                    + "    documentation and/or other materials provided with the distribution\\.\n"
+                    + " ((3\\.)? The name of .+ may not be used to endorse or promote products\n"
+                    + "    derived from this software without specific prior written permission\\.|\n"
+                    + "  (3\\.)? Neither the name of .+ nor the names of its\n"
+                    + "     contributors may be used to endorse or promote products derived from\n"
+                    + "     this software without specific prior written permission\\.)\n"
+                    + "\n"
+                    + "THIS SOFTWARE IS PROVIDED BY .+ (``|''|\")AS IS(''|\") AND ANY EXPRESS OR\n"
+                    + "IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\n"
+                    + "OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED\\.\n"
+                    + "IN NO EVENT SHALL .+ BE LIABLE FOR ANY DIRECT, INDIRECT,\n"
+                    + "INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES \\(INCLUDING, BUT\n"
+                    + "NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,\n"
+                    + "DATA, OR PROFITS; OR BUSINESS INTERRUPTION\\) HOWEVER CAUSED AND ON ANY\n"
+                    + "THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT\n"
+                    + "\\(INCLUDING NEGLIGENCE OR OTHERWISE\\) ARISING IN ANY WAY OUT OF THE USE OF\n"
+                    + "THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE\\.\n").replaceAll("\\s+", "\\\\s*"),
+                Pattern.DOTALL
+            )
+        ),
+        new LicenseMatcher(
+            "CDDL-1.0",
+            true,
+            false,
+            Pattern.compile("COMMON DEVELOPMENT AND DISTRIBUTION LICENSE.*Version 1.0", Pattern.DOTALL)
+        ),
+        new LicenseMatcher(
+            "CDDL-1.1",
+            true,
+            false,
+            Pattern.compile("COMMON DEVELOPMENT AND DISTRIBUTION LICENSE.*Version 1.1", Pattern.DOTALL)
+        ),
+        new LicenseMatcher("ICU", true, false, Pattern.compile("ICU License - ICU 1.8.1 and later", Pattern.DOTALL)),
+        new LicenseMatcher(
+            "MIT",
+            true,
+            false,
+            Pattern.compile(
+                ("\n"
+                    + "Permission is hereby granted, free of charge, to any person obtaining a copy of\n"
+                    + "this software and associated documentation files \\(the \"Software\"\\), to deal in\n"
+                    + "the Software without restriction, including without limitation the rights to\n"
+                    + "use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies\n"
+                    + "of the Software, and to permit persons to whom the Software is furnished to do\n"
+                    + "so, subject to the following conditions:\n"
+                    + "\n"
+                    + "The above copyright notice and this permission notice shall be included in all\n"
+                    + "copies or substantial portions of the Software\\.\n"
+                    + "\n"
+                    + "THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\n"
+                    + "IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\n"
+                    + "FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT\\. IN NO EVENT SHALL THE\n"
+                    + "AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\n"
+                    + "LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\n"
+                    + "OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE\n"
+                    + "SOFTWARE\\.\n").replaceAll("\\s+", "\\\\s*"),
+                Pattern.DOTALL
+            )
+        ),
+        new LicenseMatcher(
+            "MIT-0",
+            true,
+            false,
+            Pattern.compile(
+                ("MIT No Attribution\n"
+                    + "Copyright .+\n"
+                    + "\n"
+                    + "Permission is hereby granted, free of charge, to any person obtaining a copy of "
+                    + "this software and associated documentation files \\(the \"Software\"\\), to deal in the Software without "
+                    + "restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, "
+                    + "and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so.\n"
+                    + "\n"
+                    + "THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, "
+                    + "INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND "
+                    + "NONINFRINGEMENT\\. IN NO EVENT SHALL THE AUTHORS OR "
+                    + "COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR "
+                    + "OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.\n")
+                        .replaceAll("\\s+", "\\\\s*"),
+                Pattern.DOTALL
+            )
+        ),
+        new LicenseMatcher("MPL-1.1", true, false, Pattern.compile("Mozilla Public License.*Version 1.1", Pattern.DOTALL)),
+        new LicenseMatcher("MPL-2.0", true, false, Pattern.compile("Mozilla\\s*Public\\s*License\\s*Version\\s*2\\.0", Pattern.DOTALL)),
+        new LicenseMatcher("XZ", false, false, Pattern.compile("Licensing of XZ for Java", Pattern.DOTALL)),
+        new LicenseMatcher("EPL-2.0", true, false, Pattern.compile("Eclipse Public License - v 2.0", Pattern.DOTALL)),
+        new LicenseMatcher("EDL-1.0", true, false, Pattern.compile("Eclipse Distribution License - v 1.0", Pattern.DOTALL)),
+        new LicenseMatcher("LGPL-2.1", true, true, Pattern.compile("GNU LESSER GENERAL PUBLIC LICENSE.*Version 2.1", Pattern.DOTALL)),
+        new LicenseMatcher("LGPL-3.0", true, true, Pattern.compile("GNU LESSER GENERAL PUBLIC LICENSE.*Version 3", Pattern.DOTALL)) };
+
+    public static LicenseInfo licenseType(File licenseFile) {
+        for (LicenseMatcher matcher : matchers) {
+            boolean matches = matcher.matches(licenseFile);
+            if (matches) {
+                return new LicenseInfo(matcher.getIdentifier(), matcher.spdxLicense, matcher.sourceRedistributionRequired);
+            }
+        }
+
+        throw new IllegalStateException("Unknown license for license file: " + licenseFile);
+    }
+
+    public static class LicenseInfo {
+        private final String identifier;
+        private final boolean spdxLicense;
+        private final boolean sourceRedistributionRequired;
+
+        public LicenseInfo(String identifier, boolean spdxLicense, boolean sourceRedistributionRequired) {
+            this.identifier = identifier;
+            this.spdxLicense = spdxLicense;
+            this.sourceRedistributionRequired = sourceRedistributionRequired;
+        }
+
+        public String getIdentifier() {
+            return identifier;
+        }
+
+        public boolean isSpdxLicense() {
+            return spdxLicense;
+        }
+
+        public boolean isSourceRedistributionRequired() {
+            return sourceRedistributionRequired;
+        }
+    }
+
+    private static class LicenseMatcher {
+        private final String identifier;
+        private final boolean spdxLicense;
+        private final boolean sourceRedistributionRequired;
+        private final Pattern pattern;
+
+        LicenseMatcher(String identifier, boolean spdxLicense, boolean sourceRedistributionRequired, Pattern pattern) {
+            this.identifier = identifier;
+            this.spdxLicense = spdxLicense;
+            this.sourceRedistributionRequired = sourceRedistributionRequired;
+            this.pattern = pattern;
+        }
+
+        public String getIdentifier() {
+            return identifier;
+        }
+
+        public boolean matches(File licenseFile) {
+            try {
+                String content = Files.readString(licenseFile.toPath()).replaceAll("\\*", " ");
+                return pattern.matcher(content).find();
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+    }
+}

--- a/buildSrc/src/main/java/org/elasticsearch/hadoop/gradle/buildtools/LicenseAnalyzer.java
+++ b/buildSrc/src/main/java/org/elasticsearch/hadoop/gradle/buildtools/LicenseAnalyzer.java
@@ -1,9 +1,20 @@
 /*
- * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License
- * 2.0 and the Server Side Public License, v 1; you may not use this file except
- * in compliance with, at your election, the Elastic License 2.0 or the Server
- * Side Public License, v 1.
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.elasticsearch.hadoop.gradle.buildtools;

--- a/buildSrc/src/main/java/org/elasticsearch/hadoop/gradle/buildtools/LicenseHeadersTask.java
+++ b/buildSrc/src/main/java/org/elasticsearch/hadoop/gradle/buildtools/LicenseHeadersTask.java
@@ -1,0 +1,250 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.hadoop.gradle.buildtools;
+
+import org.apache.rat.Defaults;
+import org.apache.rat.ReportConfiguration;
+import org.apache.rat.analysis.IHeaderMatcher;
+import org.apache.rat.analysis.util.HeaderMatcherMultiplexer;
+import org.apache.rat.anttasks.SubstringLicenseMatcher;
+import org.apache.rat.api.RatException;
+import org.apache.rat.document.impl.FileDocument;
+import org.apache.rat.license.SimpleLicenseFamily;
+import org.apache.rat.report.RatReport;
+import org.apache.rat.report.claim.ClaimStatistic;
+import org.apache.rat.report.xml.XmlReportFactory;
+import org.apache.rat.report.xml.writer.impl.base.XmlWriter;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.GradleException;
+import org.gradle.api.file.FileCollection;
+import org.gradle.api.provider.ListProperty;
+import org.gradle.api.tasks.CacheableTask;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.InputFiles;
+import org.gradle.api.tasks.Internal;
+import org.gradle.api.tasks.OutputFile;
+import org.gradle.api.tasks.PathSensitive;
+import org.gradle.api.tasks.PathSensitivity;
+import org.gradle.api.tasks.SkipWhenEmpty;
+import org.gradle.api.tasks.TaskAction;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.Writer;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Checks files for license headers..
+ */
+@CacheableTask
+public abstract class LicenseHeadersTask extends DefaultTask {
+    public LicenseHeadersTask() {
+        setDescription("Checks sources for missing, incorrect, or unacceptable license headers");
+    }
+
+    /**
+     * The list of java files to check. protected so the afterEvaluate closure in the
+     * constructor can write to it.
+     */
+    @InputFiles
+    @SkipWhenEmpty
+    @PathSensitive(PathSensitivity.RELATIVE)
+    public List<FileCollection> getJavaFiles() {
+        return getSourceFolders().get();
+    }
+
+    @Internal
+    public abstract ListProperty<FileCollection> getSourceFolders();
+
+    public File getReportFile() {
+        return reportFile;
+    }
+
+    public void setReportFile(File reportFile) {
+        this.reportFile = reportFile;
+    }
+
+    public List<String> getApprovedLicenses() {
+        return approvedLicenses;
+    }
+
+    public void setApprovedLicenses(List<String> approvedLicenses) {
+        this.approvedLicenses = approvedLicenses;
+    }
+
+    public List<String> getExcludes() {
+        return excludes;
+    }
+
+    public Map<String, String> getAdditionalLicenses() {
+        return additionalLicenses;
+    }
+
+    public void setExcludes(List<String> excludes) {
+        this.excludes = excludes;
+    }
+
+    @OutputFile
+    private File reportFile = new File(getProject().getBuildDir(), "reports/licenseHeaders/rat.xml");
+
+    /**
+     * Allowed license families for this project.
+     */
+    @Input
+    private List<String> approvedLicenses = new ArrayList<String>(Arrays.asList("SSPL+Elastic License", "Generated", "Vendored"));
+    /**
+     * Files that should be excluded from the license header check. Use with extreme care, only in situations where the license on the
+     * source file is compatible with the codebase but we do not want to add the license to the list of approved headers (to avoid the
+     * possibility of inadvertently using the license on our own source files).
+     */
+    @Input
+    private List<String> excludes = new ArrayList<String>();
+    /**
+     * Additional license families that may be found. The key is the license category name (5 characters),
+     * followed by the family name and the value list of patterns to search for.
+     */
+    @Input
+    protected Map<String, String> additionalLicenses = new HashMap<String, String>();
+
+    /**
+     * Add a new license type.
+     * <p>
+     * The license may be added to the {@link #approvedLicenses} using the {@code familyName}.
+     *
+     * @param categoryName A 5-character string identifier for the license
+     * @param familyName   An expanded string name for the license
+     * @param pattern      A pattern to search for, which if found, indicates a file contains the license
+     */
+    public void additionalLicense(final String categoryName, String familyName, String pattern) {
+        if (categoryName.length() != 5) {
+            throw new IllegalArgumentException("License category name must be exactly 5 characters, got " + categoryName);
+        }
+
+        additionalLicenses.put(categoryName + familyName, pattern);
+    }
+
+    @TaskAction
+    public void runRat() {
+        ReportConfiguration reportConfiguration = new ReportConfiguration();
+        reportConfiguration.setAddingLicenses(true);
+        List<IHeaderMatcher> matchers = new ArrayList<>();
+        matchers.add(Defaults.createDefaultMatcher());
+
+        // BSD 4-clause stuff (is disallowed below)
+        // we keep this here, in case someone adds BSD code for some reason, it should never be allowed.
+        matchers.add(subStringMatcher("BSD4 ", "Original BSD License (with advertising clause)", "All advertising materials"));
+        // Apache
+        matchers.add(subStringMatcher("AL   ", "Apache", "Licensed to Elasticsearch B.V. under one or more contributor"));
+        // Generated resources
+        matchers.add(subStringMatcher("GEN  ", "Generated", "ANTLR GENERATED CODE"));
+        // Vendored Code
+        matchers.add(subStringMatcher("VEN  ", "Vendored", "@notice"));
+        // Dual SSPLv1 and Elastic
+        matchers.add(subStringMatcher("DUAL", "SSPL+Elastic License", "the Elastic License 2.0 or the Server"));
+
+        for (Map.Entry<String, String> additional : additionalLicenses.entrySet()) {
+            String category = additional.getKey().substring(0, 5);
+            String family = additional.getKey().substring(5);
+            matchers.add(subStringMatcher(category, family, additional.getValue()));
+        }
+
+        reportConfiguration.setHeaderMatcher(new HeaderMatcherMultiplexer(matchers.toArray(IHeaderMatcher[]::new)));
+        reportConfiguration.setApprovedLicenseNames(approvedLicenses.stream().map(license -> {
+            SimpleLicenseFamily simpleLicenseFamily = new SimpleLicenseFamily();
+            simpleLicenseFamily.setFamilyName(license);
+            return simpleLicenseFamily;
+        }).toArray(SimpleLicenseFamily[]::new));
+
+        ClaimStatistic stats = generateReport(reportConfiguration, getReportFile());
+        boolean unknownLicenses = stats.getNumUnknown() > 0;
+        boolean unApprovedLicenses = stats.getNumUnApproved() > 0;
+        if (unknownLicenses || unApprovedLicenses) {
+            getLogger().error("The following files contain unapproved license headers:");
+            unapprovedFiles(getReportFile()).stream().forEachOrdered(unapprovedFile -> getLogger().error(unapprovedFile));
+            throw new GradleException("Check failed. License header problems were found. Full details: " + reportFile.getAbsolutePath());
+        }
+    }
+
+    private IHeaderMatcher subStringMatcher(String licenseFamilyCategory, String licenseFamilyName, String substringPattern) {
+        SubstringLicenseMatcher substringLicenseMatcher = new SubstringLicenseMatcher();
+        substringLicenseMatcher.setLicenseFamilyCategory(licenseFamilyCategory);
+        substringLicenseMatcher.setLicenseFamilyName(licenseFamilyName);
+
+        SubstringLicenseMatcher.Pattern pattern = new SubstringLicenseMatcher.Pattern();
+        pattern.setSubstring(substringPattern);
+        substringLicenseMatcher.addConfiguredPattern(pattern);
+        return substringLicenseMatcher;
+    }
+
+    private ClaimStatistic generateReport(ReportConfiguration config, File xmlReportFile) {
+        try {
+            Files.deleteIfExists(reportFile.toPath());
+            BufferedWriter bufferedWriter = new BufferedWriter(new FileWriter(xmlReportFile));
+            return toXmlReportFile(config, bufferedWriter);
+        } catch (IOException | RatException exception) {
+            throw new GradleException("Cannot generate license header report for " + getPath(), exception);
+        }
+    }
+
+    private ClaimStatistic toXmlReportFile(ReportConfiguration config, Writer writer) throws RatException, IOException {
+        ClaimStatistic stats = new ClaimStatistic();
+        RatReport standardReport = XmlReportFactory.createStandardReport(new XmlWriter(writer), stats, config);
+
+        standardReport.startReport();
+        for (FileCollection dirSet : getSourceFolders().get()) {
+            for (File f : dirSet.getAsFileTree().matching(patternFilterable -> patternFilterable.exclude(getExcludes()))) {
+                standardReport.report(new FileDocument(f));
+            }
+        }
+        standardReport.endReport();
+        writer.flush();
+        writer.close();
+        return stats;
+    }
+
+    private static List<String> unapprovedFiles(File xmlReportFile) {
+        try {
+            NodeList resourcesNodes = DocumentBuilderFactory.newInstance()
+                .newDocumentBuilder()
+                .parse(xmlReportFile)
+                .getElementsByTagName("resource");
+            return elementList(resourcesNodes).stream()
+                .filter(
+                    resource -> elementList(resource.getChildNodes()).stream()
+                        .anyMatch(n -> n.getTagName().equals("license-approval") && n.getAttribute("name").equals("false"))
+                )
+                .map(e -> e.getAttribute("name"))
+                .sorted()
+                .collect(Collectors.toList());
+        } catch (SAXException | IOException | ParserConfigurationException e) {
+            throw new GradleException("Error parsing xml report " + xmlReportFile.getAbsolutePath());
+        }
+    }
+
+    private static List<Element> elementList(NodeList resourcesNodes) {
+        List<Element> nodeList = new ArrayList<>(resourcesNodes.getLength());
+        for (int idx = 0; idx < resourcesNodes.getLength(); idx++) {
+            nodeList.add((Element) resourcesNodes.item(idx));
+        }
+        return nodeList;
+    }
+}

--- a/buildSrc/src/main/java/org/elasticsearch/hadoop/gradle/buildtools/LicenseHeadersTask.java
+++ b/buildSrc/src/main/java/org/elasticsearch/hadoop/gradle/buildtools/LicenseHeadersTask.java
@@ -1,9 +1,20 @@
 /*
- * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License
- * 2.0 and the Server Side Public License, v 1; you may not use this file except
- * in compliance with, at your election, the Elastic License 2.0 or the Server
- * Side Public License, v 1.
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.elasticsearch.hadoop.gradle.buildtools;

--- a/buildSrc/src/main/java/org/elasticsearch/hadoop/gradle/buildtools/LoggedExec.java
+++ b/buildSrc/src/main/java/org/elasticsearch/hadoop/gradle/buildtools/LoggedExec.java
@@ -1,9 +1,20 @@
 /*
- * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License
- * 2.0 and the Server Side Public License, v 1; you may not use this file except
- * in compliance with, at your election, the Elastic License 2.0 or the Server
- * Side Public License, v 1.
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 package org.elasticsearch.hadoop.gradle.buildtools;
 

--- a/buildSrc/src/main/java/org/elasticsearch/hadoop/gradle/buildtools/LoggedExec.java
+++ b/buildSrc/src/main/java/org/elasticsearch/hadoop/gradle/buildtools/LoggedExec.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+package org.elasticsearch.hadoop.gradle.buildtools;
+
+import org.elasticsearch.gradle.FileSystemOperationsAware;
+import org.gradle.api.Action;
+import org.gradle.api.GradleException;
+import org.gradle.api.Task;
+import org.gradle.api.file.FileSystemOperations;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
+import org.gradle.api.tasks.Exec;
+import org.gradle.api.tasks.WorkResult;
+import org.gradle.process.BaseExecSpec;
+import org.gradle.process.ExecOperations;
+import org.gradle.process.ExecResult;
+import org.gradle.process.ExecSpec;
+import org.gradle.process.JavaExecSpec;
+
+import javax.inject.Inject;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.UncheckedIOException;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.regex.Pattern;
+
+/**
+ * A wrapper around gradle's Exec task to capture output and log on error.
+ */
+@SuppressWarnings("unchecked")
+public class LoggedExec extends Exec implements FileSystemOperationsAware {
+
+    private static final Logger LOGGER = Logging.getLogger(LoggedExec.class);
+    private Consumer<Logger> outputLogger;
+    private FileSystemOperations fileSystemOperations;
+
+    @Inject
+    public LoggedExec(FileSystemOperations fileSystemOperations) {
+        this.fileSystemOperations = fileSystemOperations;
+        if (getLogger().isInfoEnabled() == false) {
+            setIgnoreExitValue(true);
+            setSpoolOutput(false);
+            // We use an anonymous inner class here because Gradle cannot properly snapshot this input for the purposes of
+            // incremental build if we use a lambda. This ensures LoggedExec tasks that declare output can be UP-TO-DATE.
+            doLast(new Action<Task>() {
+                @Override
+                public void execute(Task task) {
+                    if (LoggedExec.this.getExecResult().getExitValue() != 0) {
+                        try {
+                            LoggedExec.this.getLogger().error("Output for " + LoggedExec.this.getExecutable() + ":");
+                            outputLogger.accept(LoggedExec.this.getLogger());
+                        } catch (Exception e) {
+                            throw new GradleException("Failed to read exec output", e);
+                        }
+                        throw new GradleException(
+                            String.format(
+                                "Process '%s %s' finished with non-zero exit value %d",
+                                LoggedExec.this.getExecutable(),
+                                LoggedExec.this.getArgs(),
+                                LoggedExec.this.getExecResult().getExitValue()
+                            )
+                        );
+                    }
+                }
+            });
+        }
+    }
+
+    public void setSpoolOutput(boolean spoolOutput) {
+        final OutputStream out;
+        if (spoolOutput) {
+            File spoolFile = new File(getProject().getBuildDir() + "/buffered-output/" + this.getName());
+            out = new LazyFileOutputStream(spoolFile);
+            outputLogger = logger -> {
+                try {
+                    // the file may not exist if the command never output anything
+                    if (Files.exists(spoolFile.toPath())) {
+                        Files.lines(spoolFile.toPath()).forEach(logger::error);
+                    }
+                } catch (IOException e) {
+                    throw new RuntimeException("could not log", e);
+                }
+            };
+        } else {
+            out = new ByteArrayOutputStream();
+            outputLogger = logger -> {
+                try {
+                    logger.error(((ByteArrayOutputStream) out).toString("UTF-8"));
+                } catch (UnsupportedEncodingException e) {
+                    throw new RuntimeException(e);
+                }
+            };
+        }
+        setStandardOutput(out);
+        setErrorOutput(out);
+    }
+
+    public static ExecResult exec(ExecOperations execOperations, Action<ExecSpec> action) {
+        return genericExec(execOperations::exec, action);
+    }
+
+    public static ExecResult javaexec(ExecOperations project, Action<JavaExecSpec> action) {
+        return genericExec(project::javaexec, action);
+    }
+
+    private static final Pattern NEWLINE = Pattern.compile(System.lineSeparator());
+
+    private static <T extends BaseExecSpec> ExecResult genericExec(Function<Action<T>, ExecResult> function, Action<T> action) {
+        if (LOGGER.isInfoEnabled()) {
+            return function.apply(action);
+        }
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        try {
+            return function.apply(spec -> {
+                spec.setStandardOutput(output);
+                spec.setErrorOutput(output);
+                action.execute(spec);
+                try {
+                    output.write(("Output for " + spec.getExecutable() + ":").getBytes(StandardCharsets.UTF_8));
+                } catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                }
+            });
+        } catch (Exception e) {
+            try {
+                if (output.size() != 0) {
+                    LOGGER.error("Exec output and error:");
+                    NEWLINE.splitAsStream(output.toString("UTF-8")).forEach(s -> LOGGER.error("| " + s));
+                }
+            } catch (UnsupportedEncodingException ue) {
+                throw new GradleException("Failed to read exec output", ue);
+            }
+            throw e;
+        }
+    }
+
+    @Override
+    public WorkResult delete(Object... objects) {
+        return fileSystemOperations.delete(d -> d.delete(objects));
+    }
+}

--- a/buildSrc/src/main/java/org/elasticsearch/hadoop/gradle/buildtools/StandaloneRestIntegTestTask.java
+++ b/buildSrc/src/main/java/org/elasticsearch/hadoop/gradle/buildtools/StandaloneRestIntegTestTask.java
@@ -1,9 +1,20 @@
 /*
- * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License
- * 2.0 and the Server Side Public License, v 1; you may not use this file except
- * in compliance with, at your election, the Elastic License 2.0 or the Server
- * Side Public License, v 1.
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 package org.elasticsearch.hadoop.gradle.buildtools;
 

--- a/buildSrc/src/main/java/org/elasticsearch/hadoop/gradle/buildtools/StandaloneRestIntegTestTask.java
+++ b/buildSrc/src/main/java/org/elasticsearch/hadoop/gradle/buildtools/StandaloneRestIntegTestTask.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+package org.elasticsearch.hadoop.gradle.buildtools;
+
+import org.elasticsearch.gradle.FileSystemOperationsAware;
+import org.elasticsearch.gradle.testclusters.ElasticsearchCluster;
+import org.elasticsearch.gradle.testclusters.TestClustersAware;
+import org.elasticsearch.gradle.testclusters.TestClustersThrottle;
+import org.gradle.api.GradleException;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.services.BuildService;
+import org.gradle.api.services.BuildServiceRegistration;
+import org.gradle.api.services.BuildServiceRegistry;
+import org.gradle.api.services.internal.BuildServiceRegistryInternal;
+import org.gradle.api.tasks.CacheableTask;
+import org.gradle.api.tasks.Internal;
+import org.gradle.api.tasks.Nested;
+import org.gradle.api.tasks.WorkResult;
+import org.gradle.api.tasks.testing.Test;
+import org.gradle.internal.resources.ResourceLock;
+import org.gradle.internal.resources.SharedResource;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+
+import static org.elasticsearch.gradle.testclusters.TestClustersPlugin.THROTTLE_SERVICE_NAME;
+
+/**
+ * Customized version of Gradle {@link Test} task which tracks a collection of {@link ElasticsearchCluster} as a task input. We must do this
+ * as a custom task type because the current {@link org.gradle.api.tasks.TaskInputs} runtime API does not have a way to register
+ * {@link Nested} inputs.
+ */
+@CacheableTask
+public class StandaloneRestIntegTestTask extends Test implements TestClustersAware, FileSystemOperationsAware {
+
+    private Collection<ElasticsearchCluster> clusters = new HashSet<>();
+
+    public StandaloneRestIntegTestTask() {
+        this.getOutputs()
+            .doNotCacheIf(
+                "Caching disabled for this task since it uses a cluster shared by other tasks",
+                /*
+                 * Look for any other tasks which use the same cluster as this task. Since tests often have side effects for the cluster
+                 * they execute against, this state can cause issues when trying to cache tests results of tasks that share a cluster. To
+                 * avoid any undesired behavior we simply disable the cache if we detect that this task uses a cluster shared between
+                 * multiple tasks.
+                 */
+                t -> getProject().getTasks()
+                    .withType(StandaloneRestIntegTestTask.class)
+                    .stream()
+                    .filter(task -> task != this)
+                    .anyMatch(task -> Collections.disjoint(task.getClusters(), getClusters()) == false)
+            );
+
+        this.getOutputs()
+            .doNotCacheIf(
+                "Caching disabled for this task since it is configured to preserve data directory",
+                // Don't cache the output of this task if it's not running from a clean data directory.
+                t -> getClusters().stream().anyMatch(cluster -> cluster.isPreserveDataDir())
+            );
+    }
+
+    @Override
+    public int getMaxParallelForks() {
+        return 1;
+    }
+
+    @Nested
+    @Override
+    public Collection<ElasticsearchCluster> getClusters() {
+        return clusters;
+    }
+
+    @Override
+    @Internal
+    public List<ResourceLock> getSharedResources() {
+        List<ResourceLock> locks = new ArrayList<>(super.getSharedResources());
+        BuildServiceRegistryInternal serviceRegistry = getServices().get(BuildServiceRegistryInternal.class);
+        Provider<TestClustersThrottle> throttleProvider = getBuildService(serviceRegistry, THROTTLE_SERVICE_NAME);
+        SharedResource resource = serviceRegistry.forService(throttleProvider);
+
+        int nodeCount = clusters.stream().mapToInt(cluster -> cluster.getNodes().size()).sum();
+        if (nodeCount > 0) {
+            locks.add(resource.getResourceLock(Math.min(nodeCount, resource.getMaxUsages())));
+        }
+        return Collections.unmodifiableList(locks);
+    }
+
+    public static <T extends BuildService<?>> Provider<T> getBuildService(BuildServiceRegistry registry, String name) {
+        BuildServiceRegistration<?, ?> registration = registry.getRegistrations().findByName(name);
+        if (registration == null) {
+            throw new GradleException("Unable to find build service with name '" + name + "'.");
+        }
+
+        return (Provider<T>) registration.getService();
+    }
+
+    public WorkResult delete(Object... objects) {
+        return getFileSystemOperations().delete(d -> d.delete(objects));
+    }
+}

--- a/buildSrc/src/main/java/org/elasticsearch/hadoop/gradle/buildtools/UpdateShasTask.java
+++ b/buildSrc/src/main/java/org/elasticsearch/hadoop/gradle/buildtools/UpdateShasTask.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.hadoop.gradle.buildtools;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
+import org.gradle.api.tasks.Internal;
+import org.gradle.api.tasks.TaskAction;
+import org.gradle.api.tasks.TaskProvider;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
+import java.security.NoSuchAlgorithmException;
+import java.util.Set;
+
+/**
+ * A task to update shas used by {@code DependencyLicensesCheck}
+ */
+public class UpdateShasTask extends DefaultTask {
+
+    private final Logger logger = Logging.getLogger(getClass());
+
+    /** The parent dependency licenses task to use configuration from */
+    private TaskProvider<DependencyLicensesTask> parentTask;
+
+    public UpdateShasTask() {
+        setDescription("Updates the sha files for the dependencyLicenses check");
+        setOnlyIf(element -> parentTask.get().getLicensesDir() != null);
+    }
+
+    @TaskAction
+    public void updateShas() throws NoSuchAlgorithmException, IOException {
+        Set<File> shaFiles = parentTask.get().getShaFiles();
+
+        for (File dependency : parentTask.get().getDependencies()) {
+            String jarName = dependency.getName();
+            File shaFile = parentTask.get().getShaFile(jarName);
+
+            if (shaFile.exists() == false) {
+                createSha(dependency, jarName, shaFile);
+            } else {
+                shaFiles.remove(shaFile);
+            }
+        }
+
+        for (File shaFile : shaFiles) {
+            logger.lifecycle("Removing unused sha " + shaFile.getName());
+            shaFile.delete();
+        }
+    }
+
+    private void createSha(File dependency, String jarName, File shaFile) throws IOException, NoSuchAlgorithmException {
+        logger.lifecycle("Adding sha for " + jarName);
+
+        String sha = parentTask.get().getSha1(dependency);
+
+        Files.write(shaFile.toPath(), sha.getBytes(StandardCharsets.UTF_8), StandardOpenOption.CREATE);
+    }
+
+    @Internal
+    public DependencyLicensesTask getParentTask() {
+        return parentTask.get();
+    }
+
+    public void setParentTask(TaskProvider<DependencyLicensesTask> parentTask) {
+        this.parentTask = parentTask;
+    }
+}

--- a/buildSrc/src/main/java/org/elasticsearch/hadoop/gradle/buildtools/UpdateShasTask.java
+++ b/buildSrc/src/main/java/org/elasticsearch/hadoop/gradle/buildtools/UpdateShasTask.java
@@ -1,9 +1,20 @@
 /*
- * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License
- * 2.0 and the Server Side Public License, v 1; you may not use this file except
- * in compliance with, at your election, the Elastic License 2.0 or the Server
- * Side Public License, v 1.
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.elasticsearch.hadoop.gradle.buildtools;

--- a/buildSrc/src/main/java/org/elasticsearch/hadoop/gradle/buildtools/Util.java
+++ b/buildSrc/src/main/java/org/elasticsearch/hadoop/gradle/buildtools/Util.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.hadoop.gradle.buildtools;
+
+import org.elasticsearch.gradle.util.GradleUtils;
+import org.elasticsearch.hadoop.gradle.buildtools.info.GlobalBuildInfoPlugin;
+import org.gradle.api.Action;
+import org.gradle.api.GradleException;
+import org.gradle.api.Project;
+import org.gradle.api.file.FileTree;
+import org.gradle.api.plugins.JavaPluginConvention;
+import org.gradle.api.tasks.SourceSet;
+import org.gradle.api.tasks.util.PatternFilterable;
+
+import javax.annotation.Nullable;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.UncheckedIOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.function.Supplier;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class Util {
+
+    public static boolean getBooleanProperty(String property, boolean defaultValue) {
+        String propertyValue = System.getProperty(property);
+        if (propertyValue == null) {
+            return defaultValue;
+        }
+        if ("true".equals(propertyValue)) {
+            return true;
+        } else if ("false".equals(propertyValue)) {
+            return false;
+        } else {
+            throw new GradleException("Sysprop [" + property + "] must be [true] or [false] but was [" + propertyValue + "]");
+        }
+    }
+
+    public static String getResourceContents(String resourcePath) {
+        try (
+            BufferedReader reader = new BufferedReader(new InputStreamReader(GlobalBuildInfoPlugin.class.getResourceAsStream(resourcePath)))
+        ) {
+            StringBuilder b = new StringBuilder();
+            for (String line = reader.readLine(); line != null; line = reader.readLine()) {
+                if (b.length() != 0) {
+                    b.append('\n');
+                }
+                b.append(line);
+            }
+
+            return b.toString();
+        } catch (IOException e) {
+            throw new UncheckedIOException("Error trying to read classpath resource: " + resourcePath, e);
+        }
+    }
+
+    public static String capitalize(String s) {
+        return s.substring(0, 1).toUpperCase(Locale.ROOT) + s.substring(1);
+    }
+
+    public static URI getBuildSrcCodeSource() {
+        try {
+            return Util.class.getProtectionDomain().getCodeSource().getLocation().toURI();
+        } catch (URISyntaxException e) {
+            throw new GradleException("Error determining build tools JAR location", e);
+        }
+    }
+
+    /**
+     * @param project The project to look for resources.
+     * @param filter  Optional filter function to filter the returned resources
+     * @return Returns the {@link FileTree} for main resources from Java projects. Returns null if no files exist.
+     */
+    @Nullable
+    public static FileTree getJavaMainSourceResources(Project project, Action<? super PatternFilterable> filter) {
+        final Optional<FileTree> mainFileTree = getJavaMainSourceSet(project).map(SourceSet::getResources).map(FileTree::getAsFileTree);
+        return mainFileTree.map(files -> files.matching(filter)).orElse(null);
+    }
+
+    /**
+     * @param project The project to look for resources.
+     * @param filter  Optional filter function to filter the returned resources
+     * @return Returns the {@link FileTree} for test resources from Java projects. Returns null if no files exist.
+     */
+    @Nullable
+    public static FileTree getJavaTestSourceResources(Project project, Action<? super PatternFilterable> filter) {
+        final Optional<FileTree> testFileTree = getJavaTestSourceSet(project).map(SourceSet::getResources).map(FileTree::getAsFileTree);
+        return testFileTree.map(files -> files.matching(filter)).orElse(null);
+    }
+
+    /**
+     * @param project The project to look for resources.
+     * @param filter  Optional filter function to filter the returned resources
+     * @return Returns the combined {@link FileTree} for test and main resources from Java projects. Returns null if no files exist.
+     */
+    @Nullable
+    public static FileTree getJavaTestAndMainSourceResources(Project project, Action<? super PatternFilterable> filter) {
+        final Optional<FileTree> testFileTree = getJavaTestSourceSet(project).map(SourceSet::getResources).map(FileTree::getAsFileTree);
+        final Optional<FileTree> mainFileTree = getJavaMainSourceSet(project).map(SourceSet::getResources).map(FileTree::getAsFileTree);
+        if (testFileTree.isPresent() && mainFileTree.isPresent()) {
+            return testFileTree.get().plus(mainFileTree.get()).matching(filter);
+        } else if (mainFileTree.isPresent()) {
+            return mainFileTree.get().matching(filter);
+        } else if (testFileTree.isPresent()) {
+            return testFileTree.get().matching(filter);
+        }
+        return null;
+    }
+
+    /**
+     * @param project The project to look for test Java resources.
+     * @return An Optional that contains the Java test SourceSet if it exists.
+     */
+    public static Optional<SourceSet> getJavaTestSourceSet(Project project) {
+        return project.getConvention().findPlugin(JavaPluginConvention.class) == null
+            ? Optional.empty()
+            : Optional.ofNullable(GradleUtils.getJavaSourceSets(project).findByName(SourceSet.TEST_SOURCE_SET_NAME));
+    }
+
+    /**
+     * @param project The project to look for main Java resources.
+     * @return An Optional that contains the Java main SourceSet if it exists.
+     */
+    public static Optional<SourceSet> getJavaMainSourceSet(Project project) {
+        return project.getConvention().findPlugin(JavaPluginConvention.class) == null
+            ? Optional.empty()
+            : Optional.ofNullable(GradleUtils.getJavaSourceSets(project).findByName(SourceSet.MAIN_SOURCE_SET_NAME));
+    }
+
+    static final Pattern GIT_PATTERN = Pattern.compile("git@([^:]+):([^\\.]+)\\.git");
+
+    /** Find the reponame. */
+    public static String urlFromOrigin(String origin) {
+        if (origin == null) {
+            return null; // best effort, the url doesnt really matter, it is just required by maven central
+        }
+        if (origin.startsWith("https")) {
+            return origin;
+        }
+        Matcher matcher = GIT_PATTERN.matcher(origin);
+        if (matcher.matches()) {
+            return String.format("https://%s/%s", matcher.group(1), matcher.group(2));
+        } else {
+            return origin; // best effort, the url doesnt really matter, it is just required by maven central
+        }
+    }
+
+    public static Object toStringable(Supplier<String> getter) {
+        return new Object() {
+            @Override
+            public String toString() {
+                return getter.get();
+            }
+        };
+    }
+}

--- a/buildSrc/src/main/java/org/elasticsearch/hadoop/gradle/buildtools/Util.java
+++ b/buildSrc/src/main/java/org/elasticsearch/hadoop/gradle/buildtools/Util.java
@@ -1,9 +1,20 @@
 /*
- * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License
- * 2.0 and the Server Side Public License, v 1; you may not use this file except
- * in compliance with, at your election, the Elastic License 2.0 or the Server
- * Side Public License, v 1.
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.elasticsearch.hadoop.gradle.buildtools;

--- a/buildSrc/src/main/java/org/elasticsearch/hadoop/gradle/buildtools/info/BuildParams.java
+++ b/buildSrc/src/main/java/org/elasticsearch/hadoop/gradle/buildtools/info/BuildParams.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+package org.elasticsearch.hadoop.gradle.buildtools.info;
+
+import org.gradle.api.JavaVersion;
+
+import java.io.File;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Consumer;
+
+import static java.util.Objects.requireNonNull;
+
+public class BuildParams {
+    private static File runtimeJavaHome;
+    private static Boolean isRuntimeJavaHomeSet;
+    private static List<JavaHome> javaVersions;
+    private static JavaVersion minimumCompilerVersion;
+    private static JavaVersion minimumRuntimeVersion;
+    private static JavaVersion runtimeJavaVersion;
+    private static Boolean inFipsJvm;
+    private static String gitRevision;
+    private static String testSeed;
+
+    /**
+     * Initialize global build parameters. This method accepts and a initialization function which in turn accepts a
+     * {@link MutableBuildParams}. Initialization can be done in "stages", therefore changes override existing values, and values from
+     * previous calls to {@link #init(Consumer)} carry forward. In cases where you want to clear existing values
+     * {@link MutableBuildParams#reset()} may be used.
+     *
+     * @param initializer Build parameter initializer
+     */
+    public static void init(Consumer<MutableBuildParams> initializer) {
+        initializer.accept(MutableBuildParams.INSTANCE);
+    }
+
+    public static File getRuntimeJavaHome() {
+        return value(runtimeJavaHome);
+    }
+
+    public static Boolean getIsRuntimeJavaHomeSet() {
+        return value(isRuntimeJavaHomeSet);
+    }
+
+    public static List<JavaHome> getJavaVersions() {
+        return value(javaVersions);
+    }
+
+    public static JavaVersion getMinimumCompilerVersion() {
+        return value(minimumCompilerVersion);
+    }
+
+    public static JavaVersion getMinimumRuntimeVersion() {
+        return value(minimumRuntimeVersion);
+    }
+
+    public static JavaVersion getRuntimeJavaVersion() {
+        return value(runtimeJavaVersion);
+    }
+
+    public static Boolean isInFipsJvm() {
+        return value(inFipsJvm);
+    }
+
+    public static String getGitRevision() {
+        return value(gitRevision);
+    }
+
+    public static String getTestSeed() {
+        return value(testSeed);
+    }
+
+    private static <T> T value(T object) {
+        if (object == null) {
+            String callingMethod = Thread.currentThread().getStackTrace()[2].getMethodName();
+
+            throw new IllegalStateException(
+                "Build parameter '"
+                    + propertyName(callingMethod)
+                    + "' has not been initialized.\n"
+                    + "Perhaps the plugin responsible for initializing this property has not been applied."
+            );
+        }
+
+        return object;
+    }
+
+    private static String propertyName(String methodName) {
+        String propertyName = methodName.startsWith("is") ? methodName.substring("is".length()) : methodName.substring("get".length());
+        return propertyName.substring(0, 1).toLowerCase() + propertyName.substring(1);
+    }
+
+    public static class MutableBuildParams {
+        private static MutableBuildParams INSTANCE = new MutableBuildParams();
+
+        private MutableBuildParams() {}
+
+        /**
+         * Resets any existing values from previous initializations.
+         */
+        public void reset() {
+            Arrays.stream(org.elasticsearch.hadoop.gradle.buildtools.info.BuildParams.class.getDeclaredFields()).filter(f -> Modifier.isStatic(f.getModifiers())).forEach(f -> {
+                try {
+                    // Since we are mutating private static fields from a public static inner class we need to suppress
+                    // accessibility controls here.
+                    f.setAccessible(true);
+                    f.set(null, null);
+                } catch (IllegalAccessException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+        }
+
+        public void setRuntimeJavaHome(File runtimeJavaHome) {
+            BuildParams.runtimeJavaHome = requireNonNull(runtimeJavaHome);
+        }
+
+        public void setIsRuntimeJavaHomeSet(boolean isRutimeJavaHomeSet) {
+            BuildParams.isRuntimeJavaHomeSet = isRutimeJavaHomeSet;
+        }
+
+        public void setJavaVersions(List<JavaHome> javaVersions) {
+            BuildParams.javaVersions = requireNonNull(javaVersions);
+        }
+
+        public void setMinimumCompilerVersion(JavaVersion minimumCompilerVersion) {
+            BuildParams.minimumCompilerVersion = requireNonNull(minimumCompilerVersion);
+        }
+
+        public void setMinimumRuntimeVersion(JavaVersion minimumRuntimeVersion) {
+            BuildParams.minimumRuntimeVersion = requireNonNull(minimumRuntimeVersion);
+        }
+
+        public void setRuntimeJavaVersion(JavaVersion runtimeJavaVersion) {
+            BuildParams.runtimeJavaVersion = requireNonNull(runtimeJavaVersion);
+        }
+
+        public void setInFipsJvm(boolean inFipsJvm) {
+            BuildParams.inFipsJvm = inFipsJvm;
+        }
+
+        public void setGitRevision(String gitRevision) {
+            BuildParams.gitRevision = requireNonNull(gitRevision);
+        }
+
+        public void setTestSeed(String testSeed) {
+            BuildParams.testSeed = requireNonNull(testSeed);
+        }
+    }
+}

--- a/buildSrc/src/main/java/org/elasticsearch/hadoop/gradle/buildtools/info/BuildParams.java
+++ b/buildSrc/src/main/java/org/elasticsearch/hadoop/gradle/buildtools/info/BuildParams.java
@@ -1,9 +1,20 @@
 /*
- * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License
- * 2.0 and the Server Side Public License, v 1; you may not use this file except
- * in compliance with, at your election, the Elastic License 2.0 or the Server
- * Side Public License, v 1.
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 package org.elasticsearch.hadoop.gradle.buildtools.info;
 

--- a/buildSrc/src/main/java/org/elasticsearch/hadoop/gradle/buildtools/info/GlobalBuildInfoPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/hadoop/gradle/buildtools/info/GlobalBuildInfoPlugin.java
@@ -1,9 +1,20 @@
 /*
- * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License
- * 2.0 and the Server Side Public License, v 1; you may not use this file except
- * in compliance with, at your election, the Elastic License 2.0 or the Server
- * Side Public License, v 1.
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 package org.elasticsearch.hadoop.gradle.buildtools.info;
 

--- a/buildSrc/src/main/java/org/elasticsearch/hadoop/gradle/buildtools/info/GlobalBuildInfoPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/hadoop/gradle/buildtools/info/GlobalBuildInfoPlugin.java
@@ -1,0 +1,459 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+package org.elasticsearch.hadoop.gradle.buildtools.info;
+
+import org.elasticsearch.gradle.OS;
+import org.elasticsearch.hadoop.gradle.buildtools.Util;
+import org.gradle.api.GradleException;
+import org.gradle.api.JavaVersion;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.provider.ProviderFactory;
+import org.gradle.internal.jvm.Jvm;
+import org.gradle.internal.jvm.inspection.JvmInstallationMetadata;
+import org.gradle.internal.jvm.inspection.JvmMetadataDetector;
+import org.gradle.internal.jvm.inspection.JvmVendor;
+import org.gradle.jvm.toolchain.internal.InstallationLocation;
+import org.gradle.jvm.toolchain.internal.JavaInstallationRegistry;
+import org.gradle.util.GradleVersion;
+
+import javax.inject.Inject;
+import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Random;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class GlobalBuildInfoPlugin implements Plugin<Project> {
+    private static final Logger LOGGER = Logging.getLogger(org.elasticsearch.hadoop.gradle.buildtools.info.GlobalBuildInfoPlugin.class);
+    private static final String DEFAULT_VERSION_JAVA_FILE_PATH = "server/src/main/java/org/elasticsearch/Version.java";
+    private static Integer _defaultParallel = null;
+
+    private final JavaInstallationRegistry javaInstallationRegistry;
+    private final JvmMetadataDetector metadataDetector;
+    private final ProviderFactory providers;
+
+    @Inject
+    public GlobalBuildInfoPlugin(
+        JavaInstallationRegistry javaInstallationRegistry,
+        JvmMetadataDetector metadataDetector,
+        ProviderFactory providers
+    ) {
+        this.javaInstallationRegistry = javaInstallationRegistry;
+        this.metadataDetector = metadataDetector;
+        this.providers = providers;
+    }
+
+    @Override
+    public void apply(Project project) {
+        if (project != project.getRootProject()) {
+            throw new IllegalStateException(this.getClass().getName() + " can only be applied to the root project.");
+        }
+        GradleVersion minimumGradleVersion = GradleVersion.version(Util.getResourceContents("/minimumGradleVersion"));
+        if (GradleVersion.current().compareTo(minimumGradleVersion) < 0) {
+            throw new GradleException("Gradle " + minimumGradleVersion.getVersion() + "+ is required");
+        }
+
+        JavaVersion minimumCompilerVersion = JavaVersion.toVersion(Util.getResourceContents("/minimumCompilerVersion"));
+        JavaVersion minimumRuntimeVersion = JavaVersion.toVersion(Util.getResourceContents("/minimumRuntimeVersion"));
+
+        File runtimeJavaHome = findRuntimeJavaHome();
+
+        File rootDir = project.getRootDir();
+        GitInfo gitInfo = gitInfo(rootDir);
+
+        BuildParams.init(params -> {
+            params.reset();
+            params.setRuntimeJavaHome(runtimeJavaHome);
+            params.setRuntimeJavaVersion(determineJavaVersion("runtime java.home", runtimeJavaHome, minimumRuntimeVersion));
+            params.setIsRuntimeJavaHomeSet(Jvm.current().getJavaHome().equals(runtimeJavaHome) == false);
+            JvmInstallationMetadata runtimeJdkMetaData = metadataDetector.getMetadata(getJavaInstallation(runtimeJavaHome).getLocation());
+            params.setJavaVersions(getAvailableJavaVersions());
+            params.setMinimumCompilerVersion(minimumCompilerVersion);
+            params.setMinimumRuntimeVersion(minimumRuntimeVersion);
+            params.setGitRevision(gitInfo.getRevision());
+            params.setTestSeed(getTestSeed());
+            params.setInFipsJvm(Util.getBooleanProperty("tests.fips.enabled", false));
+        });
+
+        // Print global build info header just before task execution
+        project.getGradle().getTaskGraph().whenReady(graph -> logGlobalBuildInfo());
+    }
+
+    private String formatJavaVendorDetails(JvmInstallationMetadata runtimeJdkMetaData) {
+        JvmVendor vendor = runtimeJdkMetaData.getVendor();
+        return runtimeJdkMetaData.getVendor().getKnownVendor().name() + "/" + vendor.getRawVendor();
+    }
+
+    private void logGlobalBuildInfo() {
+        final String osName = System.getProperty("os.name");
+        final String osVersion = System.getProperty("os.version");
+        final String osArch = System.getProperty("os.arch");
+        final Jvm gradleJvm = Jvm.current();
+        JvmInstallationMetadata gradleJvmMetadata = metadataDetector.getMetadata(gradleJvm.getJavaHome());
+        final String gradleJvmVendorDetails = gradleJvmMetadata.getVendor().getDisplayName();
+        LOGGER.quiet("=======================================");
+        LOGGER.quiet("Elasticsearch Build Hamster says Hello!");
+        LOGGER.quiet("  Gradle Version        : " + GradleVersion.current().getVersion());
+        LOGGER.quiet("  OS Info               : " + osName + " " + osVersion + " (" + osArch + ")");
+        if (BuildParams.getIsRuntimeJavaHomeSet()) {
+            final String runtimeJvmVendorDetails = metadataDetector.getMetadata(BuildParams.getRuntimeJavaHome())
+                .getVendor()
+                .getDisplayName();
+            LOGGER.quiet("  Runtime JDK Version   : " + BuildParams.getRuntimeJavaVersion() + " (" + runtimeJvmVendorDetails + ")");
+            LOGGER.quiet("  Runtime java.home     : " + BuildParams.getRuntimeJavaHome());
+            LOGGER.quiet("  Gradle JDK Version    : " + gradleJvm.getJavaVersion() + " (" + gradleJvmVendorDetails + ")");
+            LOGGER.quiet("  Gradle java.home      : " + gradleJvm.getJavaHome());
+        } else {
+            LOGGER.quiet("  JDK Version           : " + gradleJvm.getJavaVersion() + " (" + gradleJvmVendorDetails + ")");
+            LOGGER.quiet("  JAVA_HOME             : " + gradleJvm.getJavaHome());
+        }
+        LOGGER.quiet("  Random Testing Seed   : " + BuildParams.getTestSeed());
+        LOGGER.quiet("  In FIPS 140 mode      : " + BuildParams.isInFipsJvm());
+        LOGGER.quiet("=======================================");
+    }
+
+    private JavaVersion determineJavaVersion(String description, File javaHome, JavaVersion requiredVersion) {
+        InstallationLocation installation = getJavaInstallation(javaHome);
+        JavaVersion actualVersion = metadataDetector.getMetadata(installation.getLocation()).getLanguageVersion();
+        if (actualVersion.isCompatibleWith(requiredVersion) == false) {
+            throwInvalidJavaHomeException(
+                description,
+                javaHome,
+                Integer.parseInt(requiredVersion.getMajorVersion()),
+                Integer.parseInt(actualVersion.getMajorVersion())
+            );
+        }
+
+        return actualVersion;
+    }
+
+    private InstallationLocation getJavaInstallation(File javaHome) {
+        return getAvailableJavaInstallationLocationSteam().filter(installationLocation -> isSameFile(javaHome, installationLocation))
+            .findFirst()
+            .orElseThrow(() -> new GradleException("Could not locate available Java installation in Gradle registry at: " + javaHome));
+    }
+
+    private boolean isSameFile(File javaHome, InstallationLocation installationLocation) {
+        try {
+            return Files.isSameFile(installationLocation.getLocation().toPath(), javaHome.toPath());
+        } catch (IOException ioException) {
+            throw new UncheckedIOException(ioException);
+        }
+    }
+
+    /**
+     * We resolve all available java versions using auto detected by gradles tool chain
+     * To make transition more reliable we only take env var provided installations into account for now
+     */
+    private List<JavaHome> getAvailableJavaVersions() {
+        return getAvailableJavaInstallationLocationSteam().map(installationLocation -> {
+            File installationDir = installationLocation.getLocation();
+            JvmInstallationMetadata metadata = metadataDetector.getMetadata(installationDir);
+            int actualVersion = Integer.parseInt(metadata.getLanguageVersion().getMajorVersion());
+            return JavaHome.of(actualVersion, providers.provider(() -> installationDir));
+        }).collect(Collectors.toList());
+    }
+
+    private Stream<InstallationLocation> getAvailableJavaInstallationLocationSteam() {
+        return Stream.concat(
+            javaInstallationRegistry.listInstallations().stream(),
+            Stream.of(new InstallationLocation(Jvm.current().getJavaHome(), "Current JVM"))
+        );
+    }
+
+    private static String getTestSeed() {
+        String testSeedProperty = System.getProperty("tests.seed");
+        final String testSeed;
+        if (testSeedProperty == null) {
+            long seed = new Random(System.currentTimeMillis()).nextLong();
+            testSeed = Long.toUnsignedString(seed, 16).toUpperCase(Locale.ROOT);
+        } else {
+            testSeed = testSeedProperty;
+        }
+        return testSeed;
+    }
+
+    private static void throwInvalidJavaHomeException(String description, File javaHome, int expectedVersion, int actualVersion) {
+        String message = String.format(
+            Locale.ROOT,
+            "The %s must be set to a JDK installation directory for Java %d but is [%s] corresponding to [%s]",
+            description,
+            expectedVersion,
+            javaHome,
+            actualVersion
+        );
+
+        throw new GradleException(message);
+    }
+
+    private static void assertMinimumCompilerVersion(JavaVersion minimumCompilerVersion) {
+        JavaVersion currentVersion = Jvm.current().getJavaVersion();
+        if (minimumCompilerVersion.compareTo(currentVersion) > 0) {
+            throw new GradleException(
+                "Project requires Java version of " + minimumCompilerVersion + " or newer but Gradle JAVA_HOME is " + currentVersion
+            );
+        }
+    }
+
+    private File findRuntimeJavaHome() {
+        String runtimeJavaProperty = System.getProperty("runtime.java");
+
+        if (runtimeJavaProperty != null) {
+            return new File(findJavaHome(runtimeJavaProperty));
+        }
+
+        return System.getenv("RUNTIME_JAVA_HOME") == null ? Jvm.current().getJavaHome() : new File(System.getenv("RUNTIME_JAVA_HOME"));
+    }
+
+    private String findJavaHome(String version) {
+        Provider<String> javaHomeNames = providers.gradleProperty("org.gradle.java.installations.fromEnv").forUseAtConfigurationTime();
+        String javaHomeEnvVar = getJavaHomeEnvVarName(version);
+
+        // Provide a useful error if we're looking for a Java home version that we haven't told Gradle about yet
+        Arrays.stream(javaHomeNames.get().split(","))
+            .filter(s -> s.equals(javaHomeEnvVar))
+            .findFirst()
+            .orElseThrow(
+                () -> new GradleException(
+                    "Environment variable '"
+                        + javaHomeEnvVar
+                        + "' is not registered with Gradle installation supplier. Ensure 'org.gradle.java.installations.fromEnv' is "
+                        + "updated in gradle.properties file."
+                )
+            );
+
+        String versionedJavaHome = System.getenv(javaHomeEnvVar);
+        if (versionedJavaHome == null) {
+            final String exceptionMessage = String.format(
+                Locale.ROOT,
+                "$%s must be set to build Elasticsearch. "
+                    + "Note that if the variable was just set you "
+                    + "might have to run `./gradlew --stop` for "
+                    + "it to be picked up. See https://github.com/elastic/elasticsearch/issues/31399 details.",
+                javaHomeEnvVar
+            );
+
+            throw new GradleException(exceptionMessage);
+        }
+        return versionedJavaHome;
+    }
+
+    private static String getJavaHomeEnvVarName(String version) {
+        return "JAVA" + version + "_HOME";
+    }
+
+    private static int findDefaultParallel(Project project) {
+        // Since it costs IO to compute this, and is done at configuration time we want to cache this if possible
+        // It's safe to store this in a static variable since it's just a primitive so leaking memory isn't an issue
+        if (_defaultParallel == null) {
+            File cpuInfoFile = new File("/proc/cpuinfo");
+            if (cpuInfoFile.exists()) {
+                // Count physical cores on any Linux distro ( don't count hyper-threading )
+                Map<String, Integer> socketToCore = new HashMap<>();
+                String currentID = "";
+
+                try (BufferedReader reader = new BufferedReader(new FileReader(cpuInfoFile))) {
+                    for (String line = reader.readLine(); line != null; line = reader.readLine()) {
+                        if (line.contains(":")) {
+                            List<String> parts = Arrays.stream(line.split(":", 2)).map(String::trim).collect(Collectors.toList());
+                            String name = parts.get(0);
+                            String value = parts.get(1);
+                            // the ID of the CPU socket
+                            if (name.equals("physical id")) {
+                                currentID = value;
+                            }
+                            // Number of cores not including hyper-threading
+                            if (name.equals("cpu cores")) {
+                                assert currentID.isEmpty() == false;
+                                socketToCore.put("currentID", Integer.valueOf(value));
+                                currentID = "";
+                            }
+                        }
+                    }
+                } catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                }
+                _defaultParallel = socketToCore.values().stream().mapToInt(i -> i).sum();
+            } else if (OS.current() == OS.MAC) {
+                // Ask macOS to count physical CPUs for us
+                ByteArrayOutputStream stdout = new ByteArrayOutputStream();
+                project.exec(spec -> {
+                    spec.setExecutable("sysctl");
+                    spec.args("-n", "hw.physicalcpu");
+                    spec.setStandardOutput(stdout);
+                });
+
+                _defaultParallel = Integer.parseInt(stdout.toString().trim());
+            }
+
+            _defaultParallel = Runtime.getRuntime().availableProcessors() / 2;
+        }
+
+        return _defaultParallel;
+    }
+
+    public static GitInfo gitInfo(File rootDir) {
+        try {
+            /*
+             * We want to avoid forking another process to run git rev-parse HEAD. Instead, we will read the refs manually. The
+             * documentation for this follows from https://git-scm.com/docs/gitrepository-layout and https://git-scm.com/docs/git-worktree.
+             *
+             * There are two cases to consider:
+             *  - a plain repository with .git directory at the root of the working tree
+             *  - a worktree with a plain text .git file at the root of the working tree
+             *
+             * In each case, our goal is to parse the HEAD file to get either a ref or a bare revision (in the case of being in detached
+             * HEAD state).
+             *
+             * In the case of a plain repository, we can read the HEAD file directly, resolved directly from the .git directory.
+             *
+             * In the case of a worktree, we read the gitdir from the plain text .git file. This resolves to a directory from which we read
+             * the HEAD file and resolve commondir to the plain git repository.
+             */
+            final Path dotGit = rootDir.toPath().resolve(".git");
+            final String revision;
+            if (Files.exists(dotGit) == false) {
+                return new GitInfo("unknown", "unknown");
+            }
+            final Path head;
+            final Path gitDir;
+            if (Files.isDirectory(dotGit)) {
+                // this is a git repository, we can read HEAD directly
+                head = dotGit.resolve("HEAD");
+                gitDir = dotGit;
+            } else {
+                // this is a git worktree, follow the pointer to the repository
+                final Path workTree = Paths.get(readFirstLine(dotGit).substring("gitdir:".length()).trim());
+                if (Files.exists(workTree) == false) {
+                    return new GitInfo("unknown", "unknown");
+                }
+                head = workTree.resolve("HEAD");
+                final Path commonDir = Paths.get(readFirstLine(workTree.resolve("commondir")));
+                if (commonDir.isAbsolute()) {
+                    gitDir = commonDir;
+                } else {
+                    // this is the common case
+                    gitDir = workTree.resolve(commonDir);
+                }
+            }
+            final String ref = readFirstLine(head);
+            if (ref.startsWith("ref:")) {
+                String refName = ref.substring("ref:".length()).trim();
+                Path refFile = gitDir.resolve(refName);
+                if (Files.exists(refFile)) {
+                    revision = readFirstLine(refFile);
+                } else if (Files.exists(gitDir.resolve("packed-refs"))) {
+                    // Check packed references for commit ID
+                    Pattern p = Pattern.compile("^([a-f0-9]{40}) " + refName + "$");
+                    try (Stream<String> lines = Files.lines(gitDir.resolve("packed-refs"))) {
+                        revision = lines.map(p::matcher)
+                            .filter(Matcher::matches)
+                            .map(m -> m.group(1))
+                            .findFirst()
+                            .orElseThrow(() -> new IOException("Packed reference not found for refName " + refName));
+                    }
+                } else {
+                    File refsDir = gitDir.resolve("refs").toFile();
+                    if (refsDir.exists()) {
+                        String foundRefs = Arrays.stream(refsDir.listFiles()).map(f -> f.getName()).collect(Collectors.joining("\n"));
+                        Logging.getLogger(org.elasticsearch.hadoop.gradle.buildtools.info.GlobalBuildInfoPlugin.class).error("Found git refs\n" + foundRefs);
+                    } else {
+                        Logging.getLogger(org.elasticsearch.hadoop.gradle.buildtools.info.GlobalBuildInfoPlugin.class).error("No git refs dir found");
+                    }
+                    throw new GradleException("Can't find revision for refName " + refName);
+                }
+            } else {
+                // we are in detached HEAD state
+                revision = ref;
+            }
+            return new GitInfo(revision, findOriginUrl(gitDir.resolve("config")));
+        } catch (final IOException e) {
+            // for now, do not be lenient until we have better understanding of real-world scenarios where this happens
+            throw new GradleException("unable to read the git revision", e);
+        }
+    }
+
+    private static String findOriginUrl(final Path configFile) throws IOException {
+        Map<String, String> props = new HashMap<>();
+
+        try (Stream<String> stream = Files.lines(configFile, StandardCharsets.UTF_8)) {
+            Iterator<String> lines = stream.iterator();
+            boolean foundOrigin = false;
+            while (lines.hasNext()) {
+                String line = lines.next().trim();
+                if (line.startsWith(";") || line.startsWith("#")) {
+                    // ignore comments
+                    continue;
+                }
+                if (foundOrigin) {
+                    if (line.startsWith("[")) {
+                        // we're on to the next config item so stop looking
+                        break;
+                    }
+                    String[] pair = line.trim().split("=", 2);
+                    props.put(pair[0].trim(), pair[1].trim());
+                } else {
+                    if (line.equals("[remote \"origin\"]")) {
+                        foundOrigin = true;
+                    }
+                }
+            }
+        }
+
+        String originUrl = props.get("url");
+        return originUrl == null ? "unknown" : originUrl;
+    }
+
+    private static String readFirstLine(final Path path) throws IOException {
+        String firstLine;
+        try (Stream<String> lines = Files.lines(path, StandardCharsets.UTF_8)) {
+            firstLine = lines.findFirst().orElseThrow(() -> new IOException("file [" + path + "] is empty"));
+        }
+        return firstLine;
+    }
+
+    public static class GitInfo {
+        private final String revision;
+        private final String origin;
+
+        GitInfo(String revision, String origin) {
+            this.revision = revision;
+            this.origin = origin;
+        }
+
+        public String getRevision() {
+            return revision;
+        }
+
+        public String getOrigin() {
+            return origin;
+        }
+    }
+}

--- a/buildSrc/src/main/java/org/elasticsearch/hadoop/gradle/buildtools/info/JavaHome.java
+++ b/buildSrc/src/main/java/org/elasticsearch/hadoop/gradle/buildtools/info/JavaHome.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+package org.elasticsearch.hadoop.gradle.buildtools.info;
+
+import org.gradle.api.provider.Provider;
+
+import java.io.File;
+
+public class JavaHome {
+    private Integer version;
+    private Provider<File> javaHome;
+
+    private JavaHome(int version, Provider<File> javaHome) {
+        this.version = version;
+        this.javaHome = javaHome;
+    }
+
+    public static org.elasticsearch.hadoop.gradle.buildtools.info.JavaHome of(int version, Provider<File> javaHome) {
+        return new org.elasticsearch.hadoop.gradle.buildtools.info.JavaHome(version, javaHome);
+    }
+
+    public Integer getVersion() {
+        return version;
+    }
+
+    public Provider<File> getJavaHome() {
+        return javaHome;
+    }
+}

--- a/buildSrc/src/main/java/org/elasticsearch/hadoop/gradle/buildtools/info/JavaHome.java
+++ b/buildSrc/src/main/java/org/elasticsearch/hadoop/gradle/buildtools/info/JavaHome.java
@@ -1,9 +1,20 @@
 /*
- * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License
- * 2.0 and the Server Side Public License, v 1; you may not use this file except
- * in compliance with, at your election, the Elastic License 2.0 or the Server
- * Side Public License, v 1.
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 package org.elasticsearch.hadoop.gradle.buildtools.info;
 

--- a/buildSrc/src/main/java/org/elasticsearch/hadoop/gradle/buildtools/package-info.java
+++ b/buildSrc/src/main/java/org/elasticsearch/hadoop/gradle/buildtools/package-info.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 /**
  * All classes in org.elasticsearch.hadoop.gradle.buildtools are originally
  * copied from the elasticsearch build-tools project. These classes are

--- a/buildSrc/src/main/java/org/elasticsearch/hadoop/gradle/buildtools/package-info.java
+++ b/buildSrc/src/main/java/org/elasticsearch/hadoop/gradle/buildtools/package-info.java
@@ -1,0 +1,13 @@
+/**
+ * All classes in org.elasticsearch.hadoop.gradle.buildtools are originally
+ * copied from the elasticsearch build-tools project. These classes are
+ * considered internal in build tools and will not be supported by the build tools
+ * team and also not being published in upcoming build tool releases.
+ * This will make it easier to build tools team to move forward and distinct explicitly
+ * between internal and shared and published build logic to be used by external
+ * elasticsearch plugins.
+ *
+ * We'll revisit these classes here and adjust as the dedicated public build tools plugins
+ * evolve over time.
+ */
+package org.elasticsearch.hadoop.gradle.buildtools;

--- a/buildSrc/src/main/java/org/elasticsearch/hadoop/gradle/util/Resources.java
+++ b/buildSrc/src/main/java/org/elasticsearch/hadoop/gradle/util/Resources.java
@@ -24,19 +24,17 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.UncheckedIOException;
 
-import org.elasticsearch.gradle.info.GlobalBuildInfoPlugin;
-
 public class Resources {
 
     /**
-     * Duplicated from org.elasticsearch.gradle.info.GlobalBuildInfoPlugin#getResourceContents(java.lang.String)
+     * Duplicated from org.elasticsearch.hadoop.gradle.buildtools.info.GlobalBuildInfoPlugin#getResourceContents(java.lang.String)
      * Needed in BuildPlugin for reading ES-Hadoop specific minimum runtime and compile versions
      * @param resourcePath the classpath resource to load
      * @return The contents of the resource file
      */
     public static String getResourceContents(String resourcePath) {
         try (BufferedReader reader = new BufferedReader(
-                new InputStreamReader(GlobalBuildInfoPlugin.class.getResourceAsStream(resourcePath))
+                new InputStreamReader(Resources.class.getResourceAsStream(resourcePath))
         )) {
             StringBuilder b = new StringBuilder();
             for (String line = reader.readLine(); line != null; line = reader.readLine()) {

--- a/dist/build.gradle
+++ b/dist/build.gradle
@@ -1,6 +1,6 @@
-import org.elasticsearch.gradle.ConcatFilesTask
-import org.elasticsearch.gradle.DependenciesInfoTask
-import org.elasticsearch.gradle.internal.precommit.DependencyLicensesTask
+import org.elasticsearch.hadoop.gradle.buildtools.ConcatFilesTask
+import org.elasticsearch.hadoop.gradle.buildtools.DependenciesInfoTask
+import org.elasticsearch.hadoop.gradle.buildtools.DependencyLicensesTask
 import org.elasticsearch.hadoop.gradle.BuildPlugin
 
 apply plugin: 'es.hadoop.build'

--- a/hive/build.gradle
+++ b/hive/build.gradle
@@ -1,4 +1,4 @@
-import org.elasticsearch.gradle.info.BuildParams
+import org.elasticsearch.hadoop.gradle.buildtools.info.BuildParams
 
 apply plugin: 'es.hadoop.build.integration'
 

--- a/mr/build.gradle
+++ b/mr/build.gradle
@@ -1,4 +1,4 @@
-import org.elasticsearch.gradle.info.BuildParams
+import org.elasticsearch.hadoop.gradle.buildtools.info.BuildParams
 
 apply plugin: 'es.hadoop.build.integration'
 

--- a/qa/kerberos/build.gradle
+++ b/qa/kerberos/build.gradle
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import org.elasticsearch.gradle.test.AntFixture
+import org.elasticsearch.hadoop.gradle.buildtools.AntFixture
 import org.elasticsearch.gradle.testclusters.DefaultTestClustersTask
 import org.elasticsearch.hadoop.gradle.fixture.hadoop.HadoopFixturePlugin
 import org.elasticsearch.hadoop.gradle.fixture.hadoop.ServiceDescriptor


### PR DESCRIPTION
This PR detangles the hadoop build from the internal classes of elasticsearch build tools.
Mostly it copies over (simplified) plugins and tasks used by hadoop that are not supported
by build tools and not be puslished in the future to be used by external plugins.
In the longterm we probably will regrow the public surface of the elasticsearch build tools but
for now we basically only want to support TestCluster usage and a basic version of the
PluginBuildPlugin to support external projects building elasticsearch plugins.

This is related to https://github.com/elastic/elasticsearch/issues/71593

Tested manually here: //gradle-enterprise.elastic.co/s/6xbuknj4e24u2

- [x ] I have signed the [Contributor License Agreement (CLA)][]

[Contributor License Agreement (CLA)]: https://www.elastic.co/contributor-agreement/
