### PR TITLE
[DOCS] Add missing 8.1.2 and 8.1.3 release notes in 8.2

### DIFF
--- a/docs/src/reference/asciidoc/appendix/release-notes/8.1.2.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/8.1.2.adoc
@@ -1,0 +1,5 @@
+[[eshadoop-8.1.2]]
+== Elasticsearch for Apache Hadoop version 8.1.2
+
+ES-Hadoop 8.1.2 is a version compatibility release, tested specifically against
+Elasticsearch 8.1.2.

--- a/docs/src/reference/asciidoc/appendix/release-notes/8.1.3.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/8.1.3.adoc
@@ -1,0 +1,8 @@
+[[eshadoop-8.1.3]]
+== Elasticsearch for Apache Hadoop version 8.1.3
+
+[[bugs-8.1.3]]
+=== Bug Fixes
+Spark::
+* Set UserProvider before discovery in Spark SQL integrations
+https://github.com/elastic/elasticsearch-hadoop/pull/1934[#1934]

--- a/docs/src/reference/asciidoc/appendix/release.adoc
+++ b/docs/src/reference/asciidoc/appendix/release.adoc
@@ -9,6 +9,7 @@ This section summarizes the changes in each release.
 [[release-notes-8]]
 ===== 8.x
 
+* <<eshadoop-8.1.3>>
 * <<eshadoop-8.1.2>>
 * <<eshadoop-8.1.1>>
 * <<eshadoop-8.1.0>>
@@ -58,6 +59,7 @@ http://github.com/elastic/elasticsearch-hadoop/issues/XXX[#XXX]
 
 ////////////////////////
 
+include::release-notes/8.1.3.adoc[]
 include::release-notes/8.1.2.adoc[]
 include::release-notes/8.1.1.adoc[]
 include::release-notes/8.1.0.adoc[]

--- a/docs/src/reference/asciidoc/appendix/release.adoc
+++ b/docs/src/reference/asciidoc/appendix/release.adoc
@@ -9,6 +9,7 @@ This section summarizes the changes in each release.
 [[release-notes-8]]
 ===== 8.x
 
+* <<eshadoop-8.1.2>>
 * <<eshadoop-8.1.1>>
 * <<eshadoop-8.1.0>>
 * <<eshadoop-8.0.1>>
@@ -57,6 +58,7 @@ http://github.com/elastic/elasticsearch-hadoop/issues/XXX[#XXX]
 
 ////////////////////////
 
+include::release-notes/8.1.2.adoc[]
 include::release-notes/8.1.1.adoc[]
 include::release-notes/8.1.0.adoc[]
 include::release-notes/8.0.1.adoc[]


### PR DESCRIPTION
Forward-fits https://github.com/elastic/elasticsearch-hadoop/pull/1938 and https://github.com/elastic/elasticsearch-hadoop/pull/1951