### PR TITLE
Fix failing strict wildcard pushdown tests

### DIFF
--- a/spark/sql-13/src/itest/scala/org/elasticsearch/spark/integration/AbstractScalaEsSparkSQL.scala
+++ b/spark/sql-13/src/itest/scala/org/elasticsearch/spark/integration/AbstractScalaEsSparkSQL.scala
@@ -1005,8 +1005,12 @@ class AbstractScalaEsScalaSparkSQL(prefix: String, readMetadata: jl.Boolean, pus
     }
 
     filter.show
-    assertEquals(1, filter.count())
-    assertEquals("feb", filter.select("tag").take(1)(0)(0))
+    if (strictPushDown) {
+      assertEquals(0, filter.count()) // Strict means specific terms matching, and the terms are lowercased
+    } else {
+      assertEquals(1, filter.count())
+      assertEquals("feb", filter.select("tag").take(1)(0)(0))
+    }
   }
 
   @Test
@@ -1021,8 +1025,12 @@ class AbstractScalaEsScalaSparkSQL(prefix: String, readMetadata: jl.Boolean, pus
     }
 
     filter.show
-    assertEquals(1, filter.count())
-    assertEquals("jan", filter.select("tag").take(1)(0)(0))
+    if (strictPushDown) {
+      assertEquals(0, filter.count()) // Strict means specific terms matching, and the terms are lowercased
+    } else {
+      assertEquals(1, filter.count())
+      assertEquals("jan", filter.select("tag").take(1)(0)(0))
+    }
   }
 
   @Test
