### PR TITLE
[8.5] [DOCS] Add 8.5.3 release notes (#2045)

### DIFF
--- a/docs/src/reference/asciidoc/appendix/release-notes/8.5.3.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/8.5.3.adoc
@@ -1,0 +1,5 @@
+[[eshadoop-8.5.3]]
+== Elasticsearch for Apache Hadoop version 8.5.3
+
+ES-Hadoop 8.5.3 is a version compatibility release, tested specifically against
+Elasticsearch 8.5.3.

--- a/docs/src/reference/asciidoc/appendix/release.adoc
+++ b/docs/src/reference/asciidoc/appendix/release.adoc
@@ -9,6 +9,7 @@ This section summarizes the changes in each release.
 [[release-notes-8]]
 ===== 8.x
 
+* <<eshadoop-8.5.3>>
 * <<eshadoop-8.5.2>>
 * <<eshadoop-8.5.1>>
 * <<eshadoop-8.5.0>>
@@ -77,6 +78,7 @@ Elasticsearch 5.3.1.
 
 ////////////////////////
 
+include::release-notes/8.5.3.adoc[]
 include::release-notes/8.5.2.adoc[]
 include::release-notes/8.5.1.adoc[]
 include::release-notes/8.5.0.adoc[]


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.5`:
 - [[DOCS] Add 8.5.3 release notes (#2045)](https://github.com/elastic/elasticsearch-hadoop/pull/2045)

<!--- Backport version: 8.4.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)