### PR TITLE
Ignoring missing indices if es.index.read.missing.as.empty is true

### DIFF
--- a/mr/src/main/java/org/elasticsearch/hadoop/rest/RestClient.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/rest/RestClient.java
@@ -314,7 +314,7 @@ public class RestClient implements Closeable, StatsAware {
         if (indexResource.isTyped()) {
             return getMappings(indexResource.index() + "/_mapping/" + indexResource.type(), true);
         } else {
-            return getMappings(indexResource.index() + "/_mapping", false);
+            return getMappings(indexResource.index() + "/_mapping" + (indexReadMissingAsEmpty ? "?ignore_unavailable=true" : ""), false);
         }
     }
 


### PR DESCRIPTION
Fixing the behavior of the `es.index.read.missing.as.empty` setting if one or more indices exist and one or more do not. Previously if any index in the list of indices was missing it would return no results. Now it returns results from indices that do exist and ignores indices that do not exist. Behavior is unchanged if this property is unset or set to false.
Closes #1055