### PR TITLE
[8.10] Fix dra-workflow pipeline spacing (#2125) | Add missing agent config to pipeline

### DIFF
--- a/.buildkite/dra-workflow.yml
+++ b/.buildkite/dra-workflow.yml
@@ -4,3 +4,9 @@ steps:
     timeout_in_minutes: 60
     env:
       USE_DRA_CREDENTIALS: true
+    agents:
+      provider: gcp
+      image: family/elasticsearch-ubuntu-2004
+      machineType: n2-standard-8
+      diskType: pd-ssd
+      diskSizeGb: 100

--- a/.buildkite/dra-workflow.yml
+++ b/.buildkite/dra-workflow.yml
@@ -1,6 +1,6 @@
 steps:
   - label: DRA Workflow
-command: .buildkite/dra.sh
-timeout_in_minutes: 60
-env:
-  USE_DRA_CREDENTIALS: true
+    command: .buildkite/dra.sh
+    timeout_in_minutes: 60
+    env:
+      USE_DRA_CREDENTIALS: true


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.10`:
 - [Fix dra-workflow pipeline spacing (#2125)](https://github.com/elastic/elasticsearch-hadoop/pull/2125)
 - Add missing agent config to pipeline (b0ad5c08)

<!--- Backport version: 9.2.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)