### PR TITLE
[8.9] [DOCS] Add 8.9.0 release notes (#2110)

### DIFF
--- a/docs/src/reference/asciidoc/appendix/release-notes/8.9.0.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/8.9.0.adoc
@@ -1,0 +1,22 @@
+[[eshadoop-8.9.0]]
+== Elasticsearch for Apache Hadoop version 8.9.0
+
+[[breaking-8.9.0]]
+=== Breaking Changes
+* Removing Pig, Storm, and Spark 1 support, as well as support for Scala 2.10 on Spark 2
+https://github.com/elastic/elasticsearch-hadoop/pull/2092[#2092]
+
+[[enhancements-8.9.0]]
+=== Enhancements
+Spark::
+* Update to Spark 3.2.4
+https://github.com/elastic/elasticsearch-hadoop/pull/2083[#2083]
+
+[[bugs-8.9.0]]
+=== Bug Fixes
+Serialization::
+* Replacing the use of Java object serialization with Jackson
+https://github.com/elastic/elasticsearch-hadoop/pull/2080[#2080]
+Build::
+* Adding a readiness check before using services in tests
+https://github.com/elastic/elasticsearch-hadoop/pull/2099[#2099]

--- a/docs/src/reference/asciidoc/appendix/release.adoc
+++ b/docs/src/reference/asciidoc/appendix/release.adoc
@@ -9,6 +9,7 @@ This section summarizes the changes in each release.
 [[release-notes-8]]
 ===== 8.x
 
+* <<eshadoop-8.9.0>>
 * <<eshadoop-8.8.2>>
 * <<eshadoop-8.8.1>>
 * <<eshadoop-8.8.0>>
@@ -86,6 +87,7 @@ Elasticsearch 5.3.1.
 
 ////////////////////////
 
+include::release-notes/8.9.0.adoc[]
 include::release-notes/8.8.2.adoc[]
 include::release-notes/8.8.1.adoc[]
 include::release-notes/8.8.0.adoc[]


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.9`:
 - [[DOCS] Add 8.9.0 release notes (#2110)](https://github.com/elastic/elasticsearch-hadoop/pull/2110)

<!--- Backport version: 8.4.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)