### PR TITLE
[8.10] [DOCS] Add 8.9.2 release notes (#2129)

### DIFF
--- a/docs/src/reference/asciidoc/appendix/release-notes/8.9.2.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/8.9.2.adoc
@@ -1,0 +1,5 @@
+[[eshadoop-8.9.2]]
+== Elasticsearch for Apache Hadoop version 8.9.2
+
+ES-Hadoop 8.9.2 is a version compatibility release, tested specifically against
+Elasticsearch 8.9.2.

--- a/docs/src/reference/asciidoc/appendix/release.adoc
+++ b/docs/src/reference/asciidoc/appendix/release.adoc
@@ -9,6 +9,7 @@ This section summarizes the changes in each release.
 [[release-notes-8]]
 ===== 8.x
 
+* <<eshadoop-8.9.2>>
 * <<eshadoop-8.9.1>>
 * <<eshadoop-8.9.0>>
 * <<eshadoop-8.8.2>>
@@ -88,6 +89,7 @@ Elasticsearch 5.3.1.
 
 ////////////////////////
 
+include::release-notes/8.9.2.adoc[]
 include::release-notes/8.9.1.adoc[]
 include::release-notes/8.9.0.adoc[]
 include::release-notes/8.8.2.adoc[]


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.10`:
 - [[DOCS] Add 8.9.2 release notes (#2129)](https://github.com/elastic/elasticsearch-hadoop/pull/2129)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)