### PR TITLE
Build Hadoop with Java 17

### DIFF
--- a/.ci/java-versions.properties
+++ b/.ci/java-versions.properties
@@ -6,5 +6,5 @@
 # build and test Elasticsearch for this branch. Valid Java versions
 # are 'java' or 'openjdk' followed by the major release number.
 
-ESH_BUILD_JAVA=openjdk14
+ESH_BUILD_JAVA=openjdk17
 ESH_RUNTIME_JAVA=openjdk17


### PR DESCRIPTION
We are bumping the compiler version of [Elasticsearch to Java 17](https://github.com/elastic/elasticsearch/pull/80851) meaning that `build-tools` will now target Java 17. For this not to break elasticsearch-hadoop, we need to start building it with Java 17 as well.