### PR TITLE
[7.14] [DOCS] Remove 7.13.4 coming tag (#1721)

### DIFF
--- a/docs/src/reference/asciidoc/appendix/release-notes/7.13.4.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/7.13.4.adoc
@@ -1,7 +1,5 @@
 [[eshadoop-7.13.4]]
 == Elasticsearch for Apache Hadoop version 7.13.4
 
-coming::[7.13.4]
-
 ES-Hadoop 7.13.4 is a version compatibility release, tested specifically against
 Elasticsearch 7.13.4.


### PR DESCRIPTION
Backports the following commits to 7.14:
 - [DOCS] Remove 7.13.4 coming tag (#1721)