### PR TITLE
[DOCS] Add 8.0.0 GA release notes

### DIFF
--- a/docs/src/reference/asciidoc/appendix/release-notes/8.0.0.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/8.0.0.adoc
@@ -1,0 +1,92 @@
+[[eshadoop-8.0.0]]
+== Elasticsearch for Apache Hadoop version 8.0.0
+
+The following list are changes in 8.0.0 as compared to 7.17.0, and combines
+release notes from the 8.0.0-alpha1, -alpha2, -beta1, -rc1 and -rc2 releases.
+
+[[breaking-8.0.0]]
+[float]
+=== Breaking Changes
+
+- Deprecate support for Spark 1.x, Scala 2.10 on Spark 2.x, Hadoop 1, Pig, and Storm
+https://github.com/elastic/elasticsearch-hadoop/pull/1845[#1845]
+
+Core::
+- Boost default scroll size to 1000
+https://github.com/elastic/elasticsearch-hadoop/pull/1429[#1429]
+
+[[new-8.0.0]]
+[float]
+=== Enhancements
+
+Build::
+- Update Gradle wrapper to 7.0
+https://github.com/elastic/elasticsearch-hadoop/pull/1641[#1641]
+
+- Upgrade build to use JDK 12 and current build tools
+https://github.com/elastic/elasticsearch-hadoop/pull/1351[#1351]
+
+- Upgrade to and fix compatibility with Gradle 5.5
+https://github.com/elastic/elasticsearch-hadoop/pull/1333[#1333]
+
+- Setting Java boot classpath so that Scala 2.10 works on Gradle 7.2
+https://github.com/elastic/elasticsearch-hadoop/pull/1800[#1800]
+
+- Build Hadoop with Java 17
+https://github.com/elastic/elasticsearch-hadoop/pull/1808[#1808]
+
+- Update Gradle wrapper to 7.3
+https://github.com/elastic/elasticsearch-hadoop/pull/1809[#1809]
+
+- Update log4j version
+https://github.com/elastic/elasticsearch-hadoop/pull/1828[#1828]
+
+- Get rid of direct cross-project dependencies to avoid gradle warnings
+https://github.com/elastic/elasticsearch-hadoop/pull/1868[#1868]
+
+Core::
+- Setting X-Opaque-ID header for all reads and writes for mapreduce and spark
+https://github.com/elastic/elasticsearch-hadoop/pull/1770[#1770]
+
+- Avoid failure when using frozen indices
+https://github.com/elastic/elasticsearch-hadoop/pull/1842[#1842]
+
+Serialization::
+- Add support for the `date_nanos` field type
+https://github.com/elastic/elasticsearch-hadoop/pull/1803[#1803]
+
+- Add support for the `date_nanos` field type
+https://github.com/elastic/elasticsearch-hadoop/pull/1803[#1803]
+
+Spark::
+- Add support for Spark 3.1 and 3.2 
+https://github.com/elastic/elasticsearch-hadoop/pull/1807[#1807]
+
+
+[[bug-8.0.0]]
+[float]
+=== Bug fixes
+Core::
+- Close RestRepository to avoid a connection leak
+https://github.com/elastic/elasticsearch-hadoop/pull/1781[#1781]
+
+- Fix support for empty and null arrays
+https://github.com/elastic/elasticsearch-hadoop/pull/1827[#1827]
+
+MapReduce::
+-  Fix `docsReceived` counter
+https://github.com/elastic/elasticsearch-hadoop/pull/1840[#1840]
+
+REST::
+- Check for invalid characters in X-Opaque-ID headers
+https://github.com/elastic/elasticsearch-hadoop/pull/1873[#1873]
+
+Spark::
+- Resolve `saveToEs` saves case classes fields with `NULL` values
+https://github.com/elastic/elasticsearch-hadoop/pull/1478[#1478]
+
+- Correctly reading empty fields in as null rather than throwing exception
+https://github.com/elastic/elasticsearch-hadoop/pull/1816[#1816]
+
+- Setting `es.read.fields.include` could throw a `NullPointerException` in older spark version
+https://github.com/elastic/elasticsearch-hadoop/pull/1822[#1822]

