### PR TITLE
Adding a known issue about X-elastic-product case sensitivity

### DIFF
--- a/docs/src/reference/asciidoc/appendix/release-notes/7.14.0.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/7.14.0.adoc
@@ -8,8 +8,9 @@
 * In 7.14.0, {esh} began preventing access to {es} clusters that did not include an `X-elastic-product` header in responses in order to
 ensure that {esh} was working with an {es} cluster that it was compatible with. See
 https://github.com/elastic/elasticsearch-hadoop/issues/1672[#1672] for more information about this. However if the case of the
-`X-elastic-product` header name sent from {es} is changed (for example if it is lower-cased) by an intermediary between {es} and {esh} (for example, the http proxy for cloud.elastic.co), then
-{esh} ignores the header and will reject the response as not being from a valid {es} cluster.
+`X-elastic-product` header name sent from {es} is changed (for example if it is lower-cased) by an intermediary between {es} and {esh} (for
+example, the http proxy for cloud.elastic.co), then {esh} ignores the header and will reject the response as not being from a valid {es}
+cluster.
 +
 We have fixed this issue in {esh} 7.14.2 and later versions. For more details,see
 https://github.com/elastic/elasticsearch-hadoop/issues/1745[#1745].

--- a/docs/src/reference/asciidoc/appendix/release-notes/7.14.0.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/7.14.0.adoc
@@ -5,7 +5,7 @@
 [discrete]
 === Known issues
 
-* In 14.0, {esh} began preventing access to {es} clusters that did not include an `X-elastic-product` header in responses in order to
+* In 7.14.0, {esh} began preventing access to {es} clusters that did not include an `X-elastic-product` header in responses in order to
 ensure that {esh} was working with an {es} cluster that it was compatible with. See
 https://github.com/elastic/elasticsearch-hadoop/issues/1672[#1672] for more information about this. However if the case of the
 `X-elastic-product` header name sent from {es} is changed (for example if it is lower-cased) by an intermediary between {es} and {esh} (for example, the http proxy for cloud.elastic.co), then

--- a/docs/src/reference/asciidoc/appendix/release-notes/7.14.0.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/7.14.0.adoc
@@ -1,7 +1,21 @@
 [[eshadoop-7.14.0]]
 == Elasticsearch for Apache Hadoop version 7.14.0
 
+[[known-issues-7.14.0]]
+[discrete]
+=== Known issues
+
+* In 14.0, {esh} began preventing access to {es} clusters that did not include an `X-elastic-product` header in responses in order to
+ensure that {esh} was working with an {es} cluster that it was compatible with. See
+https://github.com/elastic/elasticsearch-hadoop/issues/1672[#1672] for more information about this. However if the case of the
+`X-elastic-product` header name sent from {es} is changed (for example if it is lower-cased) by an intermediary between {es} and {esh}, then
+{esh} ignores the header and will reject the response as not being from a valid {es} cluster.
++
+We have fixed this issue in {esh} 7.14.2 and later versions. For more details,see
+https://github.com/elastic/elasticsearch-hadoop/issues/1745[#1745].
+
 [[new-7.14.0]]
+[discrete]
 === Enhancements
 
 Build::

--- a/docs/src/reference/asciidoc/appendix/release-notes/7.14.0.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/7.14.0.adoc
@@ -8,7 +8,7 @@
 * In 14.0, {esh} began preventing access to {es} clusters that did not include an `X-elastic-product` header in responses in order to
 ensure that {esh} was working with an {es} cluster that it was compatible with. See
 https://github.com/elastic/elasticsearch-hadoop/issues/1672[#1672] for more information about this. However if the case of the
-`X-elastic-product` header name sent from {es} is changed (for example if it is lower-cased) by an intermediary between {es} and {esh}, then
+`X-elastic-product` header name sent from {es} is changed (for example if it is lower-cased) by an intermediary between {es} and {esh} (for example, the http proxy for cloud.elastic.co), then
 {esh} ignores the header and will reject the response as not being from a valid {es} cluster.
 +
 We have fixed this issue in {esh} 7.14.2 and later versions. For more details,see

--- a/docs/src/reference/asciidoc/appendix/release-notes/7.14.1.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/7.14.1.adoc
@@ -1,7 +1,22 @@
 [[eshadoop-7.14.1]]
 == Elasticsearch for Apache Hadoop version 7.14.1
 
+[[known-issues-7.14.1]]
+[discrete]
+=== Known issues
+
+* In 7.14.0, {esh} began preventing access to {es} clusters that did not include an `X-elastic-product` header in responses in order to
+ensure that {esh} was working with an {es} cluster that it was compatible with. See
+https://github.com/elastic/elasticsearch-hadoop/issues/1672[#1672] for more information about this. However if the case of the
+`X-elastic-product` header name sent from {es} is changed (for example if it is lower-cased) by an intermediary between {es} and {esh} (for
+example, the http proxy for cloud.elastic.co), then {esh} ignores the header and will reject the response as not being from a valid {es}
+cluster.
++
+We have fixed this issue in {esh} 7.14.2 and later versions. For more details,see
+https://github.com/elastic/elasticsearch-hadoop/issues/1745[#1745].
+
 [[new-7.14.1]]
+[discrete]
 === Enhancements
 
 Build::


### PR DESCRIPTION
This commit adds a known issue to the 7.14.0 release notes about the case sensitivity of the X-elastic-product header
in 7.14.0 and 7.14.1.
Relates #1745 #1672