### PR TITLE
Fix checking self-signed certs of length greater than 1

### DIFF
--- a/mr/src/main/java/org/elasticsearch/hadoop/rest/commonshttp/SSLSocketFactory.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/rest/commonshttp/SSLSocketFactory.java
@@ -89,7 +89,7 @@ class SSLSocketFactory implements SecureProtocolSocketFactory {
 
     private static class SelfSignedStrategy implements TrustStrategy {
         public boolean isTrusted(X509Certificate[] chain, String authType) throws CertificateException {
-            return chain.length == 1;
+            return chain.length >= 1;
         }
     }
 


### PR DESCRIPTION
This PR fixes issues related to self-signed certificates of length greater than 1: https://github.com/elastic/elasticsearch-hadoop/issues/1651, https://github.com/elastic/elasticsearch-hadoop/issues/1146. The only change required was adopting the check to assert that certificate list is longer than 1, not exactly 1.

This is necessary to work with many certificates. My use case is running Elasticsearch (ECK) and Spark on Kubernetes cluster (https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-tls-certificates.html#k8s-default-self-signed-certificate) and we have self-signed certificates of length 1.


- [x] I have signed the [Contributor License Agreement (CLA)][]

[Contributor License Agreement (CLA)]: https://www.elastic.co/contributor-agreement/