--- a/docs/src/reference/asciidoc/appendix/release-notes/8.0.0.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/8.0.0.adoc
@@ -20,26 +20,27 @@ https://github.com/elastic/elasticsearch-hadoop/pull/1429[#1429]
 === Enhancements
 
 Build::
-- Update Gradle wrapper to 7.0
-https://github.com/elastic/elasticsearch-hadoop/pull/1641[#1641]
-
 - Upgrade build to use JDK 12 and current build tools
 https://github.com/elastic/elasticsearch-hadoop/pull/1351[#1351]
-
-- Upgrade to and fix compatibility with Gradle 5.5
-https://github.com/elastic/elasticsearch-hadoop/pull/1333[#1333]
-
-- Setting Java boot classpath so that Scala 2.10 works on Gradle 7.2
-https://github.com/elastic/elasticsearch-hadoop/pull/1800[#1800]
 
 - Build Hadoop with Java 17
 https://github.com/elastic/elasticsearch-hadoop/pull/1808[#1808]
 
-- Update Gradle wrapper to 7.3
-https://github.com/elastic/elasticsearch-hadoop/pull/1809[#1809]
-
 - Update log4j version
 https://github.com/elastic/elasticsearch-hadoop/pull/1828[#1828]
+
+Build/Gradle::
+- Upgrade to and fix compatibility with Gradle 5.5
+https://github.com/elastic/elasticsearch-hadoop/pull/1333[#1333]
+
+- Update Gradle wrapper to 7.0
+https://github.com/elastic/elasticsearch-hadoop/pull/1641[#1641]
+
+- Setting Java boot classpath so that Scala 2.10 works on Gradle 7.2
+https://github.com/elastic/elasticsearch-hadoop/pull/1800[#1800]
+
+- Update Gradle wrapper to 7.3
+https://github.com/elastic/elasticsearch-hadoop/pull/1809[#1809]
 
 - Get rid of direct cross-project dependencies to avoid gradle warnings
 https://github.com/elastic/elasticsearch-hadoop/pull/1868[#1868]
@@ -52,9 +53,6 @@ https://github.com/elastic/elasticsearch-hadoop/pull/1770[#1770]
 https://github.com/elastic/elasticsearch-hadoop/pull/1842[#1842]
 
 Serialization::
-- Add support for the `date_nanos` field type
-https://github.com/elastic/elasticsearch-hadoop/pull/1803[#1803]
-
 - Add support for the `date_nanos` field type
 https://github.com/elastic/elasticsearch-hadoop/pull/1803[#1803]
 

--- a/docs/src/reference/asciidoc/appendix/release-notes/8.0.0.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/8.0.0.adoc
@@ -8,10 +8,11 @@ release notes from the 8.0.0-alpha1, -alpha2, -beta1, -rc1 and -rc2 releases.
 [float]
 === Breaking Changes
 
+
+Core::
 - Deprecate support for Spark 1.x, Scala 2.10 on Spark 2.x, Hadoop 1, Pig, and Storm
 https://github.com/elastic/elasticsearch-hadoop/pull/1845[#1845]
 
-Core::
 - Boost default scroll size to 1000
 https://github.com/elastic/elasticsearch-hadoop/pull/1429[#1429]
 

--- a/docs/src/reference/asciidoc/appendix/release-notes/8.0.0.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/8.0.0.adoc
@@ -8,7 +8,6 @@ release notes from the 8.0.0-alpha1, -alpha2, -beta1, -rc1 and -rc2 releases.
 [float]
 === Breaking Changes
 
-
 Core::
 - Deprecate support for Spark 1.x, Scala 2.10 on Spark 2.x, Hadoop 1, Pig, and Storm
 https://github.com/elastic/elasticsearch-hadoop/pull/1845[#1845]