@@ -1036,7 +1044,7 @@ class AbstractScalaEsScalaSparkSQL(prefix: String, readMetadata: jl.Boolean, pus
   @Test
   def testDataSourcePushDown12And() {
     val df = esDataSource("pd_and")
-    var filter = df.filter(df("reason").isNotNull.and(df("airport").endsWith("O")))
+    var filter = df.filter(df("reason").isNotNull.and(df("tag").equalTo("jan")))
 
     assertEquals(1, filter.count())
     assertEquals("jan", filter.select("tag").take(1)(0)(0))

--- a/spark/sql-13/src/itest/scala/org/elasticsearch/spark/integration/AbstractScalaEsSparkSQL.scala
+++ b/spark/sql-13/src/itest/scala/org/elasticsearch/spark/integration/AbstractScalaEsSparkSQL.scala
@@ -998,7 +998,7 @@ class AbstractScalaEsScalaSparkSQL(prefix: String, readMetadata: jl.Boolean, pus
     val df = esDataSource("pd_starts_with")
     var filter = df.filter(df("airport").startsWith("O"))
 
-    if (!keepHandledFilters) {
+    if (!keepHandledFilters && !strictPushDown) {
       // term query pick field with multi values
       assertEquals(2, filter.count())
       return
@@ -1018,7 +1018,7 @@ class AbstractScalaEsScalaSparkSQL(prefix: String, readMetadata: jl.Boolean, pus
     val df = esDataSource("pd_ends_with")
     var filter = df.filter(df("airport").endsWith("O"))
 
-    if (!keepHandledFilters) {
+    if (!keepHandledFilters && !strictPushDown) {
       // term query pick field with multi values
       assertEquals(2, filter.count())
       return

--- a/spark/sql-20/src/itest/scala/org/elasticsearch/spark/integration/AbstractScalaEsSparkSQL.scala
+++ b/spark/sql-20/src/itest/scala/org/elasticsearch/spark/integration/AbstractScalaEsSparkSQL.scala
@@ -1062,8 +1062,12 @@ class AbstractScalaEsScalaSparkSQL(prefix: String, readMetadata: jl.Boolean, pus
     }
 
     filter.show
-    assertEquals(1, filter.count())
-    assertEquals("feb", filter.select("tag").take(1)(0)(0))
+    if (strictPushDown) {
+      assertEquals(0, filter.count()) // Strict means specific terms matching, and the terms are lowercased
+    } else {
+      assertEquals(1, filter.count())
+      assertEquals("feb", filter.select("tag").take(1)(0)(0))
+    }
   }
 
   @Test
@@ -1078,8 +1082,12 @@ class AbstractScalaEsScalaSparkSQL(prefix: String, readMetadata: jl.Boolean, pus
     }
 
     filter.show
-    assertEquals(1, filter.count())
-    assertEquals("jan", filter.select("tag").take(1)(0)(0))
+    if (strictPushDown) {
+      assertEquals(0, filter.count()) // Strict means specific terms matching, and the terms are lowercased
+    } else {
+      assertEquals(1, filter.count())
+      assertEquals("jan", filter.select("tag").take(1)(0)(0))
+    }
   }
 
   @Test
@@ -1093,7 +1101,7 @@ class AbstractScalaEsScalaSparkSQL(prefix: String, readMetadata: jl.Boolean, pus
   @Test
   def testDataSourcePushDown12And() {
     val df = esDataSource("pd_and")
-    var filter = df.filter(df("reason").isNotNull.and(df("airport").endsWith("O")))
+    var filter = df.filter(df("reason").isNotNull.and(df("tag").equalTo("jan")))
 
     assertEquals(1, filter.count())
     assertEquals("jan", filter.select("tag").take(1)(0)(0))

--- a/spark/sql-20/src/itest/scala/org/elasticsearch/spark/integration/AbstractScalaEsSparkSQL.scala
+++ b/spark/sql-20/src/itest/scala/org/elasticsearch/spark/integration/AbstractScalaEsSparkSQL.scala
@@ -1055,7 +1055,7 @@ class AbstractScalaEsScalaSparkSQL(prefix: String, readMetadata: jl.Boolean, pus
     val df = esDataSource("pd_starts_with")
     var filter = df.filter(df("airport").startsWith("O"))
 
-    if (!keepHandledFilters) {
+    if (!keepHandledFilters && !strictPushDown) {
       // term query pick field with multi values
       assertEquals(2, filter.count())
       return
@@ -1075,7 +1075,7 @@ class AbstractScalaEsScalaSparkSQL(prefix: String, readMetadata: jl.Boolean, pus
     val df = esDataSource("pd_ends_with")
     var filter = df.filter(df("airport").endsWith("O"))
 
-    if (!keepHandledFilters) {
+    if (!keepHandledFilters && !strictPushDown) {
       // term query pick field with multi values
       assertEquals(2, filter.count())
       return

--- a/spark/sql-30/src/itest/scala/org/elasticsearch/spark/integration/AbstractScalaEsSparkSQL.scala
+++ b/spark/sql-30/src/itest/scala/org/elasticsearch/spark/integration/AbstractScalaEsSparkSQL.scala
@@ -1062,8 +1062,12 @@ class AbstractScalaEsScalaSparkSQL(prefix: String, readMetadata: jl.Boolean, pus
     }
 
     filter.show
-    assertEquals(1, filter.count())
-    assertEquals("feb", filter.select("tag").take(1)(0)(0))
+    if (strictPushDown) {
+      assertEquals(0, filter.count()) // Strict means specific terms matching, and the terms are lowercased
+    } else {
+      assertEquals(1, filter.count())
+      assertEquals("feb", filter.select("tag").take(1)(0)(0))
+    }
   }
 
   @Test
@@ -1078,8 +1082,12 @@ class AbstractScalaEsScalaSparkSQL(prefix: String, readMetadata: jl.Boolean, pus
     }
 
     filter.show
-    assertEquals(1, filter.count())
-    assertEquals("jan", filter.select("tag").take(1)(0)(0))
+    if (strictPushDown) {
+      assertEquals(0, filter.count()) // Strict means specific terms matching, and the terms are lowercased
+    } else {
+      assertEquals(1, filter.count())
+      assertEquals("jan", filter.select("tag").take(1)(0)(0))
+    }
   }
 
   @Test
@@ -1093,7 +1101,7 @@ class AbstractScalaEsScalaSparkSQL(prefix: String, readMetadata: jl.Boolean, pus
   @Test
   def testDataSourcePushDown12And() {
     val df = esDataSource("pd_and")
-    var filter = df.filter(df("reason").isNotNull.and(df("airport").endsWith("O")))
+    var filter = df.filter(df("reason").isNotNull.and(df("tag").equalTo("jan")))
 
     assertEquals(1, filter.count())
     assertEquals("jan", filter.select("tag").take(1)(0)(0))

--- a/spark/sql-30/src/itest/scala/org/elasticsearch/spark/integration/AbstractScalaEsSparkSQL.scala
+++ b/spark/sql-30/src/itest/scala/org/elasticsearch/spark/integration/AbstractScalaEsSparkSQL.scala
@@ -1055,7 +1055,7 @@ class AbstractScalaEsScalaSparkSQL(prefix: String, readMetadata: jl.Boolean, pus
     val df = esDataSource("pd_starts_with")
     var filter = df.filter(df("airport").startsWith("O"))
 
-    if (!keepHandledFilters) {
+    if (!keepHandledFilters && !strictPushDown) {
       // term query pick field with multi values
       assertEquals(2, filter.count())
       return
@@ -1075,7 +1075,7 @@ class AbstractScalaEsScalaSparkSQL(prefix: String, readMetadata: jl.Boolean, pus
     val df = esDataSource("pd_ends_with")
     var filter = df.filter(df("airport").endsWith("O"))
 
-    if (!keepHandledFilters) {
+    if (!keepHandledFilters && !strictPushDown) {
       // term query pick field with multi values
       assertEquals(2, filter.count())
       return


### PR DESCRIPTION
A change that went in a while ago has made changes to the wildcard query functionality. It now functions as it had historically. This PR updates the testing logic to make sure the wildcard tests account for these differences.