### PR TITLE
Fixing a scala compilation problem

### DIFF
--- a/spark/core/src/main/scala/org/elasticsearch/spark/serialization/ScalaValueWriter.scala
+++ b/spark/core/src/main/scala/org/elasticsearch/spark/serialization/ScalaValueWriter.scala
@@ -61,7 +61,14 @@ class ScalaValueWriter(writeUnknownTypes: Boolean = false) extends JdkValueWrite
         generator.writeBeginObject()
         for ((k, v) <- m) {
           if (shouldKeep(parentField, k.toString)) {
-            if (v != None && v!= null && v != () || hasWriteNullValues) {
+            val nonEmptyValue = Option(v) match {
+              case Some(()) => false
+              case Some(None) => false
+              case Some(_) => true
+              case None => true
+              case _ => false
+            }
+            if (nonEmptyValue || hasWriteNullValues) {
               generator.writeFieldName(k.toString)
               val result = doWrite(v, generator, k.toString)
               if (!result.isSuccesful) {

--- a/spark/core/src/main/scala/org/elasticsearch/spark/serialization/ScalaValueWriter.scala
+++ b/spark/core/src/main/scala/org/elasticsearch/spark/serialization/ScalaValueWriter.scala
@@ -61,14 +61,13 @@ class ScalaValueWriter(writeUnknownTypes: Boolean = false) extends JdkValueWrite
         generator.writeBeginObject()
         for ((k, v) <- m) {
           if (shouldKeep(parentField, k.toString)) {
-            val nonEmptyValue = Option(v) match {
+            val hasValue = Option(v) match {
               case Some(()) => false
               case Some(None) => false
               case Some(_) => true
               case None => true
-              case _ => false
             }
-            if (nonEmptyValue || hasWriteNullValues) {
+            if (hasValue || hasWriteNullValues) {
               generator.writeFieldName(k.toString)
               val result = doWrite(v, generator, k.toString)
               if (!result.isSuccesful) {

--- a/spark/core/src/test/scala/org/elasticsearch/spark/serialization/ScalaValueWriterTest.scala
+++ b/spark/core/src/test/scala/org/elasticsearch/spark/serialization/ScalaValueWriterTest.scala
@@ -196,14 +196,14 @@ class ScalaValueWriterTest {
   @Test
   def testCaseClassWithInnerObjectAndNullSetting(): Unit = {
 
-    case class TestCaseClass(option1: Option[String], option2: Option[TestCaseClassInner])
+    case class TestCaseClass(option1: Option[String], option2: Option[TestCaseClassInner], option3: Any)
     case class TestCaseClassInner(option1: Option[String], option2: Option[String])
-    val caseClass = TestCaseClass(None, Some(TestCaseClassInner(option1 = Some("value1"), option2 = None)))
+    val caseClass = TestCaseClass(None, Some(TestCaseClassInner(option1 = Some("value1"), option2 = None)), ())
 
     val settings = new TestSettings()
     settings.setProperty(ConfigurationOptions.ES_SPARK_DATAFRAME_WRITE_NULL_VALUES, "true")
 
-    assertEquals("""{"option1":null,"option2":{"option1":"value1","option2":null}}""", serialize(caseClass, settings))
+    assertEquals("""{"option1":null,"option2":{"option1":"value1","option2":null},"option3":null}""", serialize(caseClass, settings))
   }
 
   @Test


### PR DESCRIPTION
The code in ScalaValueWriter::doWriteScala was not compiling on the 7.17 branch. The problem is that the () reference to Unit was confusing the compiler. This commit makes the reference to Unit more explicit, and adds a test to make sure that Unit is being handled as expected.