### PR TITLE
[master] [DOCS] Remove 7.13.2 coming tag (#1690)

### DIFF
--- a/docs/src/reference/asciidoc/appendix/release-notes/7.13.2.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/7.13.2.adoc
@@ -1,7 +1,5 @@
 [[eshadoop-7.13.2]]
 == Elasticsearch for Apache Hadoop version 7.13.2
 
-coming::[7.13.2]
-
 ES-Hadoop 7.13.2 is a version compatibility release, tested specifically against
 Elasticsearch 7.13.2.


### PR DESCRIPTION
Backports the following commits to master:
 - [DOCS] Remove 7.13.2 coming tag (#1690)