### PR TITLE
Getting rid of gradle warnings

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/IntegrationBuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/IntegrationBuildPlugin.groovy
@@ -73,6 +73,7 @@ class IntegrationBuildPlugin implements Plugin<Project> {
             // Configure root javadoc process to compile and consume this project's javadocs
             Javadoc rootJavadoc = project.rootProject.getTasks().getByName("javadoc") as Javadoc
             Javadoc subJavadoc = project.getTasks().getByName('javadoc') as Javadoc
+            rootJavadoc.dependsOn(subJavadoc)
             rootJavadoc.source += subJavadoc.source
             rootJavadoc.classpath += project.files(project.sourceSets.main.compileClasspath)
         }


### PR DESCRIPTION
This commit adds a dependency between the top-level javadoc task and the sub-level javadoc tasks so that we don't get
gradle 8 warnings.