### PR TITLE
Updating log4j version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ org.gradle.java.installations.fromEnv=JAVA_HOME,RUNTIME_JAVA_HOME,JAVA15_HOME,JA
 
 ## Dependecies Version
 # Logging
-log4jVersion = 2.17.0
+log4jVersion = 2.17.1
 
 # Hadoop versions
 hadoop3Version  = 3.1.2

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ org.gradle.java.installations.fromEnv=JAVA_HOME,RUNTIME_JAVA_HOME,JAVA15_HOME,JA
 
 ## Dependecies Version
 # Logging
-log4jVersion = 2.15.0
+log4jVersion = 2.17.0
 
 # Hadoop versions
 hadoop3Version  = 3.1.2


### PR DESCRIPTION
Updating the log4j version to 2.17.0 since more vulnerabilities were found with 2.15.0.