### PR TITLE
[8.2][DOCS] Add 8.2.0 release notes (#1956)

### DIFF
--- a/docs/src/reference/asciidoc/appendix/release-notes/8.2.0.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/8.2.0.adoc
@@ -1,0 +1,23 @@
+[[eshadoop-8.2.0]]
+== Elasticsearch for Apache Hadoop version 8.2.0
+
+[[new-8.2.0]]
+=== New Features
+Spark::
+* Bumping spark build version to 3.2.1
+http://github.com/elastic/elasticsearch-hadoop/pull/1923[#1923]
+
+[[enhancements-8.2.0]]
+=== Enhancements
+Core::
+* Updating IOUtils.toCanonicalFilePath to work in a spring boot application
+http://github.com/elastic/elasticsearch-hadoop/pull/1899[#1899]
+
+[[bugs-8.2.0]]
+=== Bug Fixes
+Serialization::
+* Fixing DST bug in data_nanos support
+http://github.com/elastic/elasticsearch-hadoop/pull/1943[#1943]
+Storm::
+* Do not fail if flush is called before any writes
+http://github.com/elastic/elasticsearch-hadoop/pull/1901[#1901]

--- a/docs/src/reference/asciidoc/appendix/release.adoc
+++ b/docs/src/reference/asciidoc/appendix/release.adoc
@@ -9,6 +9,7 @@ This section summarizes the changes in each release.
 [[release-notes-8]]
 ===== 8.x
 
+* <<eshadoop-8.2.0>>
 * <<eshadoop-8.1.3>>
 * <<eshadoop-8.1.2>>
 * <<eshadoop-8.1.1>>
@@ -59,6 +60,7 @@ http://github.com/elastic/elasticsearch-hadoop/issues/XXX[#XXX]
 
 ////////////////////////
 
+include::release-notes/8.2.0.adoc[]
 include::release-notes/8.1.3.adoc[]
 include::release-notes/8.1.2.adoc[]
 include::release-notes/8.1.1.adoc[]


### PR DESCRIPTION
Backports https://github.com/elastic/elasticsearch-hadoop/pull/1956