### PR TITLE
[8.5] [DOCS] Add 8.5.0 release notes (#2032)

### DIFF
--- a/docs/src/reference/asciidoc/appendix/release-notes/8.5.0.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/8.5.0.adoc
@@ -1,0 +1,15 @@
+[[eshadoop-8.5.0]]
+== Elasticsearch for Apache Hadoop version 8.5.0
+
+[[enhancements-8.5.0]]
+=== Enhancements
+Section::
+* Adding a user-agent header
+https://github.com/elastic/elasticsearch-hadoop/pull/1993[#1993]
+
+[[bugs-8.5.0]]
+=== Bug Fixes
+Section::
+* Ignoring missing indices if es.index.read.missing.as.empty is true
+https://github.com/elastic/elasticsearch-hadoop/pull/1997[#1997]
+http://github.com/elastic/elasticsearch-hadoop/issues/1055[#1055]

--- a/docs/src/reference/asciidoc/appendix/release.adoc
+++ b/docs/src/reference/asciidoc/appendix/release.adoc
@@ -9,6 +9,7 @@ This section summarizes the changes in each release.
 [[release-notes-8]]
 ===== 8.x
 
+* <<eshadoop-8.5.0>>
 * <<eshadoop-8.4.3>>
 * <<eshadoop-8.4.2>>
 * <<eshadoop-8.4.1>>
@@ -74,6 +75,7 @@ Elasticsearch 5.3.1.
 
 ////////////////////////
 
+include::release-notes/8.5.0.adoc[]
 include::release-notes/8.4.3.adoc[]
 include::release-notes/8.4.2.adoc[]
 include::release-notes/8.4.1.adoc[]


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.5`:
 - [[DOCS] Add 8.5.0 release notes (#2032)](https://github.com/elastic/elasticsearch-hadoop/pull/2032)

<!--- Backport version: 8.4.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)