### PR TITLE
Fix buildSrc classpath after build-tools refactoring

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -68,11 +68,12 @@ dependencies {
     compileOnly gradleApi()
     compileOnly localGroovy()
 
+    // Required for dependency licenses task
+    implementation 'org.apache.rat:apache-rat:0.11'
+    implementation 'commons-codec:commons-codec:1.12'
+
     if (localRepo) {
         implementation name: "build-tools-${buildToolsVersion}"
-        // Required for dependency licenses task (explicitly added in case of localRepo missing transitive dependencies)
-        implementation group: 'commons-codec', name: 'commons-codec', version: '1.12'
-        implementation group: 'org.apache.rat', name: 'apache-rat', version: '0.11'
     } else {
         implementation group: 'org.elasticsearch.gradle', name: 'build-tools', version: buildToolsVersion
     }


### PR DESCRIPTION
We need to explicitly add the former transitive dependencies of commons codec and ant-rat to the buildSrc compile classpath as the code relying on this has moved directly to buildSrc here.

- [X] I have signed the [Contributor License Agreement (CLA)][]

[Contributor License Agreement (CLA)]: https://www.elastic.co/contributor-agreement/
