### PR TITLE
Upgrading to gradle 7.5.1

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
It looks like this commit https://github.com/elastic/elasticsearch/pull/88595/files#diff-b02217a5b8647aa4eda31838ce5ff2fb75a8e7056932ccb62220313defdb9e95R93 in https://github.com/elastic/elasticsearch/pull/88595 caused the 7.17 es-hadoop build to fail because it's using a method that's not in gradle 7.3. Here's the stack trace we were seeing in `./gradlew build integrationTest --stacktrace`:
```
2022-08-15T16:13:53.280-0500 [ERROR] [org.gradle.internal.buildevents.BuildExceptionReporter] java.lang.NoSuchMethodError: 'org.gradle.internal.resources.ResourceLock org.gradle.internal.resources.SharedResource.getResourceLock()'
2022-08-15T16:13:53.280-0500 [ERROR] [org.gradle.internal.buildevents.BuildExceptionReporter]   at org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask.getSharedResources(StandaloneRestIntegTestTask.java:94)
2022-08-15T16:13:53.280-0500 [ERROR] [org.gradle.internal.buildevents.BuildExceptionReporter]   at org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask_Decorated.getSharedResources(Unknown Source)
2022-08-15T16:13:53.280-0500 [ERROR] [org.gradle.internal.buildevents.BuildExceptionReporter]   at org.gradle.execution.plan.LocalTaskNode.getResourcesToLock(LocalTaskNode.java:88)
2022-08-15T16:13:53.280-0500 [ERROR] [org.gradle.internal.buildevents.BuildExceptionReporter]   at org.gradle.execution.plan.DefaultExecutionPlan.tryLockSharedResourceFor(DefaultExecutionPlan.java:655)
2022-08-15T16:13:53.280-0500 [ERROR] [org.gradle.internal.buildevents.BuildExceptionReporter]   at org.gradle.execution.plan.DefaultExecutionPlan.tryAcquireLocksForNode(DefaultExecutionPlan.java:611)
2022-08-15T16:13:53.281-0500 [ERROR] [org.gradle.internal.buildevents.BuildExceptionReporter]   at org.gradle.execution.plan.DefaultExecutionPlan.selectNext(DefaultExecutionPlan.java:579)
2022-08-15T16:13:53.281-0500 [ERROR] [org.gradle.internal.buildevents.BuildExceptionReporter]   at org.gradle.execution.plan.DefaultPlanExecutor$ExecutorWorker.lambda$executeNextNode$1(DefaultPlanExecutor.java:166)
2022-08-15T16:13:53.281-0500 [ERROR] [org.gradle.internal.buildevents.BuildExceptionReporter]   at org.gradle.internal.resources.DefaultResourceLockCoordinationService.withStateLock(DefaultResourceLockCoordinationService.java:45)
2022-08-15T16:13:53.281-0500 [ERROR] [org.gradle.internal.buildevents.BuildExceptionReporter]   at org.gradle.execution.plan.DefaultPlanExecutor$ExecutorWorker.executeNextNode(DefaultPlanExecutor.java:155)
2022-08-15T16:13:53.281-0500 [ERROR] [org.gradle.internal.buildevents.BuildExceptionReporter]   at org.gradle.execution.plan.DefaultPlanExecutor$ExecutorWorker.run(DefaultPlanExecutor.java:124)
2022-08-15T16:13:53.281-0500 [ERROR] [org.gradle.internal.buildevents.BuildExceptionReporter]   at org.gradle.internal.concurrent.ExecutorPolicy$CatchAndRecordFailures.onExecute(ExecutorPolicy.java:64)
2022-08-15T16:13:53.281-0500 [ERROR] [org.gradle.internal.buildevents.BuildExceptionReporter]   at org.gradle.internal.concurrent.ManagedExecutorImpl$1.run(ManagedExecutorImpl.java:48)
2022-08-15T16:13:53.281-0500 [ERROR] [org.gradle.internal.buildevents.BuildExceptionReporter]   at org.gradle.internal.concurrent.ThreadFactoryImpl$ManagedThreadRunnable.run(ThreadFactoryImpl.java:61)
```
This fixes it by upgrading the es-hadoop build to gradle 7.5.1. We've already done this for the es-hadoop 8.x line.