### PR TITLE
[DOCS] Remove coming tag from 7.14.1 release notes

### DIFF
--- a/docs/src/reference/asciidoc/appendix/release-notes/7.14.1.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/7.14.1.adoc
@@ -1,8 +1,6 @@
 [[eshadoop-7.14.1]]
 == Elasticsearch for Apache Hadoop version 7.14.1
 
-coming::[7.14.1]
-
 [[new-7.14.1]]
 === Enhancements
 


### PR DESCRIPTION
This PR removes the "coming" qualification from the 7.14.1 Elasticsearch for Apache Hadoop release notes.