### PR TITLE
[DOCS] Remove PR #1350 from 8.0.0-alpha1 RNs

### DIFF
--- a/docs/src/reference/asciidoc/appendix/release-notes/8.0.0-alpha1.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/8.0.0-alpha1.adoc
@@ -8,10 +8,6 @@ Core::
 * Boost default scroll size to 1000
 https://github.com/elastic/elasticsearch-hadoop/pull/1429[#1429]
 
-Build::
-* Remove Scala 2.10 Support
-https://github.com/elastic/elasticsearch-hadoop/pull/1350[#1350]
-
 [[new-8.0.0-alpha1]]
 [float]
 === Enhancements


### PR DESCRIPTION
I originally included PR #1350 in the 8.0.0-alpha1 release notes. However, the changes in that PR were undone in #1471.

Relates to https://github.com/elastic/elasticsearch-hadoop/pull/1726.