### PR TITLE
Adding a user-agent header

### DIFF
--- a/mr/src/main/java/org/elasticsearch/hadoop/cfg/ConfigurationOptions.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/cfg/ConfigurationOptions.java
@@ -287,7 +287,7 @@ public interface ConfigurationOptions {
 
     String ES_NET_HTTP_HEADER_PREFIX = "es.net.http.header.";
     String ES_NET_HTTP_HEADER_OPAQUE_ID = ES_NET_HTTP_HEADER_PREFIX + "X-Opaque-ID";
-
+    String ES_NET_HTTP_HEADER_USER_AGENT = ES_NET_HTTP_HEADER_PREFIX + "User-Agent";
     String ES_NET_HTTP_AUTH_USER = "es.net.http.auth.user";
     String ES_NET_HTTP_AUTH_PASS = "es.net.http.auth.pass";
 

--- a/mr/src/main/java/org/elasticsearch/hadoop/cfg/HadoopSettings.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/cfg/HadoopSettings.java
@@ -24,9 +24,11 @@ import java.util.Properties;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.mapreduce.JobContext;
+import org.apache.hadoop.util.VersionInfo;
 import org.elasticsearch.hadoop.mr.HadoopCfgUtils;
 import org.elasticsearch.hadoop.mr.HadoopIOUtils;
 import org.elasticsearch.hadoop.util.Assert;
+import org.elasticsearch.hadoop.util.Version;
 
 public class HadoopSettings extends Settings {
 
@@ -40,6 +42,7 @@ public class HadoopSettings extends Settings {
         String taskAttemptId = cfg.get(JobContext.TASK_ATTEMPT_ID, "");
         String opaqueId = String.format(Locale.ROOT, "[mapreduce] [%s] [%s] [%s]", user, jobName, taskAttemptId);
         setOpaqueId(opaqueId);
+        setUserAgent(String.format(Locale.ROOT, "Elasticsearch-Hadoop/%s mapreduce %s", Version.version(), VersionInfo.getVersion()));
     }
 
     @Override

--- a/mr/src/main/java/org/elasticsearch/hadoop/cfg/HadoopSettings.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/cfg/HadoopSettings.java
@@ -42,7 +42,7 @@ public class HadoopSettings extends Settings {
         String taskAttemptId = cfg.get(JobContext.TASK_ATTEMPT_ID, "");
         String opaqueId = String.format(Locale.ROOT, "[mapreduce] [%s] [%s] [%s]", user, jobName, taskAttemptId);
         setOpaqueId(opaqueId);
-        setUserAgent(String.format(Locale.ROOT, "Elasticsearch-Hadoop/%s mapreduce %s", Version.version(), VersionInfo.getVersion()));
+        setUserAgent(String.format(Locale.ROOT, "elasticsearch-hadoop/%s hadoop/%s", Version.versionNumber(), VersionInfo.getVersion()));
     }
 
     @Override

--- a/mr/src/main/java/org/elasticsearch/hadoop/cfg/Settings.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/cfg/Settings.java
@@ -801,5 +801,10 @@ public abstract class Settings {
     public String getOpaqueId() {
         return getProperty(ES_NET_HTTP_HEADER_OPAQUE_ID);
     }
+
+    public Settings setUserAgent(String userAgent) {
+        setProperty(ES_NET_HTTP_HEADER_USER_AGENT, cleanOpaqueId(userAgent));
+        return this;
+    }
 }
 

--- a/spark/core/src/main/scala/org/elasticsearch/spark/cfg/SparkSettings.java
+++ b/spark/core/src/main/scala/org/elasticsearch/spark/cfg/SparkSettings.java
@@ -25,7 +25,6 @@ import java.util.Properties;
 
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.spark.SparkConf;
-import org.apache.spark.SparkContext;
 import org.elasticsearch.hadoop.cfg.Settings;
 import org.elasticsearch.hadoop.util.Assert;
 import org.elasticsearch.hadoop.util.IOUtils;
@@ -57,7 +56,7 @@ public class SparkSettings extends Settings {
                         Locale.ROOT,
                         "elasticsearch-hadoop/%s spark/%s",
                         Version.versionNumber(),
-                        SparkContext.getOrCreate(cfg).version()
+                        org.apache.spark.package$.MODULE$.SPARK_VERSION()
                 )
         );
     }

--- a/spark/core/src/main/scala/org/elasticsearch/spark/cfg/SparkSettings.java
+++ b/spark/core/src/main/scala/org/elasticsearch/spark/cfg/SparkSettings.java
@@ -55,8 +55,8 @@ public class SparkSettings extends Settings {
         this.setOpaqueId(opaqueId);
         this.setUserAgent(String.format(
                         Locale.ROOT,
-                        "Elasticsearch-Hadoop/%s spark %s",
-                        Version.version(),
+                        "elasticsearch-hadoop/%s spark/%s",
+                        Version.versionNumber(),
                         SparkContext.getOrCreate(cfg).version()
                 )
         );

--- a/spark/core/src/main/scala/org/elasticsearch/spark/cfg/SparkSettings.java
+++ b/spark/core/src/main/scala/org/elasticsearch/spark/cfg/SparkSettings.java
@@ -25,10 +25,12 @@ import java.util.Properties;
 
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.spark.SparkConf;
+import org.apache.spark.SparkContext;
 import org.elasticsearch.hadoop.cfg.Settings;
 import org.elasticsearch.hadoop.util.Assert;
 import org.elasticsearch.hadoop.util.IOUtils;
 
+import org.elasticsearch.hadoop.util.Version;
 import scala.Option;
 import scala.Tuple2;
 
@@ -51,6 +53,13 @@ public class SparkSettings extends Settings {
         String appId = cfg.get("spark.app.id", "");
         String opaqueId = String.format(Locale.ROOT, "[spark] [%s] [%s] [%s]", user, appName, appId);
         this.setOpaqueId(opaqueId);
+        this.setUserAgent(String.format(
+                        Locale.ROOT,
+                        "Elasticsearch-Hadoop/%s spark %s",
+                        Version.version(),
+                        SparkContext.getOrCreate(cfg).version()
+                )
+        );
     }
 
     @Override


### PR DESCRIPTION
Adding a simple user agent that contains just es-hadoop version information and hadoop or spark version information. For example:
```
elasticsearch-hadoop/8.5.0-SNAPSHOT spark/1.6.2
```