### PR TITLE
Do not fail if flush is called before any writes

### DIFF
--- a/mr/src/main/java/org/elasticsearch/hadoop/rest/RestRepository.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/rest/RestRepository.java
@@ -194,11 +194,12 @@ public class RestRepository implements Closeable, StatsAware {
     }
 
     public BulkResponse tryFlush() {
-        if (writeInitialized == false) {
+        if (writeInitialized) {
+            return bulkProcessor.tryFlush();
+        } else {
             log.warn("Attempt to flush before any data had been written");
             return BulkResponse.complete();
         }
-        return bulkProcessor.tryFlush();
     }
 
     public void flush() {

--- a/mr/src/main/java/org/elasticsearch/hadoop/rest/RestRepository.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/rest/RestRepository.java
@@ -194,13 +194,19 @@ public class RestRepository implements Closeable, StatsAware {
     }
 
     public BulkResponse tryFlush() {
-        Assert.isTrue(writeInitialized, "Cannot flush non-initialized write operation");
+        if (writeInitialized == false) {
+            log.warn("Attempt to flush before any data had been written");
+            return BulkResponse.complete();
+        }
         return bulkProcessor.tryFlush();
     }
 
     public void flush() {
-        Assert.isTrue(writeInitialized, "Cannot flush non-initialized write operation");
-        bulkProcessor.flush();
+        if (writeInitialized) {
+            bulkProcessor.flush();
+        } else {
+            log.warn("Attempt to flush before any data had been written");
+        }
     }
 
     @Override


### PR DESCRIPTION
This commit logs a warning instead of throwing an exception if an attempt to flush before writing is made (which our
Storm implementation can do).
Closes #1357