### PR TITLE
[8.11] [DOCS] Add 8.11.0 release notes (#2154)

### DIFF
--- a/docs/src/reference/asciidoc/appendix/release-notes/8.11.0.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/8.11.0.adoc
@@ -1,0 +1,5 @@
+[[eshadoop-8.11.0]]
+== Elasticsearch for Apache Hadoop version 8.11.0
+
+ES-Hadoop 8.11.0 is a version compatibility release, tested specifically against
+Elasticsearch 8.11.0.

--- a/docs/src/reference/asciidoc/appendix/release.adoc
+++ b/docs/src/reference/asciidoc/appendix/release.adoc
@@ -9,6 +9,7 @@ This section summarizes the changes in each release.
 [[release-notes-8]]
 ===== 8.x
 
+* <<eshadoop-8.11.0>>
 * <<eshadoop-8.10.4>>
 * <<eshadoop-8.10.3>>
 * <<eshadoop-8.10.2>>
@@ -94,6 +95,7 @@ Elasticsearch 5.3.1.
 
 ////////////////////////
 
+include::release-notes/8.11.0.adoc[]
 include::release-notes/8.10.4.adoc[]
 include::release-notes/8.10.3.adoc[]
 include::release-notes/8.10.2.adoc[]


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.11`:
 - [[DOCS] Add 8.11.0 release notes (#2154)](https://github.com/elastic/elasticsearch-hadoop/pull/2154)

<!--- Backport version: 8.4.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)