### PR TITLE
Fix pom file naming after Gradle update

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/BuildPlugin.groovy
@@ -62,6 +62,8 @@ import org.gradle.external.javadoc.JavadocOutputLevel
 import org.gradle.external.javadoc.MinimalJavadocOptions
 import org.gradle.plugins.ide.eclipse.EclipsePlugin
 import org.gradle.plugins.ide.idea.IdeaPlugin
+import org.gradle.api.plugins.BasePluginExtension
+
 import org.w3c.dom.NodeList
 
 import javax.inject.Inject
@@ -669,7 +671,7 @@ class BuildPlugin implements Plugin<Project>  {
         // Set the pom's destination to the distribution directory
         project.tasks.withType(GenerateMavenPom).all { GenerateMavenPom pom ->
             if (pom.name == "generatePomFileFor${publication.name.capitalize()}Publication") {
-                def baseExtension = project.getExtensions().getByName('base');
+                BasePluginExtension baseExtension = project.getExtensions().getByType(BasePluginExtension.class);
                 pom.destination = project.provider({"${project.buildDir}/distributions/${baseExtension.archivesName.get()}-${project.getVersion()}.pom"})
             }
         }
@@ -729,7 +731,7 @@ class BuildPlugin implements Plugin<Project>  {
     private static void updateVariantPomLocationAndArtifactId(Project project, MavenPublication publication, SparkVariant variant) {
         // Add variant classifier to the pom file name if required
         String classifier = variant.shouldClassifySparkVersion() && variant.isDefaultVariant() == false ? "-${variant.getName()}" : ''
-        def baseExtension = project.getExtensions().getByName('base')
+        BasePluginExtension baseExtension = project.getExtensions().getByType(BasePluginExtension.class);
         String filename = "${baseExtension.archivesName.get()}_${variant.scalaMajorVersion}-${project.getVersion()}${classifier}"
         // Fix the pom name
         project.tasks.withType(GenerateMavenPom).all { GenerateMavenPom pom ->

--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/BuildPlugin.groovy
@@ -669,7 +669,8 @@ class BuildPlugin implements Plugin<Project>  {
         // Set the pom's destination to the distribution directory
         project.tasks.withType(GenerateMavenPom).all { GenerateMavenPom pom ->
             if (pom.name == "generatePomFileFor${publication.name.capitalize()}Publication") {
-                pom.destination = project.provider({"${project.buildDir}/distributions/${project.archivesBaseName}-${project.getVersion()}.pom"})
+                def baseExtension = project.getExtensions().getByName('base');
+                pom.destination = project.provider({"${project.buildDir}/distributions/${baseExtension.archivesName}-${project.getVersion()}.pom"})
             }
         }
 
@@ -728,7 +729,8 @@ class BuildPlugin implements Plugin<Project>  {
     private static void updateVariantPomLocationAndArtifactId(Project project, MavenPublication publication, SparkVariant variant) {
         // Add variant classifier to the pom file name if required
         String classifier = variant.shouldClassifySparkVersion() && variant.isDefaultVariant() == false ? "-${variant.getName()}" : ''
-        String filename = "${project.base.archivesName}_${variant.scalaMajorVersion}-${project.getVersion()}${classifier}"
+        def baseExtension = project.getExtensions().getByName('base')
+        String filename = "${baseExtension.archivesName.get()}_${variant.scalaMajorVersion}-${project.getVersion()}${classifier}"
         // Fix the pom name
         project.tasks.withType(GenerateMavenPom).all { GenerateMavenPom pom ->
             if (pom.name == "generatePomFileFor${publication.name.capitalize()}Publication") {
@@ -739,7 +741,7 @@ class BuildPlugin implements Plugin<Project>  {
         publication.getPom().withXml { XmlProvider xml ->
             Node root = xml.asNode()
             Node artifactId = (root.get('artifactId') as NodeList).get(0) as Node
-            artifactId.setValue("${project.archivesBaseName}_${variant.scalaMajorVersion}")
+            artifactId.setValue("${baseExtension.archivesName.get()}_${variant.scalaMajorVersion}")
         }
     }
 

--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/BuildPlugin.groovy
@@ -670,7 +670,7 @@ class BuildPlugin implements Plugin<Project>  {
         project.tasks.withType(GenerateMavenPom).all { GenerateMavenPom pom ->
             if (pom.name == "generatePomFileFor${publication.name.capitalize()}Publication") {
                 def baseExtension = project.getExtensions().getByName('base');
-                pom.destination = project.provider({"${project.buildDir}/distributions/${baseExtension.archivesName}-${project.getVersion()}.pom"})
+                pom.destination = project.provider({"${project.buildDir}/distributions/${baseExtension.archivesName.get()}-${project.getVersion()}.pom"})
             }
         }
 

--- a/dist/build.gradle
+++ b/dist/build.gradle
@@ -144,7 +144,7 @@ publishing {
                 repository.appendNode('url', 'https://clojars.org/repo')
 
                 // Correct the artifact Id, otherwise it is listed as 'dist'
-                root.get('artifactId').get(0).setValue(project.archivesBaseName)
+                root.get('artifactId').get(0).setValue(project.base.archivesName.get())
             }
         }
     }

--- a/dist/build.gradle
+++ b/dist/build.gradle
@@ -2,6 +2,7 @@ import org.elasticsearch.hadoop.gradle.buildtools.ConcatFilesTask
 import org.elasticsearch.hadoop.gradle.buildtools.DependenciesInfoTask
 import org.elasticsearch.hadoop.gradle.buildtools.DependencyLicensesTask
 import org.elasticsearch.hadoop.gradle.BuildPlugin
+import org.gradle.api.plugins.BasePluginExtension
 
 apply plugin: 'es.hadoop.build'
 
@@ -142,9 +143,10 @@ publishing {
                 Node repository = repositories.appendNode('repository')
                 repository.appendNode('id', 'clojars.org')
                 repository.appendNode('url', 'https://clojars.org/repo')
+                BasePluginExtension baseExtension = project.getExtensions().getByType(BasePluginExtension.class)
 
                 // Correct the artifact Id, otherwise it is listed as 'dist'
-                root.get('artifactId').get(0).setValue(project.base.archivesName.get())
+                root.get('artifactId').get(0).setValue(baseExtension.archivesName.get())
             }
         }
     }


### PR DESCRIPTION
This fixes the broken pom file generation after the Gradle 8.2 update  