### PR TITLE
Use DRA repository for build-tools dependencies

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -61,6 +61,7 @@ repositories {
         flatDir { dirs new File(project.rootDir, "../localRepo") }
     } else {
         maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
+        maven { url "https://artifacts-snapshot.elastic.co/elasticsearch/${esVersion}/maven" }
     }
 }
 

--- a/qa/build.gradle
+++ b/qa/build.gradle
@@ -40,6 +40,7 @@ subprojects {
                 flatDir { dirs new File(project.rootProject.rootDir, "localRepo") }
             } else {
                 maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
+                maven { url "https://artifacts-snapshot.elastic.co/elasticsearch/${version}/maven" }
             }
         }
         dependencies {


### PR DESCRIPTION
Backporting the use of a new snapshot repository from main.