### PR TITLE
[7.x] Remove conjars repository as it is not consistently available (#1684)

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/BaseBuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/BaseBuildPlugin.groovy
@@ -172,7 +172,6 @@ class BaseBuildPlugin implements Plugin<Project> {
      */
     private static void configureRepositories(Project project) {
         project.repositories.mavenCentral()
-        project.repositories.maven { url "https://conjars.org/repo" }
         project.repositories.maven { url "https://clojars.org/repo" }
         project.repositories.maven { url 'https://repo.spring.io/plugins-release-local' }
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Remove conjars repository as it is not consistently available (#1684)