### PR TITLE
Fixing DST bug in data_nanos support (#1943)

### DIFF
--- a/mr/src/main/java/org/elasticsearch/hadoop/serialization/builder/JdkValueWriter.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/serialization/builder/JdkValueWriter.java
@@ -23,8 +23,9 @@ import org.elasticsearch.hadoop.util.ObjectUtils;
 
 import javax.xml.bind.DatatypeConverter;
 import java.sql.Timestamp;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.time.OffsetDateTime;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.Calendar;
 import java.util.Date;
@@ -131,8 +132,9 @@ public class JdkValueWriter extends FilteringValueWriter<Object> {
         }
         else if (value instanceof Timestamp) {
             Timestamp timestamp = (Timestamp) value;
-            LocalDateTime localDateTime = timestamp.toLocalDateTime();
-            OffsetDateTime offsetDateTime = OffsetDateTime.of(localDateTime, OffsetDateTime.now().getOffset());
+            long epochSeconds = timestamp.getTime() / 1000; // Getting rid of millisconds because they're captured in timestamp.getNanos()
+            Instant instant = Instant.ofEpochSecond(epochSeconds, timestamp.getNanos());
+            OffsetDateTime offsetDateTime = OffsetDateTime.ofInstant(instant, ZoneId.systemDefault());
             generator.writeString(DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(offsetDateTime));
         }
         else if (value instanceof Date) {


### PR DESCRIPTION
In #1803 we added support for the data_nanos Elasticsearch field type. However there is a bug in that sets the zone offset to the offset right now, as opposed to what the zone offset was at the time of the date. So for example if the date was 2015-01-01T06:10:30.123456789-06:00, then if you read that date after daylight saving had begun you would see it as 2015-01-01T06:10:30.123456789-05:00.