### PR TITLE
[7.17][DOCS] Removes coming tag from release notes

### DIFF
--- a/docs/src/reference/asciidoc/appendix/release-notes/7.17.2.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/7.17.2.adoc
@@ -1,8 +1,6 @@
 [[eshadoop-7.17.2]]
 == Elasticsearch for Apache Hadoop version 7.17.2
 
-coming::[7.17.2]
-
 [[bugs-7.17.2]]
 === Bug Fixes
 


### PR DESCRIPTION
## Overview

This PR removes the `coming` tag from the 7.17.2 release notes page.