### PR TITLE
[7.x] [DOCS] Add 7.14.1 release notes (#1740)

### DIFF
--- a/docs/src/reference/asciidoc/appendix/release-notes/7.14.1.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/7.14.1.adoc
@@ -1,8 +1,6 @@
 [[eshadoop-7.14.1]]
 == Elasticsearch for Apache Hadoop version 7.14.1
 
-coming::[7.14.1]
-
 [[new-7.14.1]]
 === Enhancements
 

--- a/docs/src/reference/asciidoc/appendix/release-notes/7.14.1.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/7.14.1.adoc
@@ -1,0 +1,11 @@
+[[eshadoop-7.14.1]]
+== Elasticsearch for Apache Hadoop version 7.14.1
+
+coming::[7.14.1]
+
+[[new-7.14.1]]
+=== Enhancements
+
+Build::
+- Fix buildSrc classpath after build-tools refactoring
+https://github.com/elastic/elasticsearch-hadoop/pull/1705[#1705]

--- a/docs/src/reference/asciidoc/appendix/release.adoc
+++ b/docs/src/reference/asciidoc/appendix/release.adoc
@@ -9,6 +9,7 @@ This section summarizes the changes in each release.
 [[release-notes-7]]
 ===== 7.x
 
+* <<eshadoop-7.14.1>>
 * <<eshadoop-7.14.0>>
 * <<eshadoop-7.13.4>>
 * <<eshadoop-7.13.3>>
@@ -103,6 +104,7 @@ http://github.com/elastic/elasticsearch-hadoop/issues/XXX[#XXX]
 
 ////////////////////////
 
+include::release-notes/7.14.1.adoc[]
 include::release-notes/7.14.0.adoc[]
 include::release-notes/7.13.4.adoc[]
 include::release-notes/7.13.3.adoc[]


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Add 7.14.1 release notes (#1740)