### PR TITLE
[8.1] [DOCS] Add 8.0.0 GA release notes (#1902)

### DIFF
--- a/docs/src/reference/asciidoc/appendix/release-notes/8.0.0.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/8.0.0.adoc
@@ -1,0 +1,47 @@
+[[eshadoop-8.0.0]]
+== Elasticsearch for Apache Hadoop version 8.0.0
+
+The following list are changes in 8.0.0 as compared to 7.17.0, and combines
+release notes from the 8.0.0-alpha1, -alpha2, -beta1, -rc1 and -rc2 releases.
+
+[[breaking-8.0.0]]
+[float]
+=== Breaking Changes
+
+Core::
+- Deprecate support for Spark 1.x, Scala 2.10 on Spark 2.x, Hadoop 1, Pig, and Storm
+https://github.com/elastic/elasticsearch-hadoop/pull/1845[#1845]
+
+- Boost default scroll size to 1000
+https://github.com/elastic/elasticsearch-hadoop/pull/1429[#1429]
+
+[[new-8.0.0]]
+[float]
+=== Enhancements
+
+Build::
+- Build ES-Hadoop with Java 17
+https://github.com/elastic/elasticsearch-hadoop/pull/1808[#1808]
+
+Build/Gradle::
+- Setting Java boot classpath so that Scala 2.10 works on Gradle 7.2
+https://github.com/elastic/elasticsearch-hadoop/pull/1800[#1800]
+
+- Update Gradle wrapper to 7.3
+https://github.com/elastic/elasticsearch-hadoop/pull/1809[#1809]
+
+- Get rid of direct cross-project dependencies to avoid gradle warnings
+https://github.com/elastic/elasticsearch-hadoop/pull/1868[#1868]
+
+Spark::
+- Add support for Spark 3.1 and 3.2 
+https://github.com/elastic/elasticsearch-hadoop/pull/1807[#1807]
+
+
+[[bug-8.0.0]]
+[float]
+=== Bug fixes
+
+Core::
+- Fix support for empty and null arrays
+https://github.com/elastic/elasticsearch-hadoop/pull/1827[#1827]

--- a/docs/src/reference/asciidoc/appendix/release-notes/8.0.0.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/8.0.0.adoc
@@ -1,6 +1,8 @@
 [[eshadoop-8.0.0]]
 == Elasticsearch for Apache Hadoop version 8.0.0
 
+coming::[8.0.0]
+
 The following list are changes in 8.0.0 as compared to 7.17.0, and combines
 release notes from the 8.0.0-alpha1, -alpha2, -beta1, -rc1 and -rc2 releases.
 

--- a/docs/src/reference/asciidoc/appendix/release.adoc
+++ b/docs/src/reference/asciidoc/appendix/release.adoc
@@ -9,6 +9,7 @@ This section summarizes the changes in each release.
 [[release-notes-8]]
 ===== 8.x
 
+* <<eshadoop-8.0.0>>
 * <<eshadoop-8.0.0-rc2>>
 * <<eshadoop-8.0.0-rc1>>
 * <<eshadoop-8.0.0-beta1>>
@@ -53,6 +54,7 @@ http://github.com/elastic/elasticsearch-hadoop/issues/XXX[#XXX]
 
 ////////////////////////
 
+include::release-notes/8.0.0.adoc[]
 include::release-notes/8.0.0-rc2.adoc[]
 include::release-notes/8.0.0-rc1.adoc[]
 include::release-notes/8.0.0-beta1.adoc[]


### PR DESCRIPTION
Backports the following commits to 8.1:
 - [DOCS] Add 8.0.0 GA release notes (#1902)