### PR TITLE
[7.x] Verify cluster main info response returns correct product headers (#1679)

### DIFF
--- a/mr/src/main/java/org/elasticsearch/hadoop/handler/impl/elasticsearch/ElasticsearchHandler.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/handler/impl/elasticsearch/ElasticsearchHandler.java
@@ -152,7 +152,7 @@ public class ElasticsearchHandler<I extends Exceptional, O, C extends ErrorColle
         }
 
         // Ensure no pattern in Index format, and extract the index to send errors to
-        InitializationUtils.discoverClusterInfo(clientSettings, LOG);
+        InitializationUtils.discoverAndValidateClusterInfo(clientSettings, LOG);
         Resource resource = new Resource(clientSettings, false);
         IndexExtractor iformat = ObjectUtils.instantiate(clientSettings.getMappingIndexExtractorClassName(), handlerSettings);
         iformat.compile(resource.toString());

--- a/mr/src/main/java/org/elasticsearch/hadoop/rest/Response.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/rest/Response.java
@@ -19,6 +19,8 @@
 package org.elasticsearch.hadoop.rest;
 
 import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
 
 public interface Response {
 
@@ -43,4 +45,6 @@ public interface Response {
     boolean hasSucceeded();
 
     boolean hasFailed();
+
+    Map<String, List<String>> headers();
 }

--- a/mr/src/main/java/org/elasticsearch/hadoop/rest/RestClient.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/rest/RestClient.java
@@ -18,6 +18,8 @@
  */
 package org.elasticsearch.hadoop.rest;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.elasticsearch.hadoop.EsHadoopException;
 import org.elasticsearch.hadoop.EsHadoopIllegalArgumentException;
 import org.elasticsearch.hadoop.EsHadoopIllegalStateException;
@@ -71,10 +73,18 @@ import static org.elasticsearch.hadoop.rest.Request.Method.GET;
 import static org.elasticsearch.hadoop.rest.Request.Method.HEAD;
 import static org.elasticsearch.hadoop.rest.Request.Method.POST;
 import static org.elasticsearch.hadoop.rest.Request.Method.PUT;
+import static org.elasticsearch.hadoop.util.EsMajorVersion.V_6_X;
+import static org.elasticsearch.hadoop.util.EsMajorVersion.V_7_X;
+import static org.elasticsearch.hadoop.util.EsMajorVersion.V_8_X;
 
 public class RestClient implements Closeable, StatsAware {
 
-    private final static int MAX_BULK_ERROR_MESSAGES = 5;
+    private static final Log LOG = LogFactory.getLog(RestClient.class);
+
+    static final String ELASTIC_PRODUCT_HEADER = "X-elastic-product";
+    static final String ELASTIC_PRODUCT_HEADER_VALUE = "Elasticsearch";
+    static final String ELASTICSEARCH_BUILD_FLAVOR = "default";
+    static final String ELASTICSEARCH_TAGLINE = "You Know, for Search";
 
     private NetworkClient network;
     private final ObjectMapper mapper;
@@ -742,7 +752,8 @@ public class RestClient implements Closeable, StatsAware {
     }
 
     public ClusterInfo mainInfo() {
-        Map<String, Object> result = get("", null);
+        Response response = execute(GET, "", true);
+        Map<String, Object> result = parseContent(response.body(), null);
         if (result == null) {
             throw new EsHadoopIllegalStateException("Unable to retrieve elasticsearch main cluster info.");
         }
@@ -753,7 +764,38 @@ public class RestClient implements Closeable, StatsAware {
         if (versionBody == null || !StringUtils.hasText(versionBody.get("number"))) {
             throw new EsHadoopIllegalStateException("Unable to retrieve elasticsearch version.");
         }
-        return new ClusterInfo(new ClusterName(clusterName, clusterUUID), EsMajorVersion.parse(versionBody.get("number")));
+        String versionNumber = versionBody.get("number");
+        EsMajorVersion major = EsMajorVersion.parse(versionNumber);
+        if (major.before(EsMajorVersion.V_6_X)) {
+            throw new EsHadoopIllegalStateException("Invalid major version [" + major + "]. " +
+                    "Version is lower than minimum required version [" + EsMajorVersion.V_6_X + "].");
+        } else if (major.onOrAfter(V_6_X)) {
+            String tagline = result.get("tagline").toString();
+            if (ELASTICSEARCH_TAGLINE.equals(tagline) == false) {
+                LOG.warn("Could not verify server is Elasticsearch! Invalid main action response body format [tag].");
+            }
+            if (major.onOrAfter(V_7_X)) {
+                String buildFlavor = versionBody.get("build_flavor");
+                if (ELASTICSEARCH_BUILD_FLAVOR.equals(buildFlavor) == false) {
+                    LOG.warn("Could not verify server is Elasticsearch! Invalid main action response body format [build_flavor].");
+                }
+
+                List<String> productHeader = response.headers().get(ELASTIC_PRODUCT_HEADER);
+                boolean validElasticsearchHeader = productHeader != null && productHeader.size() == 1 && productHeader.get(0).equals(ELASTIC_PRODUCT_HEADER_VALUE);
+                boolean verifyServer = (major.on(V_7_X) && major.parseMinorVersion(versionNumber) >= 14) || major.onOrAfter(V_8_X);
+                if (validElasticsearchHeader == false) {
+                    if (verifyServer) {
+                        throw new EsHadoopTransportException("Connected, but could not verify server is Elasticsearch. Response missing [" +
+                                ELASTIC_PRODUCT_HEADER + "] header. Please check that you are connecting to an Elasticsearch instance, and " +
+                                "that any networking filters are preserving that header.");
+                    } else {
+                        LOG.warn("Could not verify server is Elasticsearch! ES-Hadoop will require server validation when connecting to an " +
+                                "Elasticsearch cluster if that Elasticsearch cluster is v7.14 and up.");
+                    }
+                }
+            }
+        }
+        return new ClusterInfo(new ClusterName(clusterName, clusterUUID), EsMajorVersion.parse(versionNumber));
     }
 
     /**

--- a/mr/src/main/java/org/elasticsearch/hadoop/rest/RestService.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/rest/RestService.java
@@ -217,7 +217,7 @@ public abstract class RestService implements Serializable {
 
         InitializationUtils.validateSettings(settings);
 
-        ClusterInfo clusterInfo = InitializationUtils.discoverClusterInfo(settings, log);
+        ClusterInfo clusterInfo = InitializationUtils.discoverAndValidateClusterInfo(settings, log);
         InitializationUtils.validateSettingsForReading(settings);
         List<NodeInfo> nodes = InitializationUtils.discoverNodesIfNeeded(settings, log);
         InitializationUtils.filterNonClientNodesIfNeeded(settings, log);
@@ -578,7 +578,7 @@ public abstract class RestService implements Serializable {
         Version.logVersion();
 
         InitializationUtils.validateSettings(settings);
-        InitializationUtils.discoverClusterInfo(settings, log);
+        InitializationUtils.discoverAndValidateClusterInfo(settings, log);
 
         InitializationUtils.validateSettingsForWriting(settings);
 

--- a/mr/src/main/java/org/elasticsearch/hadoop/rest/SimpleResponse.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/rest/SimpleResponse.java
@@ -19,17 +19,26 @@
 package org.elasticsearch.hadoop.rest;
 
 import java.io.InputStream;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 
 public class SimpleResponse implements Response {
 
     private final int status;
     private final InputStream body;
     private final CharSequence uri;
+    private final Map<String, List<String>> headers;
 
     public SimpleResponse(int status, InputStream body, CharSequence uri) {
+        this(status, body, uri, Collections.emptyMap());
+    }
+
+    public SimpleResponse(int status, InputStream body, CharSequence uri, Map<String, List<String>> headers) {
         this.status = status;
         this.body = body;
         this.uri = uri;
+        this.headers = headers;
     }
 
     @Override
@@ -90,5 +99,10 @@ public class SimpleResponse implements Response {
     @Override
     public boolean hasFailed() {
         return !hasSucceeded();
+    }
+
+    @Override
+    public Map<String, List<String>> headers() {
+        return headers;
     }
 }

--- a/mr/src/main/java/org/elasticsearch/hadoop/util/EsMajorVersion.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/util/EsMajorVersion.java
@@ -92,6 +92,27 @@ public class EsMajorVersion implements Serializable {
                 "Highest supported version is [" + LATEST.version + "]. You may need to upgrade ES-Hadoop.");
     }
 
+    public int parseMinorVersion(String versionString) {
+        String majorPrefix = "" + major + ".";
+        if (versionString.startsWith(majorPrefix) == false) {
+            throw new EsHadoopIllegalArgumentException("Invalid version string for major version; " +
+                    "Received [" + versionString + "] for major version [" + version + "]");
+        }
+        String minorRemainder = versionString.substring(majorPrefix.length());
+        int dot = minorRemainder.indexOf('.');
+        if (dot < 1) {
+            throw new EsHadoopIllegalArgumentException("Could not parse Elasticsearch minor version [" +
+                    versionString + "]. Invalid version format.");
+        }
+        String rawMinorVersion = minorRemainder.substring(0, dot);
+        try {
+            return Integer.parseInt(rawMinorVersion);
+        } catch (NumberFormatException e) {
+            throw new EsHadoopIllegalArgumentException("Could not parse Elasticsearch minor version [" +
+                    versionString + "]. Non-numeric minor version [" + rawMinorVersion + "].", e);
+        }
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/mr/src/test/java/org/elasticsearch/hadoop/rest/RestClientTest.java
+++ b/mr/src/test/java/org/elasticsearch/hadoop/rest/RestClientTest.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.hadoop.rest;
 
+import org.elasticsearch.hadoop.EsHadoopIllegalStateException;
 import org.elasticsearch.hadoop.cfg.Settings;
 import org.elasticsearch.hadoop.rest.query.MatchAllQueryBuilder;
 import org.elasticsearch.hadoop.rest.stats.Stats;
@@ -31,6 +32,10 @@ import org.junit.Test;
 import org.mockito.Mockito;
 
 import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -422,12 +427,91 @@ public class RestClientTest {
     }
 
     @Test
+    public void testMainInfo() {
+        String response = "{\n" +
+                "\"name\": \"node\",\n" +
+                "\"cluster_name\": \"cluster\",\n" +
+                "\"cluster_uuid\": \"uuid\",\n" +
+                "\"version\": {\n" +
+                "  \"number\": \"7.14.0\"\n" +
+                "},\n" +
+                "\"tagline\": \"You Know, for Search\"\n" +
+                "}";
+
+        NetworkClient mock = Mockito.mock(NetworkClient.class);
+        Map<String, List<String>> headers = new HashMap<>();
+        headers.computeIfAbsent(RestClient.ELASTIC_PRODUCT_HEADER, k -> new ArrayList<>()).add(RestClient.ELASTIC_PRODUCT_HEADER_VALUE);
+        Mockito.when(mock.execute(Mockito.any(SimpleRequest.class), Mockito.eq(true)))
+                .thenReturn(new SimpleResponse(201, new FastByteArrayInputStream(new BytesArray(response)), "localhost:9200", headers));
+
+        RestClient client = new RestClient(new TestSettings(), mock);
+
+        ClusterInfo clusterInfo = client.mainInfo();
+
+        assertNotNull(clusterInfo.getClusterName());
+        assertNotNull(clusterInfo.getClusterName().getUUID());
+    }
+
+    @Test
+    public void testMainInfoWithClusterTooOld() {
+        String response = "{\n" +
+                "\"name\": \"node\",\n" +
+                "\"cluster_name\": \"cluster\",\n" +
+                "\"version\": {\n" +
+                "  \"number\": \"2.0.0\"\n" +
+                "},\n" +
+                "\"tagline\": \"You Know, for Search\"\n" +
+                "}";
+
+        NetworkClient mock = Mockito.mock(NetworkClient.class);
+        Mockito.when(mock.execute(Mockito.any(SimpleRequest.class), Mockito.eq(true)))
+                .thenReturn(new SimpleResponse(201, new FastByteArrayInputStream(new BytesArray(response)), "localhost:9200"));
+
+        RestClient client = new RestClient(new TestSettings(), mock);
+
+        try {
+            client.mainInfo();
+            fail("Shouldn't operate on main version that is too old.");
+        } catch (EsHadoopIllegalStateException e) {
+            assertEquals("Invalid major version [2.0.0]. Version is lower than minimum required version [6.x].", e.getMessage());
+        }
+    }
+
+    @Test
+    public void testMainInfoWithoutRequiredHeaders() {
+        String response = "{\n" +
+                "\"name\": \"node\",\n" +
+                "\"cluster_name\": \"cluster\",\n" +
+                "\"cluster_uuid\": \"uuid\",\n" +
+                "\"version\": {\n" +
+                "  \"number\": \"7.14.0\"\n" +
+                "},\n" +
+                "\"tagline\": \"You Know, for Search\"\n" +
+                "}";
+
+        NetworkClient mock = Mockito.mock(NetworkClient.class);
+        Mockito.when(mock.execute(Mockito.any(SimpleRequest.class), Mockito.eq(true)))
+                .thenReturn(new SimpleResponse(201, new FastByteArrayInputStream(new BytesArray(response)), "localhost:9200"));
+
+        RestClient client = new RestClient(new TestSettings(), mock);
+
+        try {
+            client.mainInfo();
+            fail("Shouldn't operate on request that does not contain the required headers.");
+        } catch (EsHadoopTransportException e) {
+            assertEquals("Connected, but could not verify server is Elasticsearch. Response missing [X-elastic-product] header. " +
+                    "Please check that you are connecting to an Elasticsearch instance, and that any networking filters are " +
+                    "preserving that header.", e.getMessage());
+        }
+    }
+
+    @Test
     public void testMainInfoWithClusterNotProvidingUUID() {
         String response = "{\n" +
                 "\"name\": \"node\",\n" +
                 "\"cluster_name\": \"cluster\",\n" +
                 "\"version\": {\n" +
-                "  \"number\": \"2.0.1\"\n" +
+                "  \"number\": \"6.0.1\"\n" +
                 "},\n" +
                 "\"tagline\": \"You Know, for Search\"\n" +
                 "}";

--- a/mr/src/test/java/org/elasticsearch/hadoop/util/EsMajorVersionTest.java
+++ b/mr/src/test/java/org/elasticsearch/hadoop/util/EsMajorVersionTest.java
@@ -22,10 +22,15 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import org.elasticsearch.hadoop.EsHadoopIllegalArgumentException;
 import org.junit.Test;
 
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class EsMajorVersionTest {
     private static final List<String> TEST_VERSIONS;
@@ -89,6 +94,36 @@ public class EsMajorVersionTest {
                 assertTrue(cmp_version.onOrBefore(version));
                 assertFalse(cmp_version.equals(version));
             }
+        }
+    }
+
+    @Test
+    public void testMinorVersionParsing() {
+        for (String testVersion : TEST_VERSIONS) {
+            EsMajorVersion version = EsMajorVersion.parse(testVersion);
+            int minorVersion = version.parseMinorVersion(testVersion);
+            assertThat(minorVersion, greaterThanOrEqualTo(0));
+        }
+        try {
+            EsMajorVersion.V_7_X.parseMinorVersion("6.0.0");
+            fail("Invalid major version");
+        } catch (EsHadoopIllegalArgumentException e) {
+            assertEquals("Invalid version string for major version; Received [6.0.0] for major version [7.x]",
+                    e.getMessage());
+        }
+        try {
+            EsMajorVersion.V_7_X.parseMinorVersion("7.");
+            fail("Invalid major version");
+        } catch (EsHadoopIllegalArgumentException e) {
+            assertEquals("Could not parse Elasticsearch minor version [7.]. Invalid version format.",
+                    e.getMessage());
+        }
+        try {
+            EsMajorVersion.V_7_X.parseMinorVersion("7.4-abcd.4");
+            fail("Invalid major version");
+        } catch (EsHadoopIllegalArgumentException e) {
+            assertEquals("Could not parse Elasticsearch minor version [7.4-abcd.4]. Non-numeric minor version [4-abcd].",
+                    e.getMessage());
         }
     }
 }


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Verify cluster main info response returns correct product headers (#1679)