### PR TITLE
Bump: log4j 2.10.0 to 2.15.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ org.gradle.java.installations.fromEnv=JAVA_HOME,RUNTIME_JAVA_HOME,JAVA15_HOME,JA
 
 ## Dependecies Version
 # Logging
-log4jVersion = 2.10.0
+log4jVersion = 2.15.0
 
 # Hadoop versions
 hadoop3Version  = 3.1.2


### PR DESCRIPTION
[CVE-2021-44228] Log4j versions prior to 2.15.0 are subject to a remote code execution vulnerability via the ldap JNDI parser.

- [x] I have signed the [Contributor License Agreement (CLA)]
