### PR TITLE
[master] [DOCS] Remove 8.0.0-rc1 coming tag (#1861)

### DIFF
--- a/docs/src/reference/asciidoc/appendix/release-notes/8.0.0-rc1.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/8.0.0-rc1.adoc
@@ -1,8 +1,6 @@
 [[eshadoop-8.0.0-rc1]]
 == Elasticsearch for Apache Hadoop version 8.0.0-rc1
 
-coming::[8.0.0-rc1]
-
 [[enhancement-8.0.0-rc1]]
 [float]
 === Enhancements


### PR DESCRIPTION
Backports the following commits to master:
 - [DOCS] Remove 8.0.0-rc1 coming tag (#1861)