### PR TITLE
[master] [DOCS] Remove 7.12.1 coming tag (#1648)

### DIFF
--- a/docs/src/reference/asciidoc/appendix/release-notes/7.12.1.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/7.12.1.adoc
@@ -1,7 +1,5 @@
 [[eshadoop-7.12.1]]
 == Elasticsearch for Apache Hadoop version 7.12.1
 
-coming::[7.12.1]
-
 ES-Hadoop 7.12.1 is a version compatibility release, tested specifically against
 Elasticsearch 7.12.1.


### PR DESCRIPTION
Backports the following commits to master:
 - [DOCS] Remove 7.12.1 coming tag (#1648)