@@ -51,6 +50,7 @@ https://github.com/elastic/elasticsearch-hadoop/pull/1807[#1807]
 [[bug-8.0.0]]
 [float]
 === Bug fixes
+
 Core::
 - Fix support for empty and null arrays
 https://github.com/elastic/elasticsearch-hadoop/pull/1827[#1827]

--- a/docs/src/reference/asciidoc/appendix/release-notes/8.0.0.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/8.0.0.adoc
@@ -76,7 +76,7 @@ MapReduce::
 https://github.com/elastic/elasticsearch-hadoop/pull/1840[#1840]
 
 Spark::
-- Resolve `saveToEs` saves case classes fields with `NULL` values
+- Better handling of null values in case classes
 https://github.com/elastic/elasticsearch-hadoop/pull/1478[#1478]
 
 - Correctly reading empty fields in as null rather than throwing exception

--- a/docs/src/reference/asciidoc/appendix/release-notes/8.0.0.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/8.0.0.adoc
@@ -20,19 +20,10 @@ https://github.com/elastic/elasticsearch-hadoop/pull/1429[#1429]
 === Enhancements
 
 Build::
-- Upgrade build to use JDK 12 and current build tools
-https://github.com/elastic/elasticsearch-hadoop/pull/1351[#1351]
-
-- Build Hadoop with Java 17
+- Build ES-Hadoop with Java 17
 https://github.com/elastic/elasticsearch-hadoop/pull/1808[#1808]
 
 Build/Gradle::
-- Upgrade to and fix compatibility with Gradle 5.5
-https://github.com/elastic/elasticsearch-hadoop/pull/1333[#1333]
-
-- Update Gradle wrapper to 7.0
-https://github.com/elastic/elasticsearch-hadoop/pull/1641[#1641]
-
 - Setting Java boot classpath so that Scala 2.10 works on Gradle 7.2
 https://github.com/elastic/elasticsearch-hadoop/pull/1800[#1800]
 

--- a/docs/src/reference/asciidoc/appendix/release-notes/8.0.0.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/8.0.0.adoc
@@ -42,10 +42,6 @@ https://github.com/elastic/elasticsearch-hadoop/pull/1809[#1809]
 - Get rid of direct cross-project dependencies to avoid gradle warnings
 https://github.com/elastic/elasticsearch-hadoop/pull/1868[#1868]
 
-Core::
-- Setting X-Opaque-ID header for all reads and writes for mapreduce and spark
-https://github.com/elastic/elasticsearch-hadoop/pull/1770[#1770]
-
 Spark::
 - Add support for Spark 3.1 and 3.2 
 https://github.com/elastic/elasticsearch-hadoop/pull/1807[#1807]

--- a/docs/src/reference/asciidoc/appendix/release-notes/8.0.0.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/8.0.0.adoc
@@ -75,10 +75,6 @@ MapReduce::
 -  Fix `docsReceived` counter
 https://github.com/elastic/elasticsearch-hadoop/pull/1840[#1840]
 
-REST::
-- Check for invalid characters in X-Opaque-ID headers
-https://github.com/elastic/elasticsearch-hadoop/pull/1873[#1873]
-
 Spark::
 - Resolve `saveToEs` saves case classes fields with `NULL` values
 https://github.com/elastic/elasticsearch-hadoop/pull/1478[#1478]
@@ -86,5 +82,5 @@ https://github.com/elastic/elasticsearch-hadoop/pull/1478[#1478]
 - Correctly reading empty fields in as null rather than throwing exception
 https://github.com/elastic/elasticsearch-hadoop/pull/1816[#1816]
 
-- Setting `es.read.fields.include` could throw a `NullPointerException` in older spark version
+- Setting `es.read.fields.include` could throw a `NullPointerException` in older Spark versions
 https://github.com/elastic/elasticsearch-hadoop/pull/1822[#1822]

