### PR TITLE
[8.8] [DOCS] Add 8.8.1 release notes

### DIFF
--- a/docs/src/reference/asciidoc/appendix/release-notes/8.8.1.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/8.8.1.adoc
@@ -1,0 +1,7 @@
+[[eshadoop-8.8.1]]
+== Elasticsearch for Apache Hadoop version 8.8.1
+
+coming::[8.8.1]
+
+ES-Hadoop 8.8.1 is a version compatibility release, tested specifically against
+Elasticsearch 8.8.1.

--- a/docs/src/reference/asciidoc/appendix/release.adoc
+++ b/docs/src/reference/asciidoc/appendix/release.adoc
@@ -9,6 +9,7 @@ This section summarizes the changes in each release.
 [[release-notes-8]]
 ===== 8.x
 
+* <<eshadoop-8.8.1>>
 * <<eshadoop-8.8.0>>
 * <<eshadoop-8.7.1>>
 * <<eshadoop-8.7.0>>
@@ -84,6 +85,7 @@ Elasticsearch 5.3.1.
 
 ////////////////////////
 
+include::release-notes/8.8.1.adoc[]
 include::release-notes/8.8.0.adoc[]
 include::release-notes/8.7.1.adoc[]
 include::release-notes/8.7.0.adoc[]


### PR DESCRIPTION
8.8 backport of https://github.com/elastic/elasticsearch-hadoop/pull/2097
