### PR TITLE
[7.x] [DOCS] Add 7.13.0 release notes (#1662)

### DIFF
--- a/docs/src/reference/asciidoc/appendix/release-notes/7.13.0.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/7.13.0.adoc
@@ -1,0 +1,11 @@
+[[eshadoop-7.13.0]]
+== Elasticsearch for Apache Hadoop version 7.13.0
+
+coming::[7.13.0]
+
+[[new-7.13.0]]
+=== Enhancements
+
+Build::
+- Upgrade Hadoop and Hive to version 3
+https://github.com/elastic/elasticsearch-hadoop/pull/1636[#1636]

--- a/docs/src/reference/asciidoc/appendix/release.adoc
+++ b/docs/src/reference/asciidoc/appendix/release.adoc
@@ -9,6 +9,7 @@ This section summarizes the changes in each release.
 [[release-notes-7]]
 ===== 7.x
 
+* <<eshadoop-7.13.0>>
 * <<eshadoop-7.12.1>>
 * <<eshadoop-7.12.0>>
 * <<eshadoop-7.11.2>>
@@ -97,6 +98,7 @@ http://github.com/elastic/elasticsearch-hadoop/issues/XXX[#XXX]
 
 ////////////////////////
 
+include::release-notes/7.13.0.adoc[]
 include::release-notes/7.12.1.adoc[]
 include::release-notes/7.12.0.adoc[]
 include::release-notes/7.11.2.adoc[]


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Add 7.13.0 release notes (#1662)