### PR TITLE
[DOCS] Add missing items to 8.0.0-rc1 release notes

### DIFF
--- a/docs/src/reference/asciidoc/appendix/release-notes/8.0.0-rc1.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/8.0.0-rc1.adoc
@@ -14,6 +14,28 @@ https://github.com/elastic/elasticsearch-hadoop/pull/1808[#1808]
 - Update Gradle wrapper to 7.3
 https://github.com/elastic/elasticsearch-hadoop/pull/1809[#1809]
 
+- Update log4j version
+https://github.com/elastic/elasticsearch-hadoop/pull/1828[#1828]
+
+Serialization::
+- Add support for the `date_nanos` field type
+https://github.com/elastic/elasticsearch-hadoop/pull/1803[#1803]
+
 Spark::
 - Add support for Spark 3.1 and 3.2 
 https://github.com/elastic/elasticsearch-hadoop/pull/1807[#1807]
+
+[[bug-8.0.0-rc1]]
+[float]
+=== Bug fixes
+
+Core::
+- Resolve `saveToEs` saves case classes fields with `NULL` values
+https://github.com/elastic/elasticsearch-hadoop/pull/1478[#1478]
+
+- Correctly reading empty fields in as null rather than throwing exception
+https://github.com/elastic/elasticsearch-hadoop/pull/1816[#1816]
+
+Spark::
+- Setting es.read.fields.include could throw a NullPointerException in older spark version
+https://github.com/elastic/elasticsearch-hadoop/pull/1822[#1822]

--- a/docs/src/reference/asciidoc/appendix/release-notes/8.0.0-rc1.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/8.0.0-rc1.adoc
@@ -29,13 +29,12 @@ https://github.com/elastic/elasticsearch-hadoop/pull/1807[#1807]
 [float]
 === Bug fixes
 
-Core::
+Spark::
 - Resolve `saveToEs` saves case classes fields with `NULL` values
 https://github.com/elastic/elasticsearch-hadoop/pull/1478[#1478]
 
 - Correctly reading empty fields in as null rather than throwing exception
 https://github.com/elastic/elasticsearch-hadoop/pull/1816[#1816]
 
-Spark::
 - Setting es.read.fields.include could throw a NullPointerException in older spark version
 https://github.com/elastic/elasticsearch-hadoop/pull/1822[#1822]


### PR DESCRIPTION
When preparing the 8.0.0-rc1 release notes in #1859, I excluded PRs with the `v7.17` label. However, 7.17 hasn't been released yet so those PRs should be included. This adds the missing PRs.