### PR TITLE
Setting java boot classpath so that scala 2.10 works on gradle 7.2

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/spark/core/build.gradle
+++ b/spark/core/build.gradle
@@ -149,6 +149,8 @@ tasks.named("test").configure {
 
 // Set minimum compatibility and java home for compiler task
 tasks.withType(ScalaCompile) { ScalaCompile task ->
+    task.scalaCompileOptions.additionalParameters = ["-javabootclasspath", new File(project.ext.runtimeJavaHome, 'jre/lib/rt.jar').absolutePath]
+    task.options.bootstrapClasspath = layout.files(new File(project.ext.runtimeJavaHome, 'jre/lib/rt.jar'))
     task.sourceCompatibility = project.ext.minimumRuntimeVersion
     task.targetCompatibility = project.ext.minimumRuntimeVersion
     task.options.forkOptions.executable = new File(project.ext.runtimeJavaHome, 'bin/java').absolutePath

--- a/spark/sql-13/build.gradle
+++ b/spark/sql-13/build.gradle
@@ -169,6 +169,8 @@ configurations.matching { it.name.contains('CompilerPlugin') == false }.all { Co
 }
 
 tasks.withType(ScalaCompile) { ScalaCompile task ->
+    task.scalaCompileOptions.additionalParameters = ["-javabootclasspath", new File(project.ext.runtimeJavaHome, 'jre/lib/rt.jar').absolutePath]
+    task.options.bootstrapClasspath = layout.files(new File(project.ext.runtimeJavaHome, 'jre/lib/rt.jar'))
     task.sourceCompatibility = project.ext.minimumRuntimeVersion
     task.targetCompatibility = project.ext.minimumRuntimeVersion
     task.options.forkOptions.executable = new File(project.ext.runtimeJavaHome, 'bin/java').absolutePath

--- a/spark/sql-20/build.gradle
+++ b/spark/sql-20/build.gradle
@@ -189,6 +189,8 @@ configurations.matching{ it.name.contains('CompilerPlugin') == false }.all { Con
 }
 
 tasks.withType(ScalaCompile) { ScalaCompile task ->
+    task.scalaCompileOptions.additionalParameters = ["-javabootclasspath", new File(project.ext.runtimeJavaHome, 'jre/lib/rt.jar').absolutePath]
+    task.options.bootstrapClasspath = layout.files(new File(project.ext.runtimeJavaHome, 'jre/lib/rt.jar'))
     task.sourceCompatibility = project.ext.minimumRuntimeVersion
     task.targetCompatibility = project.ext.minimumRuntimeVersion
     task.options.forkOptions.executable = new File(project.ext.runtimeJavaHome, 'bin/java').absolutePath

--- a/spark/sql-30/build.gradle
+++ b/spark/sql-30/build.gradle
@@ -172,6 +172,8 @@ configurations.matching{ it.name.contains('CompilerPlugin') == false }.all { Con
 }
 
 tasks.withType(ScalaCompile) { ScalaCompile task ->
+    task.scalaCompileOptions.additionalParameters = ["-javabootclasspath", new File(project.ext.runtimeJavaHome, 'jre/lib/rt.jar').absolutePath]
+    task.options.bootstrapClasspath = layout.files(new File(project.ext.runtimeJavaHome, 'jre/lib/rt.jar'))
     task.sourceCompatibility = project.ext.minimumRuntimeVersion
     task.targetCompatibility = project.ext.minimumRuntimeVersion
     task.options.forkOptions.executable = new File(project.ext.runtimeJavaHome, 'bin/java').absolutePath


### PR DESCRIPTION
Building scala 2.10 code stopped working when I upgraded to gradle 7.2 (scala 2.11 and 2.12 continued working
fine). I still don't fully understand it, but the problem seems to be that the java boot classpath jars are no longer
getting into the scala boot classpath. I found that I had to set it in two ways: (1) I have to explicitly set it in
scalaCompileOptions.additionalParameters or the build fails and (2) I have to set it in options.bootstrapClasspath
or I get warnings from javac that its boot classpath is incompatible with the source version. The two commands
I've been using to test this out are:
```
./gradlew :elasticsearch-spark:compileSpark13scala210Scala
```
and
```
./gradlew :elasticsearch-spark:test
```
