### PR TITLE
Adding an explicit dependency on jar to setupUsers

### DIFF
--- a/qa/kerberos/build.gradle
+++ b/qa/kerberos/build.gradle
@@ -281,7 +281,7 @@ if (disableTests) {
             }
         }
     }
-    setupUsers.dependsOn(kdcFixture)
+    setupUsers.dependsOn(kdcFixture, jar)
     integrationTest.dependsOn(setupUsers)
     
     // =============================================================================


### PR DESCRIPTION
It looks like `:qa:kerberos:setupUsers` fails on a clean installation because it has an implicit dependency on the :qa:kerberos code having been built. This commit adds an explicit dependency. I happened to stumble on this while tracking down other problems, but I don't think it impacts any of our normal builds.