### PR TITLE
[8.4] [DOCS] Add 8.4.0 release notes (#1989)

### DIFF
--- a/docs/src/reference/asciidoc/appendix/release-notes/8.4.0.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/8.4.0.adoc
@@ -1,0 +1,8 @@
+[[eshadoop-8.4.0]]
+== Elasticsearch for Apache Hadoop version 8.4.0
+
+[[enhancements-8.4.0]]
+=== Enhancements
+Section::
+* Upgrade to Gradle 7.5
+https://github.com/elastic/elasticsearch-hadoop/pull/1980[#1980]

--- a/docs/src/reference/asciidoc/appendix/release.adoc
+++ b/docs/src/reference/asciidoc/appendix/release.adoc
@@ -9,6 +9,7 @@ This section summarizes the changes in each release.
 [[release-notes-8]]
 ===== 8.x
 
+* <<eshadoop-8.4.0>>
 * <<eshadoop-8.3.3>>
 * <<eshadoop-8.3.2>>
 * <<eshadoop-8.3.1>>
@@ -70,6 +71,7 @@ Elasticsearch 5.3.1.
 
 ////////////////////////
 
+include::release-notes/8.4.0.adoc[]
 include::release-notes/8.3.3.adoc[]
 include::release-notes/8.3.2.adoc[]
 include::release-notes/8.3.1.adoc[]


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.4`:
 - [[DOCS] Add 8.4.0 release notes (#1989)](https://github.com/elastic/elasticsearch-hadoop/pull/1989)

<!--- Backport version: 8.4.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)