### PR TITLE
Expected exception when incorrectly configuring upsert has changed

### DIFF
--- a/mr/src/itest/java/org/elasticsearch/hadoop/integration/mr/AbstractMROldApiSaveTest.java
+++ b/mr/src/itest/java/org/elasticsearch/hadoop/integration/mr/AbstractMROldApiSaveTest.java
@@ -287,7 +287,7 @@ public class AbstractMROldApiSaveTest {
     }
 
 
-    @Test(expected = IOException.class)
+    @Test(expected = EsHadoopIllegalArgumentException.class)
     public void testUpdateWithoutId() throws Exception {
         JobConf conf = createJobConf();
         conf.set(ConfigurationOptions.ES_WRITE_OPERATION, "upsert");


### PR DESCRIPTION
AbstractMROldApiSaveTest.testUpdateWithoutId broke when #1839 was merged because we are now failing earlier if
upsert is used but `es.mapping.id` is not set. The exception is now the same as the one you get when update is not
configured to use `es.mapping.id`.
Relates #1839 #69