### PR TITLE
Set UserProvider before discovery in Spark SQL integrations

### DIFF
--- a/qa/kerberos/build.gradle
+++ b/qa/kerberos/build.gradle
@@ -521,7 +521,7 @@ if (disableTests) {
     // =============================================================================
     // Spark Jobs
     // =============================================================================
-    
+
     // Run the Spark job to load data to ES. Ensure Kerberos settings are available.
     SparkApp sparkLoadData = config.createClusterTask('sparkLoadData', SparkApp.class) {
         clusterConfiguration = config
@@ -682,7 +682,9 @@ if (disableTests) {
     
     Map<String, Task> readJobs = [
             'mr': mrReadData,
-            'spark': sparkReadData,
+            'sparkRDD': sparkReadData,
+            'sparkDF': sparkReadData,
+            'sparkDS': sparkReadData,
             'hive': hiveReadData,
             'pig': pigReadData
     ]

--- a/qa/kerberos/src/itest/java/org/elasticsearch/hadoop/qa/kerberos/AbstractClusterVerificationTests.java
+++ b/qa/kerberos/src/itest/java/org/elasticsearch/hadoop/qa/kerberos/AbstractClusterVerificationTests.java
@@ -40,7 +40,9 @@ public class AbstractClusterVerificationTests {
     public static Collection<Object[]> params() {
         List<Object[]> params = new ArrayList<>();
         params.add(new Object[]{"mr",        "part-m-", 345, true});
-        params.add(new Object[]{"spark",     "part-",   345, true});
+        params.add(new Object[]{"sparkRDD",  "part-",   345, true});
+        params.add(new Object[]{"sparkDF",   "part-",   345, true});
+        params.add(new Object[]{"sparkDS",   "part-",   345, true});
         params.add(new Object[]{"hive",      "000000_0",     345, false});
         params.add(new Object[]{"pig",       "part-m-", 345, true});
         return params;

--- a/spark/sql-13/src/main/scala/org/elasticsearch/spark/sql/DefaultSource.scala
+++ b/spark/sql-13/src/main/scala/org/elasticsearch/spark/sql/DefaultSource.scala
@@ -151,6 +151,7 @@ private[sql] case class ElasticsearchRelation(parameters: Map[String, String], @
 
   @transient private[sql] lazy val cfg = {
     val conf = new SparkSettingsManager().load(sqlContext.sparkContext.getConf).merge(parameters.asJava)
+    InitializationUtils.setUserProviderIfNotSet(conf, classOf[HadoopUserProvider], LogFactory.getLog(classOf[ElasticsearchRelation]))
     InitializationUtils.discoverClusterInfo(conf, LogFactory.getLog(classOf[ElasticsearchRelation]))
     conf
   }
@@ -533,10 +534,10 @@ private[sql] case class ElasticsearchRelation(parameters: Map[String, String], @
 
       // perform a scan-scroll delete
       val cfgCopy = cfg.copy()
+      InitializationUtils.setUserProviderIfNotSet(cfgCopy, classOf[HadoopUserProvider], null)
       InitializationUtils.discoverClusterInfo(cfgCopy, Utils.LOGGER)
       InitializationUtils.setValueWriterIfNotSet(cfgCopy, classOf[JdkValueWriter], null)
       InitializationUtils.setFieldExtractorIfNotSet(cfgCopy, classOf[ConstantFieldExtractor], null) //throw away extractor
-      InitializationUtils.setUserProviderIfNotSet(cfgCopy, classOf[HadoopUserProvider], null)
       cfgCopy.setProperty(ConfigurationOptions.ES_BATCH_FLUSH_MANUAL, "false")
       cfgCopy.setProperty(ConfigurationOptions.ES_BATCH_SIZE_ENTRIES, "1000")
       cfgCopy.setProperty(ConfigurationOptions.ES_BATCH_SIZE_BYTES, "1mb")

--- a/spark/sql-13/src/main/scala/org/elasticsearch/spark/sql/EsSparkSQL.scala
+++ b/spark/sql-13/src/main/scala/org/elasticsearch/spark/sql/EsSparkSQL.scala
@@ -30,6 +30,7 @@ import org.elasticsearch.hadoop.cfg.ConfigurationOptions.ES_QUERY
 import org.elasticsearch.hadoop.cfg.ConfigurationOptions.ES_RESOURCE_READ
 import org.elasticsearch.hadoop.cfg.ConfigurationOptions.ES_RESOURCE_WRITE
 import org.elasticsearch.hadoop.cfg.PropertiesSettings
+import org.elasticsearch.hadoop.mr.security.HadoopUserProvider
 import org.elasticsearch.hadoop.util.ObjectUtils
 import org.elasticsearch.spark.cfg.SparkSettingsManager
 import org.elasticsearch.hadoop.rest.InitializationUtils
@@ -74,6 +75,7 @@ object EsSparkSQL {
       esCfg.merge(cfg.asJava)
 
       // Need to discover es version before checking index existence
+      InitializationUtils.setUserProviderIfNotSet(esCfg, classOf[HadoopUserProvider], LOG)
       InitializationUtils.discoverClusterInfo(esCfg, LOG)
       InitializationUtils.checkIdForOperation(esCfg)
       InitializationUtils.checkIndexExistence(esCfg)

--- a/spark/sql-20/src/main/scala/org/elasticsearch/spark/sql/DefaultSource.scala
+++ b/spark/sql-20/src/main/scala/org/elasticsearch/spark/sql/DefaultSource.scala
@@ -149,6 +149,7 @@ private[sql] class DefaultSource extends RelationProvider with SchemaRelationPro
         s"Cannot continue with [$outputMode].")
     }
 
+    InitializationUtils.setUserProviderIfNotSet(jobSettings, classOf[HadoopUserProvider], LogFactory.getLog(classOf[DefaultSource]))
     InitializationUtils.discoverClusterInfo(jobSettings, LogFactory.getLog(classOf[DefaultSource]))
     InitializationUtils.checkIdForOperation(jobSettings)
     InitializationUtils.checkIndexExistence(jobSettings)
@@ -229,6 +230,7 @@ private[sql] case class ElasticsearchRelation(parameters: Map[String, String], @
 
   @transient lazy val cfg = {
     val conf = new SparkSettingsManager().load(sqlContext.sparkContext.getConf).merge(parameters.asJava)
+    InitializationUtils.setUserProviderIfNotSet(conf, classOf[HadoopUserProvider], LogFactory.getLog(classOf[ElasticsearchRelation]))
     InitializationUtils.discoverClusterInfo(conf, LogFactory.getLog(classOf[ElasticsearchRelation]))
     conf
   }
@@ -611,10 +613,10 @@ private[sql] case class ElasticsearchRelation(parameters: Map[String, String], @
 
       // perform a scan-scroll delete
       val cfgCopy = cfg.copy()
+      InitializationUtils.setUserProviderIfNotSet(cfgCopy, classOf[HadoopUserProvider], null)
       InitializationUtils.discoverClusterInfo(cfgCopy, Utils.LOGGER)
       InitializationUtils.setValueWriterIfNotSet(cfgCopy, classOf[JdkValueWriter], null)
       InitializationUtils.setFieldExtractorIfNotSet(cfgCopy, classOf[ConstantFieldExtractor], null) //throw away extractor
-      InitializationUtils.setUserProviderIfNotSet(cfgCopy, classOf[HadoopUserProvider], null)
       cfgCopy.setProperty(ConfigurationOptions.ES_BATCH_FLUSH_MANUAL, "false")
       cfgCopy.setProperty(ConfigurationOptions.ES_BATCH_SIZE_ENTRIES, "1000")
       cfgCopy.setProperty(ConfigurationOptions.ES_BATCH_SIZE_BYTES, "1mb")

--- a/spark/sql-20/src/main/scala/org/elasticsearch/spark/sql/EsSparkSQL.scala
+++ b/spark/sql-20/src/main/scala/org/elasticsearch/spark/sql/EsSparkSQL.scala
@@ -28,6 +28,7 @@ import org.elasticsearch.hadoop.cfg.ConfigurationOptions.ES_QUERY
 import org.elasticsearch.hadoop.cfg.ConfigurationOptions.ES_RESOURCE_READ
 import org.elasticsearch.hadoop.cfg.ConfigurationOptions.ES_RESOURCE_WRITE
 import org.elasticsearch.hadoop.cfg.PropertiesSettings
+import org.elasticsearch.hadoop.mr.security.HadoopUserProvider
 import org.elasticsearch.hadoop.rest.InitializationUtils
 import org.elasticsearch.hadoop.util.ObjectUtils
 import org.elasticsearch.spark.cfg.SparkSettingsManager
@@ -94,6 +95,7 @@ object EsSparkSQL {
       esCfg.merge(cfg.asJava)
 
       // Need to discover ES Version before checking index existence
+      InitializationUtils.setUserProviderIfNotSet(esCfg, classOf[HadoopUserProvider], LOG)
       InitializationUtils.discoverClusterInfo(esCfg, LOG)
       InitializationUtils.checkIdForOperation(esCfg)
       InitializationUtils.checkIndexExistence(esCfg)

--- a/spark/sql-30/src/main/scala/org/elasticsearch/spark/sql/DefaultSource.scala
+++ b/spark/sql-30/src/main/scala/org/elasticsearch/spark/sql/DefaultSource.scala
@@ -149,6 +149,7 @@ private[sql] class DefaultSource extends RelationProvider with SchemaRelationPro
         s"Cannot continue with [$outputMode].")
     }
 
+    InitializationUtils.setUserProviderIfNotSet(jobSettings, classOf[HadoopUserProvider], LogFactory.getLog(classOf[DefaultSource]))
     InitializationUtils.discoverClusterInfo(jobSettings, LogFactory.getLog(classOf[DefaultSource]))
     InitializationUtils.checkIdForOperation(jobSettings)
     InitializationUtils.checkIndexExistence(jobSettings)
@@ -229,6 +230,7 @@ private[sql] case class ElasticsearchRelation(parameters: Map[String, String], @
 
   @transient lazy val cfg = {
     val conf = new SparkSettingsManager().load(sqlContext.sparkContext.getConf).merge(parameters.asJava)
+    InitializationUtils.setUserProviderIfNotSet(conf, classOf[HadoopUserProvider], LogFactory.getLog(classOf[ElasticsearchRelation]))
     InitializationUtils.discoverClusterInfo(conf, LogFactory.getLog(classOf[ElasticsearchRelation]))
     conf
   }
@@ -611,10 +613,10 @@ private[sql] case class ElasticsearchRelation(parameters: Map[String, String], @
 
       // perform a scan-scroll delete
       val cfgCopy = cfg.copy()
+      InitializationUtils.setUserProviderIfNotSet(cfgCopy, classOf[HadoopUserProvider], null)
       InitializationUtils.discoverClusterInfo(cfgCopy, Utils.LOGGER)
       InitializationUtils.setValueWriterIfNotSet(cfgCopy, classOf[JdkValueWriter], null)
       InitializationUtils.setFieldExtractorIfNotSet(cfgCopy, classOf[ConstantFieldExtractor], null) //throw away extractor
-      InitializationUtils.setUserProviderIfNotSet(cfgCopy, classOf[HadoopUserProvider], null)
       cfgCopy.setProperty(ConfigurationOptions.ES_BATCH_FLUSH_MANUAL, "false")
       cfgCopy.setProperty(ConfigurationOptions.ES_BATCH_SIZE_ENTRIES, "1000")
       cfgCopy.setProperty(ConfigurationOptions.ES_BATCH_SIZE_BYTES, "1mb")

--- a/spark/sql-30/src/main/scala/org/elasticsearch/spark/sql/EsSparkSQL.scala
+++ b/spark/sql-30/src/main/scala/org/elasticsearch/spark/sql/EsSparkSQL.scala
@@ -28,6 +28,7 @@ import org.elasticsearch.hadoop.cfg.ConfigurationOptions.ES_QUERY
 import org.elasticsearch.hadoop.cfg.ConfigurationOptions.ES_RESOURCE_READ
 import org.elasticsearch.hadoop.cfg.ConfigurationOptions.ES_RESOURCE_WRITE
 import org.elasticsearch.hadoop.cfg.PropertiesSettings
+import org.elasticsearch.hadoop.mr.security.HadoopUserProvider
 import org.elasticsearch.hadoop.rest.InitializationUtils
 import org.elasticsearch.hadoop.util.ObjectUtils
 import org.elasticsearch.spark.cfg.SparkSettingsManager
@@ -94,6 +95,7 @@ object EsSparkSQL {
       esCfg.merge(cfg.asJava)
 
       // Need to discover ES Version before checking index existence
+      InitializationUtils.setUserProviderIfNotSet(esCfg, classOf[HadoopUserProvider], LOG)
       InitializationUtils.discoverClusterInfo(esCfg, LOG)
       InitializationUtils.checkIdForOperation(esCfg)
       InitializationUtils.checkIndexExistence(esCfg)


### PR DESCRIPTION
This PR adds the requisite configuration step for the UserProvider implementation before attempting to discover the cluster information in the SparkSQL integrations. This additionally updates the integration tests to add coverage for the write and read paths for SparkSQL.

Fixes #1933 