### PR TITLE
Getting rid of direct cross-project dependencies to avoid gradle warnings (#1868)

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/BuildPlugin.groovy
@@ -822,6 +822,12 @@ class BuildPlugin implements Plugin<Project>  {
         commonItestTaskConfiguration(project, integrationTest)
         // TODO: Should this be the case? It is in Elasticsearch, but we may have to update some CI jobs?
         project.tasks.check.dependsOn(integrationTest)
+
+        Configuration itestJarConfig = project.getConfigurations().maybeCreate("itestJarConfig")
+        itestJarConfig.canBeConsumed = Boolean.TRUE
+        itestJarConfig.canBeResolved = Boolean.FALSE
+        project.getArtifacts().add(itestJarConfig.getName(), itestJar)
+
         return integrationTest
     }
 

--- a/qa/kerberos/build.gradle
+++ b/qa/kerberos/build.gradle
@@ -83,8 +83,8 @@ dependencies {
     implementation("org.apache.hadoop:hadoop-client:${HadoopClusterConfiguration.HADOOP.defaultVersion()}")
     implementation("org.apache.spark:spark-sql_2.12:$project.ext.spark30Version")
 
-    implementation(project(":elasticsearch-hadoop-mr").sourceSets.itest.runtimeClasspath)
-    implementation(project(":elasticsearch-storm").sourceSets.itest.runtimeClasspath)
+    implementation( project(path: ':elasticsearch-hadoop-mr', configuration: 'itestJarConfig'))
+    implementation( project(path: ':elasticsearch-storm', configuration: 'itestJarConfig'))
 
     kdcFixture project(':test:fixtures:minikdc')
 


### PR DESCRIPTION
This commit avoids gradle warnings when running ./gradlew :qa:kerberos:compileJava. The :qa:kerberos project
had been directly pulling in the itest.runtimeClasspath from the storm and hadoop-mr projects, which is not allowed
in gradle 8.