### PR TITLE
[8.1] [DOCS] Remove 8.0.0-rc2 coming tag (#1894)

### DIFF
--- a/docs/src/reference/asciidoc/appendix/release-notes/8.0.0-rc2.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/8.0.0-rc2.adoc
@@ -1,8 +1,6 @@
 [[eshadoop-8.0.0-rc2]]
 == Elasticsearch for Apache Hadoop version 8.0.0-rc2
 
-coming::[8.0.0-rc2]
-
 [[breaking-8.0.0-rc2]]
 [float]
 === Breaking changes


### PR DESCRIPTION
Backports the following commits to 8.1:
 - [DOCS] Remove 8.0.0-rc2 coming tag (#1894)