### PR TITLE
Getting rid of gradle deprecation warnings (#1792)

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/BuildPlugin.groovy
@@ -378,7 +378,7 @@ class BuildPlugin implements Plugin<Project> {
 
         // Enable HTML test reports
         project.tasks.withType(Test) { Test testTask ->
-            testTask.getReports().getByName('html').setEnabled(true)
+            testTask.getReports().getByName('html').setRequired(true)
         }
 
         // Configure project jar task with manifest and include license and notice data.
@@ -846,7 +846,7 @@ class BuildPlugin implements Plugin<Project> {
             maxGranularity 2
         }
 
-        integrationTest.reports.html.enabled = false
+        integrationTest.reports.html.required = false
     }
 
     private static void configurePrecommit(Project project) {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/test/fixtures/minikdc/build.gradle
+++ b/test/fixtures/minikdc/build.gradle
@@ -40,7 +40,7 @@ targetCompatibility = '1.8'
 // gradle hides EVERYTHING so you have no clue what went wrong.
 task kdc(type: JavaExec) {
     classpath = sourceSets.main.compileClasspath + sourceSets.main.output
-    main = "org.elasticsearch.hadoop.test.fixture.minikdc.MiniKdcFixture"
+    mainClass = "org.elasticsearch.hadoop.test.fixture.minikdc.MiniKdcFixture"
     args = [ 'build/fixtures/miniKdcFixture' ]
 }
 


### PR DESCRIPTION
Gradle has deprecated several features, and irritatingly it fails the build if you use those features
without passing the "--warning-mode=none" argument. This commit replaces those deprecated
things so that you can run the build without passing "--warning-mode=none".