### PR TITLE
Checking result of bulk writes

### DIFF
--- a/mr/src/main/java/org/elasticsearch/hadoop/serialization/bulk/AbstractBulkFactory.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/serialization/bulk/AbstractBulkFactory.java
@@ -150,9 +150,12 @@ public abstract class AbstractBulkFactory implements BulkFactory {
             else {
                 BytesArray ba = pool.get();
                 JacksonJsonGenerator generator = new JacksonJsonGenerator(new FastByteArrayOutputStream(ba));
-                valueWriter.write(value, generator);
+                ValueWriter.Result writeResult = valueWriter.write(value, generator);
                 generator.flush();
                 generator.close();
+                if(writeResult.isSuccesful() == false) {
+                    throw new RuntimeException("Write failed");
+                }
             }
         }
 


### PR DESCRIPTION
AbstractBulkFactory currently ignores the results of certain writes, meaning that a user might corrupt or lose data without realizing it. This commit checks the result and explicitly throws an Exception if there is a problem.