### PR TITLE
[buildkite] Add initial catalog-info.yml

### DIFF
--- a/catalog-info.yml
+++ b/catalog-info.yml
@@ -1,0 +1,72 @@
+---
+# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/e57ee3bed7a6f73077a3f55a38e76e40ec87a7cf/rre.schema.json
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: buildkite-pipeline-elasticsearch-hadoop
+  description: Elasticsearch tests and checks that are run a few times daily
+  links:
+    - title: Pipeline
+      url: https://buildkite.com/elastic/elasticsearch-hadoop-tests
+spec:
+  type: buildkite-pipeline
+  system: buildkite
+  owner: group:elasticsearch-team
+  implementation:
+    apiVersion: buildkite.elastic.dev/v1
+    kind: Pipeline
+    metadata:
+      description: 'Runs full suite of elasticsearch-hadoop tests'
+      name: elasticsearch-hadoop / tests
+    spec:
+      repository: elastic/elasticsearch-hadoop
+      pipeline_file: .buildkite/pipeline.py
+      default_branch: main
+      branch_configuration: 'main 8.* 7.17'
+      teams:
+        elasticsearch-team: {}
+        everyone:
+          access_level: BUILD_AND_READ
+      provider_settings:
+        trigger_mode: none
+        build_pull_requests: true
+        build_pull_request_forks: false
+        publish_commit_status: true
+        build_branches: true
+---
+# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/e57ee3bed7a6f73077a3f55a38e76e40ec87a7cf/rre.schema.json
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: buildkite-pipeline-elasticsearch-hadoop-on-merge
+  description: Runs full suite of elasticsearch-hadoop tests and publishes DRA snapshot
+  links:
+    - title: Pipeline
+      url: https://buildkite.com/elastic/elasticsearch-hadoop-on-merge
+spec:
+  type: buildkite-pipeline
+  system: buildkite
+  owner: group:elasticsearch-team
+  implementation:
+    apiVersion: buildkite.elastic.dev/v1
+    kind: Pipeline
+    metadata:
+      description: 'Runs full suite of elasticsearch-hadoop tests and publishes DRA snapshot'
+      name: elasticsearch-hadoop / on-merge
+    spec:
+      repository: elastic/elasticsearch-hadoop
+      pipeline_file: .buildkite/pipeline.py
+      env:
+        ENABLE_DRA_SNAPSHOT: 'true'
+      default_branch: main
+      branch_configuration: 'main 8.* 7.17'
+      teams:
+        elasticsearch-team: {}
+        everyone:
+          access_level: BUILD_AND_READ
+      provider_settings:
+        trigger_mode: none
+        build_pull_requests: false
+        build_pull_request_forks: false
+        publish_commit_status: true
+        build_branches: true


### PR DESCRIPTION
I need to write Vault secrets for the work going on in #2114, but I don't believe I can do it until this repo has a catalog-info file. This is the file that holds the top-level Buildkite pipeline definitions.

So, I'm splitting it out from the other PR, and taking the triggers off for now.