### PR TITLE
Using case-insensitive headers

### DIFF
--- a/mr/src/main/java/org/elasticsearch/hadoop/rest/Response.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/rest/Response.java
@@ -46,5 +46,10 @@ public interface Response {
 
     boolean hasFailed();
 
-    Map<String, List<String>> headers();
+    /**
+     * Returns the headers with the given name
+     * @param headerName, case-insensitive
+     * @return The list of matching headers
+     */
+    List<String> getHeaders(String headerName);
 }

--- a/mr/src/main/java/org/elasticsearch/hadoop/rest/RestClient.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/rest/RestClient.java
@@ -780,7 +780,7 @@ public class RestClient implements Closeable, StatsAware {
                     LOG.warn("Could not verify server is Elasticsearch! Invalid main action response body format [build_flavor].");
                 }
 
-                List<String> productHeader = response.headers().get(ELASTIC_PRODUCT_HEADER);
+                List<String> productHeader = response.getHeaders(ELASTIC_PRODUCT_HEADER);
                 boolean validElasticsearchHeader = productHeader != null && productHeader.size() == 1 && productHeader.get(0).equals(ELASTIC_PRODUCT_HEADER_VALUE);
                 boolean verifyServer = (major.on(V_7_X) && major.parseMinorVersion(versionNumber) >= 14) || major.onOrAfter(V_8_X);
                 if (validElasticsearchHeader == false) {

--- a/mr/src/main/java/org/elasticsearch/hadoop/rest/SimpleResponse.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/rest/SimpleResponse.java
@@ -104,7 +104,7 @@ public class SimpleResponse implements Response {
 
     @Override
     public List<String> getHeaders(String headerName) {
-        return headers.entrySet().stream().filter(entry -> entry.getKey().equalsIgnoreCase(headerName)).map(entry -> entry.getValue())
+        return headers.entrySet().stream().filter(entry -> entry.getKey().equalsIgnoreCase(headerName)).map(Map.Entry::getValue)
                 .flatMap(List::stream).collect(Collectors.toList());
     }
 }

--- a/mr/src/main/java/org/elasticsearch/hadoop/rest/SimpleResponse.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/rest/SimpleResponse.java
@@ -22,6 +22,7 @@ import java.io.InputStream;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 public class SimpleResponse implements Response {
 
@@ -102,7 +103,8 @@ public class SimpleResponse implements Response {
     }
 
     @Override
-    public Map<String, List<String>> headers() {
-        return headers;
+    public List<String> getHeaders(String headerName) {
+        return headers.entrySet().stream().filter(entry -> entry.getKey().equalsIgnoreCase(headerName)).map(entry -> entry.getValue())
+                .flatMap(List::stream).collect(Collectors.toList());
     }
 }

--- a/mr/src/test/java/org/elasticsearch/hadoop/rest/RestClientTest.java
+++ b/mr/src/test/java/org/elasticsearch/hadoop/rest/RestClientTest.java
@@ -23,24 +23,14 @@ import org.elasticsearch.hadoop.EsHadoopIllegalStateException;
 import org.elasticsearch.hadoop.cfg.Settings;
 import org.elasticsearch.hadoop.rest.query.MatchAllQueryBuilder;
 import org.elasticsearch.hadoop.rest.stats.Stats;
-import org.elasticsearch.hadoop.util.BytesArray;
-import org.elasticsearch.hadoop.util.ClusterInfo;
-import org.elasticsearch.hadoop.util.EsMajorVersion;
-import org.elasticsearch.hadoop.util.FastByteArrayInputStream;
-import org.elasticsearch.hadoop.util.TestSettings;
+import org.elasticsearch.hadoop.util.*;
 import org.junit.Test;
 import org.mockito.Mockito;
 
 import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 public class RestClientTest {
 
@@ -440,7 +430,7 @@ public class RestClientTest {
 
         NetworkClient mock = Mockito.mock(NetworkClient.class);
         Map<String, List<String>> headers = new HashMap<>();
-        headers.computeIfAbsent(RestClient.ELASTIC_PRODUCT_HEADER, k -> new ArrayList<>()).add(RestClient.ELASTIC_PRODUCT_HEADER_VALUE);
+        headers.computeIfAbsent(RestClient.ELASTIC_PRODUCT_HEADER.toLowerCase(Locale.ROOT), k -> new ArrayList<>()).add(RestClient.ELASTIC_PRODUCT_HEADER_VALUE);
         Mockito.when(mock.execute(Mockito.any(SimpleRequest.class), Mockito.eq(true)))
                 .thenReturn(new SimpleResponse(201, new FastByteArrayInputStream(new BytesArray(response)), "localhost:9200", headers));
 

--- a/mr/src/test/java/org/elasticsearch/hadoop/rest/RestClientTest.java
+++ b/mr/src/test/java/org/elasticsearch/hadoop/rest/RestClientTest.java
@@ -23,14 +23,25 @@ import org.elasticsearch.hadoop.EsHadoopIllegalStateException;
 import org.elasticsearch.hadoop.cfg.Settings;
 import org.elasticsearch.hadoop.rest.query.MatchAllQueryBuilder;
 import org.elasticsearch.hadoop.rest.stats.Stats;
-import org.elasticsearch.hadoop.util.*;
+import org.elasticsearch.hadoop.util.BytesArray;
+import org.elasticsearch.hadoop.util.ClusterInfo;
+import org.elasticsearch.hadoop.util.EsMajorVersion;
+import org.elasticsearch.hadoop.util.FastByteArrayInputStream;
+import org.elasticsearch.hadoop.util.TestSettings;
 import org.junit.Test;
 import org.mockito.Mockito;
 
 import java.io.InputStream;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
 
 public class RestClientTest {
 


### PR DESCRIPTION
The check for the X-elastic-product header is currently case sensitive. However header names are
supposed to be case-insensitive. This commit makes the check case sensitive.
Relates #1745 