### PR TITLE
[8.0] [DOCS] Add 8.0.0-rc2 release notes (#1892)

### DIFF
--- a/docs/src/reference/asciidoc/appendix/release-notes/8.0.0-rc2.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/8.0.0-rc2.adoc
@@ -1,0 +1,37 @@
+[[eshadoop-8.0.0-rc2]]
+== Elasticsearch for Apache Hadoop version 8.0.0-rc2
+
+coming::[8.0.0-rc2]
+
+[[breaking-8.0.0-rc2]]
+[float]
+=== Breaking changes
+- Deprecate support for Spark 1.x, Scala 2.10 on Spark 2.x, Hadoop 1, Pig, and Storm
+https://github.com/elastic/elasticsearch-hadoop/pull/1845[#1845]
+
+[[enhancement-8.0.0-rc2]]
+[float]
+=== Enhancements
+Build::
+- Get rid of direct cross-project dependencies to avoid gradle warnings
+https://github.com/elastic/elasticsearch-hadoop/pull/1868[#1868]
+
+Core::
+- Avoid failure when using frozen indices
+https://github.com/elastic/elasticsearch-hadoop/pull/1842[#1842]
+
+[[bug-8.0.0-rc2]]
+[float]
+=== Bug fixes
+
+Core::
+- Fix support for empty and null arrays
+https://github.com/elastic/elasticsearch-hadoop/pull/1827[#1827]
+
+MapReduce::
+-  Fix `docsReceived` counter
+https://github.com/elastic/elasticsearch-hadoop/pull/1840[#1840]
+
+REST::
+- Check for invalid characters in X-Opaque-ID headers
+https://github.com/elastic/elasticsearch-hadoop/pull/1873[#1873]

--- a/docs/src/reference/asciidoc/appendix/release.adoc
+++ b/docs/src/reference/asciidoc/appendix/release.adoc
@@ -9,6 +9,7 @@ This section summarizes the changes in each release.
 [[release-notes-8]]
 ===== 8.x
 
+* <<eshadoop-8.0.0-rc2>>
 * <<eshadoop-8.0.0-rc1>>
 * <<eshadoop-8.0.0-beta1>>
 * <<eshadoop-8.0.0-alpha2>>
@@ -52,6 +53,7 @@ http://github.com/elastic/elasticsearch-hadoop/issues/XXX[#XXX]
 
 ////////////////////////
 
+include::release-notes/8.0.0-rc2.adoc[]
 include::release-notes/8.0.0-rc1.adoc[]
 include::release-notes/8.0.0-beta1.adoc[]
 include::release-notes/8.0.0-alpha2.adoc[]


### PR DESCRIPTION
Backports the following commits to 8.0:
 - [DOCS] Add 8.0.0-rc2 release notes (#1892)