### PR TITLE
Adding support for commas in field names

### DIFF
--- a/mr/src/main/java/org/elasticsearch/hadoop/util/StringUtils.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/util/StringUtils.java
@@ -29,6 +29,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.StringTokenizer;
+import java.util.stream.Collectors;
 
 
 /**
@@ -126,18 +127,42 @@ public abstract class StringUtils {
         if (!StringUtils.hasText(string)) {
             return Collections.emptyList();
         }
-        StringTokenizer st = new StringTokenizer(string, delimiters);
-        List<String> tokens = new ArrayList<String>();
-        while (st.hasMoreTokens()) {
-            String token = st.nextToken();
-            if (trimTokens) {
-                token = token.trim();
+        List<String> tokens = new ArrayList<>();
+        char[] delims = delimiters.toCharArray();
+        StringBuilder currentToken = new StringBuilder();
+        boolean inQuotedToken = false;
+        for (char character : string.toCharArray()) {
+            if (character == '\"') {
+                inQuotedToken = !inQuotedToken;
             }
-            if (!ignoreEmptyTokens || token.length() > 0) {
-                tokens.add(token);
+            else if (inQuotedToken == false && isCharacterInArray(character, delims)) {
+                addTokenToList(tokens, currentToken, trimTokens, ignoreEmptyTokens);
+                currentToken = new StringBuilder();
+            } else {
+                currentToken.append(character);
             }
         }
+        addTokenToList(tokens, currentToken, trimTokens, ignoreEmptyTokens);
         return tokens;
+    }
+
+    private static void addTokenToList(List<String> tokens, StringBuilder newToken, boolean trimTokens, boolean ignoreEmptyTokens) {
+        String token = newToken.toString();
+        if (trimTokens) {
+            token = token.trim();
+        }
+        if (!ignoreEmptyTokens || token.length() > 0) {
+            tokens.add(token);
+        }
+    }
+
+    private static boolean isCharacterInArray(char character, char[] charArray) {
+        for (char arrayChar : charArray) {
+            if (character == arrayChar) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public static String concatenate(Collection<?> list) {
@@ -151,15 +176,10 @@ public abstract class StringUtils {
         if (delimiter == null) {
             delimiter = EMPTY;
         }
-        StringBuilder sb = new StringBuilder();
-
-        for (Object object : list) {
-            sb.append(object.toString());
-            sb.append(delimiter);
-        }
-
-        sb.setLength(sb.length() - delimiter.length());
-        return sb.toString();
+        final String finalDelimiter = delimiter;
+        return list.stream().map(item -> item.toString())
+                .map(token -> optionallyWrapToken(token, finalDelimiter))
+                .collect(Collectors.joining(delimiter));
     }
 
     public static String concatenate(Object[] array, String delimiter) {
@@ -169,15 +189,14 @@ public abstract class StringUtils {
         if (delimiter == null) {
             delimiter = EMPTY;
         }
+        final String finalDelimiter = delimiter;
+        return Arrays.stream(array).map(item -> item.toString())
+                .map(token -> optionallyWrapToken(token, finalDelimiter))
+                .collect(Collectors.joining(delimiter));
+    }
 
-        StringBuilder sb = new StringBuilder();
-        for (int i = 0; i < array.length; i++) {
-            if (i > 0) {
-                sb.append(delimiter);
-            }
-            sb.append(array[i]);
-        }
-        return sb.toString();
+    private static String optionallyWrapToken(String token, String delimiter) {
+        return token.contains(delimiter) ? "\"" + token + "\"" : token;
     }
 
     public static String deleteWhitespace(CharSequence sequence) {

--- a/mr/src/test/java/org/elasticsearch/hadoop/util/StringUtilsTest.java
+++ b/mr/src/test/java/org/elasticsearch/hadoop/util/StringUtilsTest.java
@@ -20,6 +20,10 @@ package org.elasticsearch.hadoop.util;
 
 import org.junit.Test;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
 import static org.junit.Assert.*;
 
 public class StringUtilsTest {
@@ -71,5 +75,33 @@ public class StringUtilsTest {
         // Multi-Index Format is not a legal singular index name, but it should be resolved to one at runtime
         assertFalse(StringUtils.isValidSingularIndexName("abc{date|yyyy-MM-dd}defg"));
 
+    }
+
+    @Test
+    public void testTokenize() {
+        List<String> test1 = Arrays.asList(new String[]{"this", "is a", "test"});
+        String concatenatedString = StringUtils.concatenate(test1);
+        List<String> tokens = StringUtils.tokenize(concatenatedString, ",", true, true);
+        assertEquals(test1, tokens);
+
+        List<String> test2 = Arrays.asList(new String[]{"this", " is a", " test ", " "});
+        concatenatedString = StringUtils.concatenate(test2);
+        tokens = StringUtils.tokenize(concatenatedString, ",", false, false);
+        assertEquals(test2, tokens);
+
+        List<String> test3 = Arrays.asList(new String[]{"this", "is, a", "test"});
+        concatenatedString = StringUtils.concatenate(test3);
+        tokens = StringUtils.tokenize(concatenatedString, ",", true, true);
+        assertEquals(test3, tokens);
+
+        Object[] test4 = new String[]{"this", "is, a", "test"};
+        concatenatedString = StringUtils.concatenate(test4, ";");
+        tokens = StringUtils.tokenize(concatenatedString, ";", true, true);
+        assertEquals(Arrays.asList(test4), tokens);
+
+        List<String> test5 = Arrays.asList(new String[]{"this", "is, a", "test"});
+        concatenatedString = StringUtils.concatenate(test5, ",");
+        tokens = StringUtils.tokenize(concatenatedString, ";,", true, true);
+        assertEquals(test5, tokens);
     }
 }

--- a/spark/sql-30/src/itest/scala/org/elasticsearch/spark/integration/AbstractScalaEsSparkSQL.scala
+++ b/spark/sql-30/src/itest/scala/org/elasticsearch/spark/integration/AbstractScalaEsSparkSQL.scala
@@ -2284,7 +2284,30 @@ class AbstractScalaEsScalaSparkSQL(prefix: String, readMetadata: jl.Boolean, pus
     assertEquals(nested(0).getLong(1), 6)
   }
 
-  
+  @Test
+  def testCommasInFieldNames(): Unit = {
+    val index = wrapIndex("commas-in-names-index")
+    val typed = "data"
+    val (target, docPath) = makeTargets(index, typed)
+    val mapping = wrapMapping("data", s"""{
+                                         |    "dynamic": "strict",
+                                         |    "properties" : {
+                                         |      "some column with a, comma and then some" : {
+                                         |        "type" : "keyword"
+                                         |      }
+                                         |    }
+                                         |  }
+        """.stripMargin)
+    RestUtils.touch(index)
+    RestUtils.putMapping(index, typed, mapping.getBytes(StringUtils.UTF_8))
+    RestUtils.postData(docPath, "{\"some column with a, comma and then some\": \"sdfdsf\"}".getBytes("UTF-8"))
+    RestUtils.refresh(target)
+    val df = sqc.read.format("es").load(index)
+    df.printSchema()
+    df.show()
+    assertEquals(1, df.count())
+  }
+
   @Test
   def testMultiIndexes() {
     // add some data


### PR DESCRIPTION
This commit adds support for commas in field names, which is allowed by Elasticsearch.
Closes #1380