### PR TITLE
[8.6] [DOCS] Add 8.6.1 release notes (#2059)

### DIFF
--- a/docs/src/reference/asciidoc/appendix/release-notes/8.6.1.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/8.6.1.adoc
@@ -1,0 +1,8 @@
+[[eshadoop-8.6.1]]
+== Elasticsearch for Apache Hadoop version 8.6.1
+
+[[enhancements-8.6.1]]
+=== Enhancements
+Section::
+* Update Spark to 3.2.3
+https://github.com/elastic/elasticsearch-hadoop/pull/2056[#2056]

--- a/docs/src/reference/asciidoc/appendix/release.adoc
+++ b/docs/src/reference/asciidoc/appendix/release.adoc
@@ -9,6 +9,7 @@ This section summarizes the changes in each release.
 [[release-notes-8]]
 ===== 8.x
 
+* <<eshadoop-8.6.1>>
 * <<eshadoop-8.6.0>>
 * <<eshadoop-8.5.3>>
 * <<eshadoop-8.5.2>>
@@ -79,6 +80,7 @@ Elasticsearch 5.3.1.
 
 ////////////////////////
 
+include::release-notes/8.6.1.adoc[]
 include::release-notes/8.6.0.adoc[]
 include::release-notes/8.5.3.adoc[]
 include::release-notes/8.5.2.adoc[]


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.6`:
 - [[DOCS] Add 8.6.1 release notes (#2059)](https://github.com/elastic/elasticsearch-hadoop/pull/2059)

<!--- Backport version: 8.4.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)