### PR TITLE
[8.0] [DOCS] Add 8.0.0-rc1 release notes (#1859)

### DIFF
--- a/docs/src/reference/asciidoc/appendix/release-notes/8.0.0-rc1.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/8.0.0-rc1.adoc
@@ -1,0 +1,21 @@
+[[eshadoop-8.0.0-rc1]]
+== Elasticsearch for Apache Hadoop version 8.0.0-rc1
+
+coming::[8.0.0-rc1]
+
+[[enhancement-8.0.0-rc1]]
+[float]
+=== Enhancements
+Build::
+- Setting Java boot classpath so that Scala 2.10 works on Gradle 7.2
+https://github.com/elastic/elasticsearch-hadoop/pull/1800[#1800]
+
+- Build Hadoop with Java 17
+https://github.com/elastic/elasticsearch-hadoop/pull/1808[#1808]
+
+- Update Gradle wrapper to 7.3
+https://github.com/elastic/elasticsearch-hadoop/pull/1809[#1809]
+
+Spark::
+- Add support for Spark 3.1 and 3.2 
+https://github.com/elastic/elasticsearch-hadoop/pull/1807[#1807]

--- a/docs/src/reference/asciidoc/appendix/release.adoc
+++ b/docs/src/reference/asciidoc/appendix/release.adoc
@@ -9,6 +9,7 @@ This section summarizes the changes in each release.
 [[release-notes-8]]
 ===== 8.x
 
+* <<eshadoop-8.0.0-rc1>>
 * <<eshadoop-8.0.0-beta1>>
 * <<eshadoop-8.0.0-alpha2>>
 * <<eshadoop-8.0.0-alpha1>>
@@ -51,6 +52,7 @@ http://github.com/elastic/elasticsearch-hadoop/issues/XXX[#XXX]
 
 ////////////////////////
 
-include::release-notes/8.0.0-alpha1.adoc[]
-include::release-notes/8.0.0-alpha2.adoc[]
+include::release-notes/8.0.0-rc1.adoc[]
 include::release-notes/8.0.0-beta1.adoc[]
+include::release-notes/8.0.0-alpha2.adoc[]
+include::release-notes/8.0.0-alpha1.adoc[]


### PR DESCRIPTION
Backports the following commits to 8.0:
 - [DOCS] Add 8.0.0-rc1 release notes (#1859)