### PR TITLE
Bump runtime java to 17

### DIFF
--- a/.ci/java-versions.properties
+++ b/.ci/java-versions.properties
@@ -7,4 +7,4 @@
 # are 'java' or 'openjdk' followed by the major release number.
 
 ESH_BUILD_JAVA=openjdk14
-ESH_RUNTIME_JAVA=java11
+ESH_RUNTIME_JAVA=openjdk17


### PR DESCRIPTION
Elasticsearch 8.0+ requires Java 17 now so we need to bump the runtime Java version used for integration tests appropriately.