### PR TITLE
Avoiding failure when using frozen indices

### DIFF
--- a/mr/src/main/java/org/elasticsearch/hadoop/rest/ScrollQuery.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/rest/ScrollQuery.java
@@ -92,6 +92,10 @@ public class ScrollQuery implements Iterator<Object>, Closeable, StatsAware {
             
             try {
                 Scroll scroll = repository.scroll(query, body, reader);
+                if (scroll == null) {
+                    finished = true;
+                    return false;
+                }
                 // size is passed as a limit (since we can't pass it directly into the request) - if it's not specified (<1) just scroll the whole index
                 size = (size < 1 ? scroll.getTotalHits() : size);
                 scrollId = scroll.getScrollId();
@@ -114,6 +118,10 @@ public class ScrollQuery implements Iterator<Object>, Closeable, StatsAware {
 
             try {
                 Scroll scroll = repository.scroll(scrollId, reader);
+                if (scroll == null) {
+                    finished = true;
+                    return false;
+                }
                 scrollId = scroll.getScrollId();
                 batch = scroll.getHits();
                 finished = scroll.isConcluded();

--- a/mr/src/main/java/org/elasticsearch/hadoop/serialization/ScrollReader.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/serialization/ScrollReader.java
@@ -268,6 +268,12 @@ public class ScrollReader implements Closeable {
     private Scroll read(Parser parser, BytesArray input) {
         // get scroll_id
         Token token = ParsingUtils.seek(parser, SCROLL_ID);
+        if (token == null) { // no scroll id is returned for frozen indices
+            if (log.isTraceEnabled()) {
+                log.info("No scroll id found, likely because the index is frozen");
+            }
+            return null;
+        }
         Assert.isTrue(token == Token.VALUE_STRING, "invalid response");
         String scrollId = parser.text();
 

--- a/mr/src/test/resources/org/elasticsearch/hadoop/serialization/scrollReaderTestData/no-scroll-id/scroll.json
+++ b/mr/src/test/resources/org/elasticsearch/hadoop/serialization/scrollReaderTestData/no-scroll-id/scroll.json
@@ -1,0 +1,20 @@
+{
+  "took":0,
+  "timed_out":false,
+  "_shards":{
+    "total":0,
+    "successful":0,
+    "skipped":0,
+    "failed":0
+  },
+  "hits":{
+    "total":{
+      "value":0,
+      "relation":"eq"
+    },
+    "max_score":0.0,
+    "hits":[
+
+    ]
+  }
+}


### PR DESCRIPTION
This commit changes es-hadoop to treat frozen indices as empty indices rather than throwing exceptions. Before
this change if you query a frozen index with es-hadoop or spark you get job failure with an exception like this:
```
org.apache.spark.SparkException: Job aborted due to stage failure: Task 0 in stage 0.0 failed 4 times, most recent failure: Lost task 0.3 in stage 0.0 (TID 3) (localhost executor 2): org.elasticsearch.hadoop.EsHadoopIllegalArgumentException: invalid response
	at org.elasticsearch.hadoop.util.Assert.isTrue(Assert.java:60)
	at org.elasticsearch.hadoop.serialization.ScrollReader.read(ScrollReader.java:272)
	at org.elasticsearch.hadoop.serialization.ScrollReader.read(ScrollReader.java:263)
	at org.elasticsearch.hadoop.rest.RestRepository.scroll(RestRepository.java:313)
	at org.elasticsearch.hadoop.rest.ScrollQuery.hasNext(ScrollQuery.java:94)
	at org.elasticsearch.spark.rdd.AbstractEsRDDIterator.hasNext(AbstractEsRDDIterator.scala:66)
	at org.apache.spark.util.Utils$.getIteratorSize(Utils.scala:1889)
	at org.apache.spark.rdd.RDD.$anonfun$count$1(RDD.scala:1253)
	at org.apache.spark.rdd.RDD.$anonfun$count$1$adapted(RDD.scala:1253)
	at org.apache.spark.SparkContext.$anonfun$runJob$5(SparkContext.scala:2254)
	at org.apache.spark.scheduler.ResultTask.runTask(ResultTask.scala:90)
	at org.apache.spark.scheduler.Task.run(Task.scala:131)
	at org.apache.spark.executor.Executor$TaskRunner.$anonfun$run$3(Executor.scala:506)
	at org.apache.spark.util.Utils$.tryWithSafeFinally(Utils.scala:1462)
	at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:509)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```
We don't want to change behavior to read frozen indices by default since they will be very slow. We might add some config to have es-hadoop pass in `ignore-throttled` so that frozen indices can be queried. But since they are deprecated that might not be worth the effort.
Relates #1734