### PR TITLE
Fix Spark 3.x test configurations

### DIFF
--- a/spark/core/build.gradle
+++ b/spark/core/build.gradle
@@ -131,7 +131,6 @@ sparkVariants {
 // deal with the messy conflicts out there
 // Ignore the scalaCompilerPlugin configurations since it is immediately resolved to configure the scala compiler tasks
 configurations.matching{ it.name.contains('CompilerPlugin') == false && (it.name.contains("spark30") || it.name.contains("Spark30")) == false}.all { Configuration conf ->
-    println conf.name
     conf.resolutionStrategy {
         eachDependency { details ->
             // change all javax.servlet artifacts to the one used by Spark otherwise these will lead to

--- a/spark/core/build.gradle
+++ b/spark/core/build.gradle
@@ -130,7 +130,8 @@ sparkVariants {
 
 // deal with the messy conflicts out there
 // Ignore the scalaCompilerPlugin configurations since it is immediately resolved to configure the scala compiler tasks
-configurations.matching{ it.name.contains('CompilerPlugin') == false }.all { Configuration conf ->
+configurations.matching{ it.name.contains('CompilerPlugin') == false && (it.name.contains("spark30") || it.name.contains("Spark30")) == false}.all { Configuration conf ->
+    println conf.name
     conf.resolutionStrategy {
         eachDependency { details ->
             // change all javax.servlet artifacts to the one used by Spark otherwise these will lead to


### PR DESCRIPTION
With the Spark 3.2 upgrade work we needed to remove an old dependency rule that was breaking runtime classpaths in the tests for Spark. This rule was removed in the Spark SQL 3 project but was not updated in the Core Spark project. This PR removes the rule to fix the core Spark tests for Spark 3.x.