### PR TITLE
[8.1] [DOCS] Remove 8.0.1 coming tag (#1914)

### DIFF
--- a/docs/src/reference/asciidoc/appendix/release-notes/8.0.1.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/8.0.1.adoc
@@ -1,7 +1,5 @@
 [[eshadoop-8.0.1]]
 == Elasticsearch for Apache Hadoop version 8.0.1
 
-coming::[8.0.1]
-
 ES-Hadoop 8.0.1 is a version compatibility release, tested specifically against
 Elasticsearch 8.0.1.


### PR DESCRIPTION
Backports the following commits to 8.1:
 - [DOCS] Remove 8.0.1 coming tag (#1914)