### PR TITLE
Fixing imports for tests

### DIFF
--- a/spark/core/src/test/scala/org/elasticsearch/spark/serialization/ScalaValueReaderTest.scala
+++ b/spark/core/src/test/scala/org/elasticsearch/spark/serialization/ScalaValueReaderTest.scala
@@ -1,5 +1,6 @@
 package org.elasticsearch.spark.serialization
 
+import org.elasticsearch.hadoop.serialization.FieldType.DATE_NANOS
 import org.elasticsearch.hadoop.serialization.Parser
 import org.junit.Assert._
 import org.junit.Test

--- a/spark/core/src/test/scala/org/elasticsearch/spark/serialization/ScalaValueWriterTest.scala
+++ b/spark/core/src/test/scala/org/elasticsearch/spark/serialization/ScalaValueWriterTest.scala
@@ -18,6 +18,7 @@
  */
 package org.elasticsearch.spark.serialization
 
+import org.elasticsearch.hadoop.cfg.ConfigurationOptions
 import org.elasticsearch.hadoop.cfg.Settings
 import org.elasticsearch.hadoop.serialization.EsHadoopSerializationException
 import org.elasticsearch.hadoop.serialization.json.JacksonJsonGenerator


### PR DESCRIPTION
This fixes some missing import statements in tests for the date_nanos fix (#1803)
Closes #1835