### PR TITLE
Fixing testDotsInFieldNames

### DIFF
--- a/spark/sql-30/src/itest/scala/org/elasticsearch/spark/integration/AbstractScalaEsSparkSQL.scala
+++ b/spark/sql-30/src/itest/scala/org/elasticsearch/spark/integration/AbstractScalaEsSparkSQL.scala
@@ -2552,6 +2552,7 @@ class AbstractScalaEsScalaSparkSQL(prefix: String, readMetadata: jl.Boolean, pus
     val (target, docPath) = makeTargets(index, typed)
     RestUtils.postData(docPath, "{\"b\":0,\"e\":{\"f.g\":\"hello\"}}".getBytes("UTF-8"))
     val df = sqc.read.format("es").load(index)
+    RestUtils.refresh(index)
     df.count()
   }
 


### PR DESCRIPTION
Calling refresh() in an integration test so that it consistently succeeds.
Relates #1900