### PR TITLE
Fix spring io repository usage

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/BaseBuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/BaseBuildPlugin.groovy
@@ -165,7 +165,7 @@ class BaseBuildPlugin implements Plugin<Project> {
         project.repositories.mavenCentral()
         project.repositories.maven { url "https://conjars.org/repo" }
         project.repositories.maven { url "https://clojars.org/repo" }
-        project.repositories.maven { url 'https://repo.spring.io/plugins-release' }
+        project.repositories.maven { url 'https://repo.spring.io/plugins-release-local' }
 
         // For Elasticsearch snapshots.
         project.repositories.maven { url "https://snapshots.elastic.co/maven/" } // default


### PR DESCRIPTION
- spring.io/plugin-release has been deprecated and need to be replaced with
spring.io/plugin-release-local

Fixes #1669