### PR TITLE
Check for invalid characters in X-Opaque-ID headers

### DIFF
--- a/mr/src/main/java/org/elasticsearch/hadoop/cfg/Settings.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/cfg/Settings.java
@@ -768,7 +768,7 @@ public abstract class Settings {
     public abstract Properties asProperties();
 
     public Settings setOpaqueId(String opaqueId) {
-        setProperty(ES_NET_HTTP_HEADER_OPAQUE_ID, opaqueId);
+        setProperty(ES_NET_HTTP_HEADER_OPAQUE_ID, opaqueId.replace("\n", "").replace("\r", ""));
         return this;
     }
 

--- a/mr/src/main/java/org/elasticsearch/hadoop/cfg/Settings.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/cfg/Settings.java
@@ -768,8 +768,25 @@ public abstract class Settings {
     public abstract Properties asProperties();
 
     public Settings setOpaqueId(String opaqueId) {
-        setProperty(ES_NET_HTTP_HEADER_OPAQUE_ID, opaqueId.replace("\n", "").replace("\r", ""));
+        setProperty(ES_NET_HTTP_HEADER_OPAQUE_ID, cleanOpaqueId(opaqueId));
         return this;
+    }
+
+    /**
+     * Headers can't contain newlines or non-ascii characters. This method strips them out, returning whatever is left.
+     * @param opaqueId
+     * @return
+     */
+    private String cleanOpaqueId(String opaqueId) {
+        char[] chars = opaqueId.toCharArray();
+        StringBuilder cleanedOpaqueId = new StringBuilder(chars.length);
+        for (int i = 0; i < chars.length; i++) {
+            int character = chars[i];
+            if (character > 31 && character < 127) { //visible ascii
+                cleanedOpaqueId.append(chars[i]);
+            }
+        }
+        return cleanedOpaqueId.toString();
     }
 
     public String getOpaqueId() {

--- a/mr/src/test/java/org/elasticsearch/hadoop/cfg/SettingsTest.java
+++ b/mr/src/test/java/org/elasticsearch/hadoop/cfg/SettingsTest.java
@@ -1,0 +1,53 @@
+package org.elasticsearch.hadoop.cfg;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+
+public class SettingsTest {
+    @Test
+    public void getXOpaqueId() throws Exception {
+        TestSettings testSettings = new TestSettings();
+        String opaqueId1 = "This is an opaque ID";
+        testSettings.setOpaqueId(opaqueId1);
+        assertEquals(opaqueId1, testSettings.getOpaqueId());
+        testSettings.setOpaqueId("This one\n has newlines\r\n and a carriage return");
+        assertEquals("This one has newlines and a carriage return", testSettings.getOpaqueId());
+        testSettings.setOpaqueId("This oñe has a non-ascii character");
+        assertEquals("This oe has a non-ascii character", testSettings.getOpaqueId());
+    }
+
+    public static class TestSettings extends Settings {
+        private Map<String, String> actualSettings = new HashMap();
+        @Override
+        public InputStream loadResource(String location) {
+            return null;
+        }
+
+        @Override
+        public Settings copy() {
+            return null;
+        }
+
+        @Override
+        public String getProperty(String name) {
+            return actualSettings.get(name);
+        }
+
+        @Override
+        public void setProperty(String name, String value) {
+            actualSettings.put(name, value);
+        }
+
+        @Override
+        public Properties asProperties() {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
This commit strips out any non-visible, non-ascii characters from the X-Opaque-ID header.
Closes #1872