### PR TITLE
[8.8] [DOCS] Add 8.8.0 release notes (#2093)

### DIFF
--- a/docs/src/reference/asciidoc/appendix/release-notes/8.8.0.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/8.8.0.adoc
@@ -1,0 +1,9 @@
+[[eshadoop-8.8.0]]
+== Elasticsearch for Apache Hadoop version 8.8.0
+
+[[bugs-8.8.0]]
+=== Bug Fixes
+Hive::
+* Fixing WritableBytesConverter to not overwrite bytes with wrong value
+https://github.com/elastic/elasticsearch-hadoop/issues/2072[#2072]
+https://github.com/elastic/elasticsearch-hadoop/pull/2075[#2075]

--- a/docs/src/reference/asciidoc/appendix/release.adoc
+++ b/docs/src/reference/asciidoc/appendix/release.adoc
@@ -9,6 +9,7 @@ This section summarizes the changes in each release.
 [[release-notes-8]]
 ===== 8.x
 
+* <<eshadoop-8.8.0>>
 * <<eshadoop-8.7.1>>
 * <<eshadoop-8.7.0>>
 * <<eshadoop-8.6.2>>
@@ -83,6 +84,7 @@ Elasticsearch 5.3.1.
 
 ////////////////////////
 
+include::release-notes/8.8.0.adoc[]
 include::release-notes/8.7.1.adoc[]
 include::release-notes/8.7.0.adoc[]
 include::release-notes/8.6.2.adoc[]


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.8`:
 - [[DOCS] Add 8.8.0 release notes (#2093)](https://github.com/elastic/elasticsearch-hadoop/pull/2093)

<!--- Backport version: 8.4.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)