### PR TITLE
Adding support for the date_nanos field type (#1803)

### DIFF
--- a/mr/src/main/java/org/elasticsearch/hadoop/mr/WritableValueReader.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/mr/WritableValueReader.java
@@ -71,6 +71,7 @@ public class WritableValueReader extends JdkValueReader {
             arrayType = BooleanWritable.class;
             break;
         case DATE:
+        case DATE_NANOS:
             arrayType = dateType();
             break;
         case BINARY:

--- a/mr/src/main/java/org/elasticsearch/hadoop/serialization/FieldType.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/serialization/FieldType.java
@@ -39,6 +39,7 @@ public enum FieldType {
     DOUBLE,
     STRING,
     DATE,
+    DATE_NANOS,
     BINARY,
     TOKEN_COUNT,
     // ES 5.x
@@ -75,6 +76,7 @@ public enum FieldType {
         CAST_HIERARCHY.put(FLOAT,            new LinkedHashSet<FieldType>(Arrays.asList(DOUBLE, KEYWORD)));
         CAST_HIERARCHY.put(STRING,           new LinkedHashSet<FieldType>(Collections.singletonList(KEYWORD)));
         CAST_HIERARCHY.put(DATE,             new LinkedHashSet<FieldType>(Collections.singletonList(KEYWORD)));
+        CAST_HIERARCHY.put(DATE_NANOS,       new LinkedHashSet<FieldType>(Collections.singletonList(KEYWORD)));
         CAST_HIERARCHY.put(BINARY,           new LinkedHashSet<FieldType>(Collections.singletonList(KEYWORD)));
         CAST_HIERARCHY.put(TOKEN_COUNT,      new LinkedHashSet<FieldType>(Arrays.asList(LONG, KEYWORD)));
         CAST_HIERARCHY.put(TEXT,             new LinkedHashSet<FieldType>(Collections.singletonList(KEYWORD)));

--- a/mr/src/main/java/org/elasticsearch/hadoop/serialization/builder/JdkValueWriter.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/serialization/builder/JdkValueWriter.java
@@ -18,15 +18,18 @@
  */
 package org.elasticsearch.hadoop.serialization.builder;
 
+import org.elasticsearch.hadoop.serialization.Generator;
+import org.elasticsearch.hadoop.util.ObjectUtils;
+
+import javax.xml.bind.DatatypeConverter;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.Map;
 import java.util.Map.Entry;
-
-import javax.xml.bind.DatatypeConverter;
-
-import org.elasticsearch.hadoop.serialization.Generator;
-import org.elasticsearch.hadoop.util.ObjectUtils;
 
 /**
  * Value writer for JDK types.
@@ -126,7 +129,12 @@ public class JdkValueWriter extends FilteringValueWriter<Object> {
             }
             generator.writeEndArray();
         }
-        // handles Timestamp also
+        else if (value instanceof Timestamp) {
+            Timestamp timestamp = (Timestamp) value;
+            LocalDateTime localDateTime = timestamp.toLocalDateTime();
+            OffsetDateTime offsetDateTime = OffsetDateTime.of(localDateTime, OffsetDateTime.now().getOffset());
+            generator.writeString(DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(offsetDateTime));
+        }
         else if (value instanceof Date) {
             Calendar cal = Calendar.getInstance();
             cal.setTime((Date) value);

--- a/mr/src/test/java/org/elasticsearch/hadoop/serialization/builder/JdkValueReaderTest.java
+++ b/mr/src/test/java/org/elasticsearch/hadoop/serialization/builder/JdkValueReaderTest.java
@@ -1,0 +1,42 @@
+package org.elasticsearch.hadoop.serialization.builder;
+
+import org.elasticsearch.hadoop.cfg.Settings;
+import org.elasticsearch.hadoop.serialization.FieldType;
+import org.elasticsearch.hadoop.serialization.Parser;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.sql.Timestamp;
+import java.util.Date;
+
+import static org.junit.Assert.assertEquals;
+
+public class JdkValueReaderTest {
+    @Test
+    public void testReadValue() {
+        JdkValueReader reader = new JdkValueReader();
+        Parser parser = Mockito.mock(Parser.class);
+
+        Mockito.when(parser.currentToken()).thenReturn(Parser.Token.VALUE_STRING);
+        Timestamp timestamp = (Timestamp) reader.readValue(parser, "2015-01-01T12:10:30.123456789Z", FieldType.DATE_NANOS);
+        assertEquals(1420114230123l, timestamp.getTime());
+        assertEquals(123456789, timestamp.getNanos());
+
+        Mockito.when(parser.currentToken()).thenReturn(Parser.Token.VALUE_NUMBER);
+        Mockito.when(parser.longValue()).thenReturn(1420114230123l);
+        Date date = (Date) reader.readValue(parser, "1420114230123", FieldType.DATE_NANOS);
+        assertEquals(1420114230123l, date.getTime());
+
+        Settings settings = Mockito.mock(Settings.class);
+        Mockito.when(settings.getMappingDateRich()).thenReturn(false);
+        reader.setSettings(settings);
+        Mockito.when(parser.currentToken()).thenReturn(Parser.Token.VALUE_STRING);
+        String stringValue = (String) reader.readValue(parser, "2015-01-01T12:10:30.123456789Z", FieldType.DATE_NANOS);
+        assertEquals("2015-01-01T12:10:30.123456789Z", stringValue);
+
+        Mockito.when(parser.currentToken()).thenReturn(Parser.Token.VALUE_NUMBER);
+        Mockito.when(parser.longValue()).thenReturn(1420114230123l);
+        Long dateLong = (Long) reader.readValue(parser, "1420114230123", FieldType.DATE_NANOS);
+        assertEquals(1420114230123l, dateLong.longValue());
+    }
+}

--- a/mr/src/test/java/org/elasticsearch/hadoop/serialization/builder/JdkValueWriterTest.java
+++ b/mr/src/test/java/org/elasticsearch/hadoop/serialization/builder/JdkValueWriterTest.java
@@ -1,0 +1,47 @@
+package org.elasticsearch.hadoop.serialization.builder;
+
+import org.elasticsearch.hadoop.serialization.Generator;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+import java.sql.Timestamp;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.Date;
+
+import static org.junit.Assert.assertEquals;
+
+public class JdkValueWriterTest {
+    @Test
+    public void testWriteDate() {
+        JdkValueWriter jdkValueWriter = new JdkValueWriter();
+        Date date = new Date(1420114230123l);
+        Generator generator = Mockito.mock(Generator.class);
+        ArgumentCaptor<String> argument = ArgumentCaptor.forClass(String.class);
+        jdkValueWriter.doWrite(date, generator, "");
+        Mockito.verify(generator).writeString(argument.capture());
+        String expected = date.toInstant().atZone(ZoneId.systemDefault()).toOffsetDateTime().toString();
+        String actual = argument.getValue();
+        assertEquals(expected, actual);
+        OffsetDateTime parsedDate = DateTimeFormatter.ISO_OFFSET_DATE_TIME.parse(actual, OffsetDateTime::from);
+        assertEquals(123000000, parsedDate.getNano()); //Nothing beyond milliseconds
+    }
+
+    @Test
+    public void testWriteDateWithNanos() {
+        JdkValueWriter jdkValueWriter = new JdkValueWriter();
+        Timestamp timestamp = new Timestamp(1420114230123l);
+        timestamp.setNanos(123456789);
+        Generator generator = Mockito.mock(Generator.class);
+        ArgumentCaptor<String> argument = ArgumentCaptor.forClass(String.class);
+        jdkValueWriter.doWrite(timestamp, generator, "");
+        Mockito.verify(generator).writeString(argument.capture());
+        String expected = timestamp.toInstant().atZone(ZoneId.systemDefault()).toOffsetDateTime().toString();
+        String actual = argument.getValue();
+        assertEquals(expected, actual);
+        OffsetDateTime parsedDate = DateTimeFormatter.ISO_OFFSET_DATE_TIME.parse(actual, OffsetDateTime::from);
+        assertEquals(123456789, parsedDate.getNano());
+    }
+}

--- a/mr/src/test/java/org/elasticsearch/hadoop/serialization/dto/mapping/MappingTest.java
+++ b/mr/src/test/java/org/elasticsearch/hadoop/serialization/dto/mapping/MappingTest.java
@@ -39,6 +39,7 @@ import static org.elasticsearch.hadoop.serialization.FieldType.BINARY;
 import static org.elasticsearch.hadoop.serialization.FieldType.BOOLEAN;
 import static org.elasticsearch.hadoop.serialization.FieldType.BYTE;
 import static org.elasticsearch.hadoop.serialization.FieldType.DATE;
+import static org.elasticsearch.hadoop.serialization.FieldType.DATE_NANOS;
 import static org.elasticsearch.hadoop.serialization.FieldType.DOUBLE;
 import static org.elasticsearch.hadoop.serialization.FieldType.FLOAT;
 import static org.elasticsearch.hadoop.serialization.FieldType.GEO_POINT;
@@ -53,6 +54,7 @@ import static org.elasticsearch.hadoop.serialization.FieldType.SCALED_FLOAT;
 import static org.elasticsearch.hadoop.serialization.FieldType.SHORT;
 import static org.elasticsearch.hadoop.serialization.FieldType.STRING;
 import static org.elasticsearch.hadoop.serialization.FieldType.TEXT;
+
 import static org.elasticsearch.hadoop.serialization.dto.mapping.MappingUtils.findTypos;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -134,7 +136,7 @@ public class MappingTest {
         MappingSet mappings = getMappingsForResource("primitives.json");
         Mapping mapping = ensureAndGet("index", "primitives", mappings);
         Field[] props = mapping.getFields();
-        assertEquals(14, props.length);
+        assertEquals(15, props.length);
         assertEquals("field01", props[0].name());
         assertEquals(BOOLEAN, props[0].type());
         assertEquals("field02", props[1].name());
@@ -163,6 +165,8 @@ public class MappingTest {
         assertEquals(HALF_FLOAT, props[12].type());
         assertEquals("field14", props[13].name());
         assertEquals(SCALED_FLOAT, props[13].type());
+        assertEquals("field15", props[14].name());
+        assertEquals(DATE_NANOS, props[14].type());
     }
 
     @Test

--- a/mr/src/test/java/org/elasticsearch/hadoop/util/DateUtilsTest.java
+++ b/mr/src/test/java/org/elasticsearch/hadoop/util/DateUtilsTest.java
@@ -1,0 +1,38 @@
+package org.elasticsearch.hadoop.util;
+
+import org.junit.Test;
+
+import java.sql.Timestamp;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class DateUtilsTest {
+    @Test
+    public void parseDateNanos() {
+        Timestamp timestamp = DateUtils.parseDateNanos("2015-01-01");
+        assertNotNull(timestamp);
+        assertEquals(1420070400000l, timestamp.getTime());
+        assertEquals(0, timestamp.getNanos());
+
+        timestamp = DateUtils.parseDateNanos("2015-01-01T12:10:30.123456789Z");
+        assertNotNull(timestamp);
+        assertEquals(1420114230123l, timestamp.getTime());
+        assertEquals(123456789, timestamp.getNanos());
+
+        timestamp = DateUtils.parseDateNanos("2015-01-01T00:00:00.000Z");
+        assertNotNull(timestamp);
+        assertEquals(1420070400000l, timestamp.getTime());
+        assertEquals(0, timestamp.getNanos());
+
+        timestamp = DateUtils.parseDateNanos("2015-01-01T12:10:30.123456Z");
+        assertNotNull(timestamp);
+        assertEquals(1420114230123l, timestamp.getTime());
+        assertEquals(123456000, timestamp.getNanos());
+
+        timestamp = DateUtils.parseDateNanos("2015-01-01T12:10:30.123Z");
+        assertNotNull(timestamp);
+        assertEquals(1420114230123l, timestamp.getTime());
+        assertEquals(123000000, timestamp.getNanos());
+    }
+}

--- a/mr/src/test/resources/org/elasticsearch/hadoop/serialization/dto/mapping/typed/primitives.json
+++ b/mr/src/test/resources/org/elasticsearch/hadoop/serialization/dto/mapping/typed/primitives.json
@@ -45,6 +45,9 @@
           "field14" : {
             "type" : "scaled_float",
             "scaling_factor" : 100.0
+          },
+          "field15" : {
+            "type" : "date_nanos"
           }
         }
       }

--- a/mr/src/test/resources/org/elasticsearch/hadoop/serialization/dto/mapping/typeless/primitives.json
+++ b/mr/src/test/resources/org/elasticsearch/hadoop/serialization/dto/mapping/typeless/primitives.json
@@ -44,6 +44,9 @@
         "field14" : {
           "type" : "scaled_float",
           "scaling_factor" : 100.0
+        },
+        "field15" : {
+          "type" : "date_nanos"
         }
       }
     }

--- a/spark/core/build.gradle
+++ b/spark/core/build.gradle
@@ -64,6 +64,7 @@ sparkVariants {
             }
 
             add(variant.configuration('itest', 'implementation'), project(":test:shared"))
+            add(variant.configuration('test', 'implementation'), "org.elasticsearch:securemock:1.2")
 
             if (variant.scalaMajorVersion == '2.10') {
                 add(variant.configuration('implementation'), "org.apache.spark:spark-unsafe_${variant.scalaMajorVersion}:${variant.sparkVersion}")

--- a/spark/core/src/main/scala/org/elasticsearch/spark/serialization/ScalaValueWriter.scala
+++ b/spark/core/src/main/scala/org/elasticsearch/spark/serialization/ScalaValueWriter.scala
@@ -18,15 +18,14 @@
  */
 package org.elasticsearch.spark.serialization
 
-import scala.collection.Map
-import scala.collection.immutable.Nil
+import org.elasticsearch.hadoop.EsHadoopIllegalArgumentException
 import org.elasticsearch.hadoop.serialization.Generator
 import org.elasticsearch.hadoop.serialization.builder.JdkValueWriter
 import org.elasticsearch.hadoop.serialization.builder.ValueWriter.Result
 import org.elasticsearch.spark.serialization.{ReflectionUtils => RU}
-import org.elasticsearch.hadoop.EsHadoopIllegalArgumentException
 
-import scala.collection.mutable
+import scala.collection.immutable.Nil
+import scala.collection.{Map, mutable}
 
 class ScalaValueWriter(writeUnknownTypes: Boolean = false) extends JdkValueWriter(writeUnknownTypes) {
 

--- a/spark/core/src/test/scala/org/elasticsearch/spark/serialization/ScalaValueReaderTest.scala
+++ b/spark/core/src/test/scala/org/elasticsearch/spark/serialization/ScalaValueReaderTest.scala
@@ -1,0 +1,45 @@
+package org.elasticsearch.spark.serialization
+
+import org.elasticsearch.hadoop.serialization.Parser
+import org.junit.Assert._
+import org.junit.Test
+import org.mockito.Mockito
+
+import java.sql.Timestamp
+import java.util.Date
+
+class ScalaValueReaderTest {
+  @Test
+  def testCreateDateNanos(): Unit = {
+    val reader = new ScalaValueReader()
+    val nanoDate = reader.createDateNanos("2015-01-01T12:10:30.123456789Z")
+    assertEquals(1420114230123l, nanoDate.getTime)
+    assertEquals(123456789, nanoDate.getNanos)
+  }
+
+  @Test
+  def testReadValue(): Unit = {
+    val reader = new ScalaValueReader()
+    val parser = Mockito.mock(classOf[Parser])
+
+    Mockito.when(parser.currentToken()).thenReturn(Parser.Token.VALUE_STRING)
+    val stringValue: String = reader.readValue(parser, "2015-01-01T12:10:30.123456789Z", DATE_NANOS).asInstanceOf[String]
+    assertEquals("2015-01-01T12:10:30.123456789Z", stringValue)
+
+    Mockito.when(parser.currentToken()).thenReturn(Parser.Token.VALUE_NUMBER)
+    Mockito.when(parser.longValue()).thenReturn(1420114230123l)
+    val dateLong = reader.readValue(parser, "1420114230123", DATE_NANOS).asInstanceOf[Long]
+    assertEquals(1420114230123l, dateLong)
+
+    reader.richDate = true
+    Mockito.when(parser.currentToken()).thenReturn(Parser.Token.VALUE_STRING)
+    val timestamp = reader.readValue(parser, "2015-01-01T12:10:30.123456789Z", DATE_NANOS).asInstanceOf[Timestamp]
+    assertEquals(1420114230123l, timestamp.getTime)
+    assertEquals(123456789, timestamp.getNanos)
+
+    Mockito.when(parser.currentToken()).thenReturn(Parser.Token.VALUE_NUMBER)
+    Mockito.when(parser.longValue()).thenReturn(1420114230123l)
+    val date = reader.readValue(parser, "1420114230123", DATE_NANOS).asInstanceOf[Date]
+    assertEquals(1420114230123l, date.getTime)
+  }
+}

--- a/spark/core/src/test/scala/org/elasticsearch/spark/serialization/ScalaValueWriterTest.scala
+++ b/spark/core/src/test/scala/org/elasticsearch/spark/serialization/ScalaValueWriterTest.scala
@@ -18,18 +18,18 @@
  */
 package org.elasticsearch.spark.serialization
 
-import org.elasticsearch.hadoop.serialization.json.JacksonJsonGenerator
-import org.junit.Test
-import org.junit.Assert._
-import java.io.ByteArrayOutputStream
-
-import org.elasticsearch.hadoop.cfg.ConfigurationOptions
 import org.elasticsearch.hadoop.cfg.Settings
 import org.elasticsearch.hadoop.serialization.EsHadoopSerializationException
+import org.elasticsearch.hadoop.serialization.json.JacksonJsonGenerator
 import org.elasticsearch.hadoop.util.TestSettings
-import org.elasticsearch.spark.serialization.testbeans.Contact
-import org.elasticsearch.spark.serialization.testbeans.ContactBook
+import org.elasticsearch.spark.serialization.testbeans.{Contact, ContactBook}
+import org.junit.Assert._
+import org.junit.Test
 
+import java.io.ByteArrayOutputStream
+import java.sql.Timestamp
+import java.time.ZoneId
+import java.util.Date
 import scala.beans.BeanProperty
 
 class ScalaValueWriterTest {
@@ -151,6 +151,23 @@ class ScalaValueWriterTest {
     node2.node = node1
 
     println(serialize(node1))
+  }
+
+  @Test
+  def testDate(): Unit = {
+    val date = new Date(1420114230123l)
+    val actual = serialize(date);
+    val expected = "\"" + date.toInstant.atZone(ZoneId.systemDefault).toOffsetDateTime.toString + "\""
+    assertEquals(expected, actual)
+  }
+
+  @Test
+  def testDateWithNanos(): Unit = {
+    val timestamp = new Timestamp(1420114230123l)
+    timestamp.setNanos(123456789)
+    val actual = serialize(timestamp);
+    val expected = "\"" + timestamp.toInstant.atZone(ZoneId.systemDefault).toOffsetDateTime.toString + "\""
+    assertEquals(expected, actual)
   }
 
 }

--- a/spark/sql-13/src/main/scala/org/elasticsearch/spark/sql/SchemaUtils.scala
+++ b/spark/sql-13/src/main/scala/org/elasticsearch/spark/sql/SchemaUtils.scala
@@ -23,11 +23,9 @@ import java.util.{LinkedHashSet => JHashSet}
 import java.util.{List => JList}
 import java.util.{Map => JMap}
 import java.util.Properties
-
 import scala.collection.JavaConverters.asScalaBufferConverter
 import scala.collection.JavaConverters.propertiesAsScalaMapConverter
 import scala.collection.mutable.ArrayBuffer
-
 import org.apache.spark.sql.types.ArrayType
 import org.apache.spark.sql.types.BinaryType
 import org.apache.spark.sql.types.BooleanType
@@ -53,6 +51,7 @@ import org.elasticsearch.hadoop.serialization.FieldType.BINARY
 import org.elasticsearch.hadoop.serialization.FieldType.BOOLEAN
 import org.elasticsearch.hadoop.serialization.FieldType.BYTE
 import org.elasticsearch.hadoop.serialization.FieldType.DATE
+import org.elasticsearch.hadoop.serialization.FieldType.DATE_NANOS
 import org.elasticsearch.hadoop.serialization.FieldType.DOUBLE
 import org.elasticsearch.hadoop.serialization.FieldType.HALF_FLOAT
 import org.elasticsearch.hadoop.serialization.FieldType.SCALED_FLOAT
@@ -167,6 +166,7 @@ private[sql] object SchemaUtils {
       case HALF_FLOAT => FloatType
       case SCALED_FLOAT => FloatType
       case DATE      => if (cfg.getMappingDateRich) TimestampType else StringType
+      case DATE_NANOS => if (cfg.getMappingDateRich) TimestampType else StringType
       case OBJECT    => convertToStruct(field, geoInfo, absoluteName, arrayIncludes, arrayExcludes, cfg)
       case NESTED    => DataTypes.createArrayType(convertToStruct(field, geoInfo, absoluteName, arrayIncludes, arrayExcludes, cfg))
       case JOIN      => convertToStruct(field, geoInfo, absoluteName, arrayIncludes, arrayExcludes, cfg)

--- a/spark/sql-20/src/main/scala/org/elasticsearch/spark/sql/SchemaUtils.scala
+++ b/spark/sql-20/src/main/scala/org/elasticsearch/spark/sql/SchemaUtils.scala
@@ -23,7 +23,6 @@ import java.util.{LinkedHashSet => JHashSet}
 import java.util.{List => JList}
 import java.util.{Map => JMap}
 import java.util.Properties
-
 import scala.collection.JavaConverters.asScalaBufferConverter
 import scala.collection.JavaConverters.propertiesAsScalaMapConverter
 import scala.collection.mutable.ArrayBuffer
@@ -52,6 +51,7 @@ import org.elasticsearch.hadoop.serialization.FieldType.BINARY
 import org.elasticsearch.hadoop.serialization.FieldType.BOOLEAN
 import org.elasticsearch.hadoop.serialization.FieldType.BYTE
 import org.elasticsearch.hadoop.serialization.FieldType.DATE
+import org.elasticsearch.hadoop.serialization.FieldType.DATE_NANOS
 import org.elasticsearch.hadoop.serialization.FieldType.DOUBLE
 import org.elasticsearch.hadoop.serialization.FieldType.HALF_FLOAT
 import org.elasticsearch.hadoop.serialization.FieldType.SCALED_FLOAT
@@ -166,6 +166,7 @@ private[sql] object SchemaUtils {
       case TEXT         => StringType
       case KEYWORD      => StringType
       case DATE         => if (cfg.getMappingDateRich) TimestampType else StringType
+      case DATE_NANOS => if (cfg.getMappingDateRich) TimestampType else StringType
       case OBJECT       => convertToStruct(field, geoInfo, absoluteName, arrayIncludes, arrayExcludes, cfg)
       case NESTED       => DataTypes.createArrayType(convertToStruct(field, geoInfo, absoluteName, arrayIncludes, arrayExcludes, cfg))
       case JOIN         => convertToStruct(field, geoInfo, absoluteName, arrayIncludes, arrayExcludes, cfg)

--- a/spark/sql-30/src/main/scala/org/elasticsearch/spark/sql/SchemaUtils.scala
+++ b/spark/sql-30/src/main/scala/org/elasticsearch/spark/sql/SchemaUtils.scala
@@ -52,6 +52,7 @@ import org.elasticsearch.hadoop.serialization.FieldType.BINARY
 import org.elasticsearch.hadoop.serialization.FieldType.BOOLEAN
 import org.elasticsearch.hadoop.serialization.FieldType.BYTE
 import org.elasticsearch.hadoop.serialization.FieldType.DATE
+import org.elasticsearch.hadoop.serialization.FieldType.DATE_NANOS
 import org.elasticsearch.hadoop.serialization.FieldType.DOUBLE
 import org.elasticsearch.hadoop.serialization.FieldType.HALF_FLOAT
 import org.elasticsearch.hadoop.serialization.FieldType.SCALED_FLOAT
@@ -148,7 +149,6 @@ private[sql] object SchemaUtils {
     val absoluteName = if (parentName != null) parentName + "." + field.name() else field.name()
     val matched = FieldFilter.filter(absoluteName, arrayIncludes, arrayExcludes, false)
     val createArray = !arrayIncludes.isEmpty() && matched.matched
-
     var dataType = Utils.extractType(field) match {
       case NULL         => NullType
       case BINARY       => BinaryType
@@ -166,6 +166,7 @@ private[sql] object SchemaUtils {
       case TEXT         => StringType
       case KEYWORD      => StringType
       case DATE         => if (cfg.getMappingDateRich) TimestampType else StringType
+      case DATE_NANOS   => if (cfg.getMappingDateRich) TimestampType else StringType
       case OBJECT       => convertToStruct(field, geoInfo, absoluteName, arrayIncludes, arrayExcludes, cfg)
       case NESTED       => DataTypes.createArrayType(convertToStruct(field, geoInfo, absoluteName, arrayIncludes, arrayExcludes, cfg))
       case JOIN         => convertToStruct(field, geoInfo, absoluteName, arrayIncludes, arrayExcludes, cfg)


### PR DESCRIPTION
Adding support for the date_nanos field type. This field type is now treated in the same way as the date
field type, except that we keep track of nanoseconds.
Closes #1653

