### PR TITLE
[8.0] [DOCS] Remove PR 1350 from 8.0.0-alpha1 RNs (#1846)

### DIFF
--- a/docs/src/reference/asciidoc/appendix/release-notes/8.0.0-alpha1.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/8.0.0-alpha1.adoc
@@ -8,10 +8,6 @@ Core::
 * Boost default scroll size to 1000
 https://github.com/elastic/elasticsearch-hadoop/pull/1429[#1429]
 
-Build::
-* Remove Scala 2.10 Support
-https://github.com/elastic/elasticsearch-hadoop/pull/1350[#1350]
-
 [[new-8.0.0-alpha1]]
 [float]
 === Enhancements


### PR DESCRIPTION
Backports the following commits to 8.0:
 - [DOCS] Remove PR 1350 from 8.0.0-alpha1 RNs (#1846)