### PR TITLE
[7.x] [DOCS] Add 7.14.0 release notes (#1727)

### DIFF
--- a/docs/src/reference/asciidoc/appendix/release-notes/7.14.0.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/7.14.0.adoc
@@ -1,0 +1,13 @@
+[[eshadoop-7.14.0]]
+== Elasticsearch for Apache Hadoop version 7.14.0
+
+[[new-7.14.0]]
+=== Enhancements
+
+Build::
+- Remove the conjars repository from the build
+https://github.com/elastic/elasticsearch-hadoop/pull/1684[#1684]
+
+Core::
+- Verify cluster main info response returns correct product headers
+https://github.com/elastic/elasticsearch-hadoop/pull/1679[#1679]

--- a/docs/src/reference/asciidoc/appendix/release.adoc
+++ b/docs/src/reference/asciidoc/appendix/release.adoc
@@ -9,6 +9,7 @@ This section summarizes the changes in each release.
 [[release-notes-7]]
 ===== 7.x
 
+* <<eshadoop-7.14.0>>
 * <<eshadoop-7.13.4>>
 * <<eshadoop-7.13.3>>
 * <<eshadoop-7.13.2>>
@@ -102,6 +103,7 @@ http://github.com/elastic/elasticsearch-hadoop/issues/XXX[#XXX]
 
 ////////////////////////
 
+include::release-notes/7.14.0.adoc[]
 include::release-notes/7.13.4.adoc[]
 include::release-notes/7.13.3.adoc[]
 include::release-notes/7.13.2.adoc[]


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Add 7.14.0 release notes (#1727)