### PR TITLE
Enable minimal security for ES testing fixtures

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/fixture/ElasticsearchFixturePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/fixture/ElasticsearchFixturePlugin.groovy
@@ -100,6 +100,10 @@ class ElasticsearchFixturePlugin implements Plugin<Project> {
             integTestCluster.setting("http.host", "localhost")
             // TODO: Remove this when this is the default in 7
             integTestCluster.systemProperty('es.http.cname_in_publish_address', 'true')
+            // Minimal Security
+            integTestCluster.setting('xpack.security.enabled', 'true')
+            integTestCluster.keystore('bootstrap.password', 'password')
+            integTestCluster.user(username: 'elastic-admin', password: 'elastic-password', role: 'superuser')
         }
 
         // Also write a script to a file for use in tests

--- a/test/shared/src/main/resources/test.properties
+++ b/test/shared/src/main/resources/test.properties
@@ -11,6 +11,10 @@ es.batch.size.bytes=1kb
 #es.nodes.client.only=true
 #es.nodes.wan.only=true
 
+# Minimal Security
+es.net.http.auth.user=elastic-admin
+es.net.http.auth.pass=elastic-password
+
 # put pressure on the bulk API
 es.batch.size.entries=3
 es.batch.write.retry.wait=1s


### PR DESCRIPTION
Recently the ES-Hadoop builds have started failing due to 401 Unauthorized exceptions. This seems to be related to recent changes to enable security by default (https://github.com/elastic/elasticsearch/pull/75816).

This PR updates the ES fixture in ES-Hadoop to enable security and use basic authentication within all the integration tests.