### PR TITLE
[8.1] [DOCS] Add 8.0.1 release notes (#1910)

### DIFF
--- a/docs/src/reference/asciidoc/appendix/release-notes/8.0.1.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/8.0.1.adoc
@@ -1,0 +1,7 @@
+[[eshadoop-8.0.1]]
+== Elasticsearch for Apache Hadoop version 8.0.1
+
+coming::[8.0.1]
+
+ES-Hadoop 8.0.1 is a version compatibility release, tested specifically against
+Elasticsearch 8.0.1.

--- a/docs/src/reference/asciidoc/appendix/release.adoc
+++ b/docs/src/reference/asciidoc/appendix/release.adoc
@@ -9,6 +9,7 @@ This section summarizes the changes in each release.
 [[release-notes-8]]
 ===== 8.x
 
+* <<eshadoop-8.0.1>>
 * <<eshadoop-8.0.0>>
 * <<eshadoop-8.0.0-rc2>>
 * <<eshadoop-8.0.0-rc1>>
@@ -54,6 +55,7 @@ http://github.com/elastic/elasticsearch-hadoop/issues/XXX[#XXX]
 
 ////////////////////////
 
+include::release-notes/8.0.1.adoc[]
 include::release-notes/8.0.0.adoc[]
 include::release-notes/8.0.0-rc2.adoc[]
 include::release-notes/8.0.0-rc1.adoc[]


### PR DESCRIPTION
Backports the following commits to 8.1:
 - [DOCS] Add 8.0.1 release notes (#1910)