### PR TITLE
[7.16] Bump Internal usages of log4j 2.10.0 to 2.15.0 (#1817)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ org.gradle.java.installations.fromEnv=JAVA_HOME,RUNTIME_JAVA_HOME,JAVA15_HOME,JA
 
 ## Dependecies Version
 # Logging
-log4jVersion = 2.10.0
+log4jVersion = 2.15.0
 
 # Hadoop versions
 hadoop3Version  = 3.1.2


### PR DESCRIPTION
Backports the following commits to 7.16:
 - Bump Internal usages of log4j 2.10.0 to 2.15.0 (#1817)