### PR TITLE
Updating the Hadoop fixture version to 3.3.2

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/fixture/hadoop/services/HadoopServiceDescriptor.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/fixture/hadoop/services/HadoopServiceDescriptor.groovy
@@ -62,7 +62,7 @@ class HadoopServiceDescriptor implements ServiceDescriptor {
 
     @Override
     Version defaultVersion() {
-        return new Version(3, 3, 0)
+        return new Version(3, 3, 2)
     }
 
     @Override


### PR DESCRIPTION
It looks like 3.3.0 is no longer available for download at https://dlcdn.apache.org/hadoop/common/, so updating to the latest.