### PR TITLE
[master] [DOCS] Remove 8.1.0 coming tag (#1916)

### DIFF
--- a/docs/src/reference/asciidoc/appendix/release-notes/8.1.0.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/8.1.0.adoc
@@ -1,8 +1,6 @@
 [[eshadoop-8.1.0]]
 == Elasticsearch for Apache Hadoop version 8.1.0
 
-coming::[8.1.0]
-
 [[new-8.1.0]]
 [float]
 === Enhancements


### PR DESCRIPTION
Backports the following commits to master:
 - [DOCS] Remove 8.1.0 coming tag (#1916)