### PR TITLE
[7.15] [DOCS] Removes coming tag from 7.14.2 release notes (#1760)

### DIFF
--- a/docs/src/reference/asciidoc/appendix/release-notes/7.14.2.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/7.14.2.adoc
@@ -1,7 +1,5 @@
 [[eshadoop-7.14.2]]
 == Elasticsearch for Apache Hadoop version 7.14.2
 
-coming::[7.14.2]
-
 ES-Hadoop 7.14.2 is a version compatibility release, tested specifically against
 Elasticsearch 7.14.2.


### PR DESCRIPTION
7.15 backport for #1760 