### PR TITLE
Closing RestRepository to avoid a connection leak

### DIFF
--- a/mr/src/main/java/org/elasticsearch/hadoop/rest/ScrollQuery.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/rest/ScrollQuery.java
@@ -77,6 +77,7 @@ public class ScrollQuery implements Iterator<Object>, Closeable, StatsAware {
             if (StringUtils.hasText(scrollId)) {
                 repository.getRestClient().deleteScroll(scrollId);
             }
+            repository.close();
         }
     }
 

--- a/mr/src/test/java/org/elasticsearch/hadoop/rest/ScrollQueryTest.java
+++ b/mr/src/test/java/org/elasticsearch/hadoop/rest/ScrollQueryTest.java
@@ -51,6 +51,7 @@ public class ScrollQueryTest {
         Assert.assertEquals("value", JsonUtils.query("field").apply(scrollQuery.next()[1]));
         Assert.assertFalse(scrollQuery.hasNext());
         scrollQuery.close();
+        Mockito.verify(repository).close();
         Stats stats = scrollQuery.stats();
         Assert.assertEquals(1, stats.docsReceived);
     }


### PR DESCRIPTION
This commit closes the RestRepository that is sent to the ScrollQuery constructor to avoid leaking connections to
Elasticsearch when many fast scrolls are called in a tight loop.
Closes #1212 