### PR TITLE
[7.17] [DOCS] Remove coming tag from 7.16.3 release notes (#1852)

### DIFF
--- a/docs/src/reference/asciidoc/appendix/release-notes/7.16.3.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/7.16.3.adoc
@@ -1,7 +1,5 @@
 [[eshadoop-7.16.3]]
 == Elasticsearch for Apache Hadoop version 7.16.3
 
-coming::[7.16.3]
-
 ES-Hadoop 7.16.3 is a version compatibility release, tested specifically against
 Elasticsearch 7.16.3.


### PR DESCRIPTION
Backports the following commits to 7.17:
 - [DOCS] Remove coming tag from 7.16.3 release notes (#1852)