### PR TITLE
[8.1] [DOCS] Add 8.1.1 release notes (#1938)

### DIFF
--- a/docs/src/reference/asciidoc/appendix/release-notes/8.1.2.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/8.1.2.adoc
@@ -1,0 +1,5 @@
+[[eshadoop-8.1.2]]
+== Elasticsearch for Apache Hadoop version 8.1.2
+
+ES-Hadoop 8.1.2 is a version compatibility release, tested specifically against
+Elasticsearch 8.1.2.

--- a/docs/src/reference/asciidoc/appendix/release.adoc
+++ b/docs/src/reference/asciidoc/appendix/release.adoc
@@ -9,6 +9,7 @@ This section summarizes the changes in each release.
 [[release-notes-8]]
 ===== 8.x
 
+* <<eshadoop-8.1.2>>
 * <<eshadoop-8.1.1>>
 * <<eshadoop-8.1.0>>
 * <<eshadoop-8.0.1>>
@@ -57,6 +58,7 @@ http://github.com/elastic/elasticsearch-hadoop/issues/XXX[#XXX]
 
 ////////////////////////
 
+include::release-notes/8.1.2.adoc[]
 include::release-notes/8.1.1.adoc[]
 include::release-notes/8.1.0.adoc[]
 include::release-notes/8.0.1.adoc[]


### PR DESCRIPTION
Backports the following commits to 8.1:
 - [DOCS] Add 8.1.1 release notes (#1938)