### PR TITLE
[8.0] Bump runtime java to 17 (#1791)

### DIFF
--- a/.ci/java-versions.properties
+++ b/.ci/java-versions.properties
@@ -7,4 +7,4 @@
 # are 'java' or 'openjdk' followed by the major release number.
 
 ESH_BUILD_JAVA=openjdk14
-ESH_RUNTIME_JAVA=java11
+ESH_RUNTIME_JAVA=openjdk17


### PR DESCRIPTION
Backports the following commits to 8.0:
 - Bump runtime java to 17 (#1791)