### PR TITLE
Upgrade to Gradle 7.5

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/fixture/hadoop/services/SparkYarnServiceDescriptor.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/fixture/hadoop/services/SparkYarnServiceDescriptor.groovy
@@ -56,7 +56,7 @@ class SparkYarnServiceDescriptor implements ServiceDescriptor {
 
     @Override
     Version defaultVersion() {
-        return new Version(3, 2, 1)
+        return new Version(3, 2, 2)
     }
 
     String hadoopVersionCompatibility() {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/hive/src/itest/java/org/elasticsearch/hadoop/integration/hive/HiveEmbeddedServer2.java
+++ b/hive/src/itest/java/org/elasticsearch/hadoop/integration/hive/HiveEmbeddedServer2.java
@@ -89,6 +89,7 @@ class HiveEmbeddedServer2 implements HiveInstance {
                 hiveServer = new HiveServer2();
                 port = MetaStoreUtils.findFreePort();
                 config.setIntVar(ConfVars.HIVE_SERVER2_THRIFT_PORT, port);
+                config.setIntVar(ConfVars.HIVE_SERVER2_WEBUI_PORT, 0); // Disable web UI
                 hiveServer.init(config);
                 hiveServer.start();
                 waitForStartup();

--- a/mr/build.gradle
+++ b/mr/build.gradle
@@ -131,6 +131,7 @@ itestJar {
 
 tasks.named("test").configure {
     jvmArgs "--add-opens=java.base/java.io=ALL-UNNAMED" // Needed for IOUtils's BYTE_ARRAY_BUFFER reflection
+    jvmArgs "--add-opens=java.base/java.lang=ALL-UNNAMED" // Needed for secure mock
 }
 
 eclipse.classpath.file {

--- a/spark/core/build.gradle
+++ b/spark/core/build.gradle
@@ -150,6 +150,7 @@ if (JavaVersion.current() >= JavaVersion.VERSION_17) {
             task.configure {
                 jvmArgs "--add-opens=java.base/java.io=ALL-UNNAMED" // Needed for IOUtils's BYTE_ARRAY_BUFFER reflection
                 jvmArgs "--add-opens=java.base/java.nio=ALL-UNNAMED" // Needed for org.apache.spark.SparkConf, which indirectly uses java.nio.DirectByteBuffer
+                jvmArgs "--add-opens=java.base/java.lang=ALL-UNNAMED" // Needed for secure mock
             }
     }
 }

--- a/spark/sql-20/build.gradle
+++ b/spark/sql-20/build.gradle
@@ -200,6 +200,7 @@ if (JavaVersion.current() >= JavaVersion.VERSION_16) {
         if (task.getName().startsWith("test"))
         task.configure {
             jvmArgs "--add-opens=java.base/java.io=ALL-UNNAMED" // Needed for IOUtils's BYTE_ARRAY_BUFFER reflection
+            jvmArgs "--add-opens=java.base/java.lang=ALL-UNNAMED" // Needed for secure mock
         }}
 }
 

--- a/spark/sql-30/build.gradle
+++ b/spark/sql-30/build.gradle
@@ -172,6 +172,7 @@ if (JavaVersion.current() >= JavaVersion.VERSION_16) {
         task.configure {
             jvmArgs "--add-opens=java.base/java.io=ALL-UNNAMED" // Needed for IOUtils's BYTE_ARRAY_BUFFER reflection
             jvmArgs "--add-opens=java.base/java.nio=ALL-UNNAMED" // Needed for org.apache.spark.SparkConf, which indirectly uses java.nio.DirectByteBuffer
+            jvmArgs "--add-opens=java.base/java.lang=ALL-UNNAMED" // Needed for secure mock
         }}
 }
 


### PR DESCRIPTION
The ES project recently upgraded Gradle and now some build code from ES depends on new methods.

Additionally, the Spark version in QA has disappeared and a new version of Spark needs to be added for testing.