### PR TITLE
[8.6] [DOCS] Add 8.5.2 release notes (#2042)

### DIFF
--- a/docs/src/reference/asciidoc/appendix/release-notes/8.5.2.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/8.5.2.adoc
@@ -1,0 +1,5 @@
+[[eshadoop-8.5.2]]
+== Elasticsearch for Apache Hadoop version 8.5.2
+
+ES-Hadoop 8.5.2 is a version compatibility release, tested specifically against
+Elasticsearch 8.5.2.

--- a/docs/src/reference/asciidoc/appendix/release.adoc
+++ b/docs/src/reference/asciidoc/appendix/release.adoc
@@ -9,6 +9,7 @@ This section summarizes the changes in each release.
 [[release-notes-8]]
 ===== 8.x
 
+* <<eshadoop-8.5.2>>
 * <<eshadoop-8.5.1>>
 * <<eshadoop-8.5.0>>
 * <<eshadoop-8.4.3>>
@@ -76,6 +77,7 @@ Elasticsearch 5.3.1.
 
 ////////////////////////
 
+include::release-notes/8.5.2.adoc[]
 include::release-notes/8.5.1.adoc[]
 include::release-notes/8.5.0.adoc[]
 include::release-notes/8.4.3.adoc[]


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.6`:
 - [[DOCS] Add 8.5.2 release notes (#2042)](https://github.com/elastic/elasticsearch-hadoop/pull/2042)

<!--- Backport version: 8.4.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)