### PR TITLE
[7.17] [DOCS] Add 7.16.2 release notes (#1825)

### DIFF
--- a/docs/src/reference/asciidoc/appendix/release-notes/7.16.2.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/7.16.2.adoc
@@ -1,0 +1,8 @@
+[[eshadoop-7.16.2]]
+== Elasticsearch for Apache Hadoop version 7.16.2
+
+[[new-7.16.2]]
+=== Enhancements
+Build::
+* Bump: log4j 2.10.0 to 2.15.0
+https://github.com/elastic/elasticsearch-hadoop/pull/1817[#1817]

--- a/docs/src/reference/asciidoc/appendix/release.adoc
+++ b/docs/src/reference/asciidoc/appendix/release.adoc
@@ -9,6 +9,7 @@ This section summarizes the changes in each release.
 [[release-notes-7]]
 ===== 7.x
 
+* <<eshadoop-7.16.2>>
 * <<eshadoop-7.16.1>>
 * <<eshadoop-7.16.0>>
 * <<eshadoop-7.15.2>>
@@ -110,6 +111,7 @@ http://github.com/elastic/elasticsearch-hadoop/issues/XXX[#XXX]
 
 ////////////////////////
 
+include::release-notes/7.16.2.adoc[]
 include::release-notes/7.16.1.adoc[]
 include::release-notes/7.16.0.adoc[]
 include::release-notes/7.15.2.adoc[]


### PR DESCRIPTION
Backports the following commits to 7.17:
 - [DOCS] Add 7.16.2 release notes (#1825)