--- a/docs/src/reference/asciidoc/appendix/release-notes/8.0.0.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/8.0.0.adoc
@@ -26,9 +26,6 @@ https://github.com/elastic/elasticsearch-hadoop/pull/1351[#1351]
 - Build Hadoop with Java 17
 https://github.com/elastic/elasticsearch-hadoop/pull/1808[#1808]
 
-- Update log4j version
-https://github.com/elastic/elasticsearch-hadoop/pull/1828[#1828]
-
 Build/Gradle::
 - Upgrade to and fix compatibility with Gradle 5.5
 https://github.com/elastic/elasticsearch-hadoop/pull/1333[#1333]
@@ -49,13 +46,6 @@ Core::
 - Setting X-Opaque-ID header for all reads and writes for mapreduce and spark
 https://github.com/elastic/elasticsearch-hadoop/pull/1770[#1770]
 
-- Avoid failure when using frozen indices
-https://github.com/elastic/elasticsearch-hadoop/pull/1842[#1842]
-
-Serialization::
-- Add support for the `date_nanos` field type
-https://github.com/elastic/elasticsearch-hadoop/pull/1803[#1803]
-
 Spark::
 - Add support for Spark 3.1 and 3.2 
 https://github.com/elastic/elasticsearch-hadoop/pull/1807[#1807]
@@ -70,17 +60,3 @@ https://github.com/elastic/elasticsearch-hadoop/pull/1781[#1781]
 
 - Fix support for empty and null arrays
 https://github.com/elastic/elasticsearch-hadoop/pull/1827[#1827]
-
-MapReduce::
--  Fix `docsReceived` counter
-https://github.com/elastic/elasticsearch-hadoop/pull/1840[#1840]
-
-Spark::
-- Better handling of null values in case classes
-https://github.com/elastic/elasticsearch-hadoop/pull/1478[#1478]
-
-- Correctly reading empty fields in as null rather than throwing exception
-https://github.com/elastic/elasticsearch-hadoop/pull/1816[#1816]
-
-- Setting `es.read.fields.include` could throw a `NullPointerException` in older Spark versions
-https://github.com/elastic/elasticsearch-hadoop/pull/1822[#1822]

--- a/docs/src/reference/asciidoc/appendix/release-notes/8.0.0.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/8.0.0.adoc
@@ -51,8 +51,5 @@ https://github.com/elastic/elasticsearch-hadoop/pull/1807[#1807]
 [float]
 === Bug fixes
 Core::
-- Close RestRepository to avoid a connection leak
-https://github.com/elastic/elasticsearch-hadoop/pull/1781[#1781]
-
 - Fix support for empty and null arrays
 https://github.com/elastic/elasticsearch-hadoop/pull/1827[#1827]

--- a/docs/src/reference/asciidoc/appendix/release.adoc
+++ b/docs/src/reference/asciidoc/appendix/release.adoc
@@ -9,6 +9,7 @@ This section summarizes the changes in each release.
 [[release-notes-8]]
 ===== 8.x
 
+* <<eshadoop-8.0.0>>
 * <<eshadoop-8.0.0-rc2>>
 * <<eshadoop-8.0.0-rc1>>
 * <<eshadoop-8.0.0-beta1>>
@@ -53,6 +54,7 @@ http://github.com/elastic/elasticsearch-hadoop/issues/XXX[#XXX]
 
 ////////////////////////
 
+include::release-notes/8.0.0.adoc[]
 include::release-notes/8.0.0-rc2.adoc[]
 include::release-notes/8.0.0-rc1.adoc[]
 include::release-notes/8.0.0-beta1.adoc[]


### PR DESCRIPTION
Adds the 8.0.0 GA release notes. I created these by combining the 8.0.0-alpha1, -alpha2, -beta1, -rc1 and -rc2 releases notes. Copy/paste may have been involved.

### Preview
https://elasticsearch-hadoop_1902.docs-preview.app.elstc.co/guide/en/elasticsearch/hadoop/8.0/eshadoop-8.0.0.html