### PR TITLE
[master] [DOCS] Remove 8.0.0 coming tag (#1907)

### DIFF
--- a/docs/src/reference/asciidoc/appendix/breaking.adoc
+++ b/docs/src/reference/asciidoc/appendix/breaking.adoc
@@ -2,11 +2,6 @@
 [[breaking-changes]]
 = Breaking Changes
 
-Generally, we strive to maintain backwards compatibility between minor
-versions (e.g. 5.x to 5.7) so that upgrades can be done without any code
-or configuration changes, but breaking changes do manifest between major
-versions (e.g. 5.x to 6.y).
-
 For clarity, we always list any breaking changes at the top of the
 <<release-notes,release notes>> for each version.
 

--- a/docs/src/reference/asciidoc/appendix/release-notes/8.0.0.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/8.0.0.adoc
@@ -1,8 +1,6 @@
 [[eshadoop-8.0.0]]
 == Elasticsearch for Apache Hadoop version 8.0.0
 
-coming::[8.0.0]
-
 The following list are changes in 8.0.0 as compared to 7.17.0, and combines
 release notes from the 8.0.0-alpha1, -alpha2, -beta1, -rc1 and -rc2 releases.
 


### PR DESCRIPTION
Backports the following commits to master:
 - [DOCS] Remove 8.0.0 coming tag (#1907)