### PR TITLE
Remove problem dependency

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/BuildPlugin.groovy
@@ -172,7 +172,7 @@ class BuildPlugin implements Plugin<Project>  {
         project.repositories.mavenCentral()
         project.repositories.maven { url "https://conjars.org/repo" }
         project.repositories.maven { url "https://clojars.org/repo" }
-        project.repositories.maven { url 'https://repo.spring.io/plugins-release' }
+        project.repositories.maven { url 'https://repo.spring.io/plugins-release-local' }
 
         // Elastic artifacts
         project.repositories.maven { url "https://artifacts.elastic.co/maven/" } // default

--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/BuildPlugin.groovy
@@ -172,7 +172,7 @@ class BuildPlugin implements Plugin<Project>  {
         project.repositories.mavenCentral()
         project.repositories.maven { url "https://conjars.org/repo" }
         project.repositories.maven { url "https://clojars.org/repo" }
-        project.repositories.maven { url 'https://repo.spring.io/plugins-release-local' }
+//        project.repositories.maven { url 'https://repo.spring.io/plugins-release' }
 
         // Elastic artifacts
         project.repositories.maven { url "https://artifacts.elastic.co/maven/" } // default

--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/BuildPlugin.groovy
@@ -172,7 +172,7 @@ class BuildPlugin implements Plugin<Project>  {
         project.repositories.mavenCentral()
         project.repositories.maven { url "https://conjars.org/repo" }
         project.repositories.maven { url "https://clojars.org/repo" }
-//        project.repositories.maven { url 'https://repo.spring.io/plugins-release' }
+        project.repositories.maven { url 'https://repo.spring.io/plugins-release' }
 
         // Elastic artifacts
         project.repositories.maven { url "https://artifacts.elastic.co/maven/" } // default

--- a/hive/build.gradle
+++ b/hive/build.gradle
@@ -33,6 +33,7 @@ sourcesJar {
 dependencies {
     provided("org.apache.hive:hive-service:$hiveVersion") {
         exclude module: "log4j-slf4j-impl"
+        exclude module: "pentaho-aggdesigner-algorithm"
     }
 
     itestRuntime("org.apache.hive:hive-jdbc:$hiveVersion") {


### PR DESCRIPTION
Snapshot builds and CI is failing because a dependency cannot be reliably pulled from the repository it is in. The locations it is persisted in are either inaccessible or being sunset, and we luckily do not even use it, so this PR removes it from being considered by the build.