### PR TITLE
Add Es Spark Accumulators

### DIFF
--- a/docs/src/reference/asciidoc/core/configuration.adoc
+++ b/docs/src/reference/asciidoc/core/configuration.adoc
@@ -460,6 +460,13 @@ compared to jobs executed against a fully green or yellow cluster. Use this sett
 caution.
 
 [float]
+==== Metrics
+
+added[8.12]
+`es.metrics.prefix` (default empty)::
+Only useful for the Spark metrics. When given the set of reported metrics will start by this prefix with a dot separator.
+
+[float]
 ==== Input
 
 added[5.0.0]

--- a/docs/src/reference/asciidoc/core/metrics.adoc
+++ b/docs/src/reference/asciidoc/core/metrics.adoc
@@ -17,31 +17,31 @@ For Spark, the same principle exists with https://spark.apache.org/docs/latest/r
 2+h| Data focused
 
 | BYTES_SENT     | Total number of data/communication bytes sent over the network to {es}
-| BYTES_ACCEPTED | Data/Documents accepted by {es} in bytes
-| BYTES_RETRIED  | Data/Documents rejected by {es} in bytes
-| BYTES_RECEIVED | Data/Documents received from {es} in bytes
+| BYTES_ACCEPTED | Data/Documents accepted by {es} in bytes 
+| BYTES_RETRIED  | Data/Documents rejected by {es} in bytes 
+| BYTES_RECEIVED | Data/Documents received from {es} in bytes 
 
 2+h| Document focused
 
 | DOCS_SENT     | Number of docs sent over the network to {es}
-| DOCS_ACCEPTED | Number of documents sent and accepted by {es}
-| DOCS_RETRIED  | Number of documents sent but rejected by {es}
-| DOCS_RECEIVED | Number of documents received from {es}
+| DOCS_ACCEPTED | Number of documents sent and accepted by {es} 
+| DOCS_RETRIED  | Number of documents sent but rejected by {es} 
+| DOCS_RECEIVED | Number of documents received from {es} 
 
 2+h| Network focused
 
 | BULK_TOTAL   | Number of bulk requests made to {es}
-| BULK_RETRIES | Number of bulk retries (caused by document rejections)
+| BULK_RETRIES | Number of bulk retries (caused by document rejections) 
 | SCROLL_TOTAL | Number of scroll pulled from {es}
-| NODE_RETRIES | Number of node fall backs (caused by network errors)
-| NET_RETRIES  | Number of network retries (caused by network errors)
+| NODE_RETRIES | Number of node fall backs (caused by network errors) 
+| NET_RETRIES  | Number of network retries (caused by network errors) 
 
 2+h| Time focused
 
-| NET_TOTAL_TIME_MS 		 | Overall time (in ms) spent over the network
-| BULK_TOTAL_TIME_MS 		 | Time (in ms) spent over the network by the bulk requests
-| BULK_RETRIES_TOTAL_TIME_MS | Time (in ms) spent over the network retrying bulk requests
-| SCROLL_TOTAL_TIME_MS       | Time (in ms) spent over the network reading the scroll requests
+| NET_TOTAL_TIME_MS 		 | Overall time (in ms) spent over the network 
+| BULK_TOTAL_TIME_MS 		 | Time (in ms) spent over the network by the bulk requests 
+| BULK_RETRIES_TOTAL_TIME_MS | Time (in ms) spent over the network retrying bulk requests 
+| SCROLL_TOTAL_TIME_MS       | Time (in ms) spent over the network reading the scroll requests 
 
 |===
 

--- a/docs/src/reference/asciidoc/core/metrics.adoc
+++ b/docs/src/reference/asciidoc/core/metrics.adoc
@@ -1,48 +1,51 @@
 [[metrics]]
 == Hadoop Metrics
 
-The Hadoop system records a set of metric counters for each job that it runs. {eh} extends on that and provides metrics about its activity for each job run by leveraging the Hadoop http://hadoop.apache.org/docs/r{hadoop-docs-v}/api/org/apache/hadoop/mapred/Counters.html[Counters] infrastructure. During each run, {eh} sends statistics from each task instance, as it is running, which get aggregated by the {mr} infrastructure and are available through the standard Hadoop APIs.
+The Hadoop Map Reduce system records a set of metric counters for each job that it runs. {eh} extends on that and provides metrics about its activity for each job run by leveraging the Hadoop http://hadoop.apache.org/docs/r{hadoop-docs-v}/api/org/apache/hadoop/mapred/Counters.html[Counters] infrastructure. During each run, {eh} sends statistics from each task instance, as it is running, which get aggregated by the {mr} infrastructure and are available through the standard Hadoop APIs.
 
-{eh} provides the following counters, available under `org.elasticsearch.hadoop.mr.Counter` enum:
+For Spark, the same principle exists with https://spark.apache.org/docs/latest/rdd-programming-guide.html#accumulators[Accumulators].
 
-.Available counters
+{eh} provides the following counters, available under `org.elasticsearch.hadoop.mr.Counter` enum or the following accumulators available under
+`org.elasticsearch.spark.acc.EsSparkAccumulators` object in function of the framework that you use:
+
+.Available counters and accumulators
 [cols="^,^",options="header"]
 
 |===
-| Counter name | Purpose
+| Name | Purpose
 
 2+h| Data focused
 
 | BYTES_SENT     | Total number of data/communication bytes sent over the network to {es}
-| BYTES_ACCEPTED | Data/Documents accepted by {es} in bytes 
-| BYTES_RETRIED  | Data/Documents rejected by {es} in bytes 
-| BYTES_RECEIVED | Data/Documents received from {es} in bytes 
+| BYTES_ACCEPTED | Data/Documents accepted by {es} in bytes
+| BYTES_RETRIED  | Data/Documents rejected by {es} in bytes
+| BYTES_RECEIVED | Data/Documents received from {es} in bytes
 
 2+h| Document focused
 
 | DOCS_SENT     | Number of docs sent over the network to {es}
-| DOCS_ACCEPTED | Number of documents sent and accepted by {es} 
-| DOCS_RETRIED  | Number of documents sent but rejected by {es} 
-| DOCS_RECEIVED | Number of documents received from {es} 
+| DOCS_ACCEPTED | Number of documents sent and accepted by {es}
+| DOCS_RETRIED  | Number of documents sent but rejected by {es}
+| DOCS_RECEIVED | Number of documents received from {es}
 
 2+h| Network focused
 
 | BULK_TOTAL   | Number of bulk requests made to {es}
-| BULK_RETRIES | Number of bulk retries (caused by document rejections) 
+| BULK_RETRIES | Number of bulk retries (caused by document rejections)
 | SCROLL_TOTAL | Number of scroll pulled from {es}
-| NODE_RETRIES | Number of node fall backs (caused by network errors) 
-| NET_RETRIES  | Number of network retries (caused by network errors) 
+| NODE_RETRIES | Number of node fall backs (caused by network errors)
+| NET_RETRIES  | Number of network retries (caused by network errors)
 
 2+h| Time focused
 
-| NET_TOTAL_TIME_MS 		 | Overall time (in ms) spent over the network 
-| BULK_TOTAL_TIME_MS 		 | Time (in ms) spent over the network by the bulk requests 
-| BULK_RETRIES_TOTAL_TIME_MS | Time (in ms) spent over the network retrying bulk requests 
-| SCROLL_TOTAL_TIME_MS       | Time (in ms) spent over the network reading the scroll requests 
+| NET_TOTAL_TIME_MS 		 | Overall time (in ms) spent over the network
+| BULK_TOTAL_TIME_MS 		 | Time (in ms) spent over the network by the bulk requests
+| BULK_RETRIES_TOTAL_TIME_MS | Time (in ms) spent over the network retrying bulk requests
+| SCROLL_TOTAL_TIME_MS       | Time (in ms) spent over the network reading the scroll requests
 
 |===
 
-One can use the counters programatically, depending on the API used, through http://hadoop.apache.org/docs/r{hadoop-docs-v}/api/index.html?org/apache/hadoop/mapred/Counters.html[mapred] or http://hadoop.apache.org/docs/r{hadoop-docs-v}/api/index.html?org/apache/hadoop/mapreduce/Counter.html[mapreduce]. Whatever the choice, {eh} performs automatic reports without any user intervention. In fact, when using {eh} one will see the stats reported at the end of the job run, for example:
+One can use the counters programmatically, depending on the API used, through http://hadoop.apache.org/docs/r{hadoop-docs-v}/api/index.html?org/apache/hadoop/mapred/Counters.html[mapred] or http://hadoop.apache.org/docs/r{hadoop-docs-v}/api/index.html?org/apache/hadoop/mapreduce/Counter.html[mapreduce]. Whatever the choice, {eh} performs automatic reports without any user intervention. In fact, when using {eh} one will see the stats reported at the end of the job run, for example:
 
 [source, bash]
 ----
@@ -69,3 +72,5 @@ Elasticsearch Hadoop Counters
     Scroll Total Time(ms)=0
 
 ----
+
+Same thing for Spark.

--- a/mr/src/main/java/org/elasticsearch/hadoop/cfg/ConfigurationOptions.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/cfg/ConfigurationOptions.java
@@ -325,4 +325,8 @@ public interface ConfigurationOptions {
     /** Security options **/
     String ES_SECURITY_AUTHENTICATION = "es.security.authentication";
     String ES_SECURITY_USER_PROVIDER_CLASS = "es.security.user.provider.class";
+
+    /** Metrics **/
+    String ES_METRICS_PREFIX = "es.metrics.prefix";
+    String ES_METRICS_PREFIX_DEFAULT = "";
 }

--- a/mr/src/main/java/org/elasticsearch/hadoop/cfg/Settings.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/cfg/Settings.java
@@ -708,6 +708,10 @@ public abstract class Settings {
         return getProperty(ConfigurationOptions.ES_SECURITY_USER_PROVIDER_CLASS);
     }
 
+    public String getMetricsPrefix() {
+        return getProperty(ES_METRICS_PREFIX, ES_METRICS_PREFIX_DEFAULT);
+    }
+
     public abstract InputStream loadResource(String location);
 
     public abstract Settings copy();

--- a/spark/core/src/itest/scala/org/elasticsearch/spark/integration/AbstractScalaEsSpark.scala
+++ b/spark/core/src/itest/scala/org/elasticsearch/spark/integration/AbstractScalaEsSpark.scala
@@ -25,6 +25,7 @@ import java.nio.file.Paths
 import java.util.concurrent.TimeUnit
 import java.{lang => jl}
 import java.{util => ju}
+
 import org.apache.spark.SparkConf
 import org.apache.spark.SparkContext
 import org.apache.spark.SparkException
@@ -32,8 +33,17 @@ import org.elasticsearch.hadoop.EsAssume
 import org.elasticsearch.hadoop.EsHadoopIllegalArgumentException
 import org.elasticsearch.hadoop.TestData
 import org.elasticsearch.hadoop.cfg.ConfigurationOptions
-import org.elasticsearch.hadoop.cfg.ConfigurationOptions.{ES_INDEX_AUTO_CREATE, ES_INDEX_READ_MISSING_AS_EMPTY, ES_INPUT_JSON, ES_MAPPING_EXCLUDE, ES_MAPPING_ID, ES_MAPPING_JOIN, ES_METRICS_PREFIX, ES_QUERY, ES_READ_METADATA, ES_RESOURCE, ES_RESOURCE_READ, ES_RESOURCE_WRITE}
-import org.elasticsearch.hadoop.util.TestUtils.{docEndpoint, resource}
+import org.elasticsearch.hadoop.cfg.ConfigurationOptions.ES_INDEX_AUTO_CREATE
+import org.elasticsearch.hadoop.cfg.ConfigurationOptions.ES_INDEX_READ_MISSING_AS_EMPTY
+import org.elasticsearch.hadoop.cfg.ConfigurationOptions.ES_INPUT_JSON
+import org.elasticsearch.hadoop.cfg.ConfigurationOptions.ES_MAPPING_EXCLUDE
+import org.elasticsearch.hadoop.cfg.ConfigurationOptions.ES_MAPPING_ID
+import org.elasticsearch.hadoop.cfg.ConfigurationOptions.ES_MAPPING_JOIN
+import org.elasticsearch.hadoop.cfg.ConfigurationOptions.ES_QUERY
+import org.elasticsearch.hadoop.cfg.ConfigurationOptions.ES_READ_METADATA
+import org.elasticsearch.hadoop.cfg.ConfigurationOptions.ES_RESOURCE
+import org.elasticsearch.hadoop.util.TestUtils.resource
+import org.elasticsearch.hadoop.util.TestUtils.docEndpoint
 import org.elasticsearch.hadoop.rest.RestUtils
 import org.elasticsearch.hadoop.rest.RestUtils.ExtendedRestClient
 import org.elasticsearch.hadoop.serialization.EsHadoopSerializationException
@@ -70,6 +80,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 import org.junit.runners.Parameterized.Parameters
+
 import org.elasticsearch.spark.integration.ScalaUtils.propertiesAsScalaMap
 import org.elasticsearch.spark.rdd.JDKCollectionConvertersCompat.Converters._
 

--- a/spark/core/src/main/scala/org/elasticsearch/spark/acc/EsSparkAccumulators.scala
+++ b/spark/core/src/main/scala/org/elasticsearch/spark/acc/EsSparkAccumulators.scala
@@ -1,0 +1,49 @@
+package org.elasticsearch.spark.acc
+
+import org.apache.spark.SparkContext
+import org.apache.spark.util.LongAccumulator
+import org.elasticsearch.hadoop.mr.Counter
+import org.elasticsearch.hadoop.rest.stats.Stats
+
+import scala.collection.JavaConverters.asScalaSetConverter
+import scala.collection.mutable
+
+object EsSparkAccumulators {
+
+  def getAll: Set[LongAccumulator] = accumulators.values.toSet
+
+  private val accumulators: mutable.Map[String, LongAccumulator] = mutable.Map[String, LongAccumulator]()
+
+  private val counters = Counter.ALL.asScala
+
+  private[spark] def build(sc: SparkContext, prefix: String): Unit = {
+    for (counter <- counters) {
+      val fullName = getAccumulatorFullName(prefix, counter.name())
+      if(!accumulators.contains(fullName)) {
+        accumulators += (fullName -> sc.longAccumulator(fullName))
+      }
+    }
+  }
+
+  private[spark] def add(stats: Stats, prefix: String): Unit = {
+    if (accumulators.nonEmpty) {
+      for (counter <- counters) {
+        accumulators.get(getAccumulatorFullName(prefix, counter.name())).foreach(_.add(counter.get(stats)))
+      }
+    }
+  }
+
+  private[spark] def get(prefix: String, counter: Counter): Long = {
+    accumulators(getAccumulatorFullName(prefix, counter.name())).value
+  }
+
+  private[spark] def clear(): Unit = {
+    accumulators.clear()
+  }
+
+  private def getAccumulatorFullName(prefix: String, name: String): String = {
+    val prefixWithSep = if (prefix.isEmpty) "" else s"${prefix}."
+    s"${prefixWithSep}${name}"
+  }
+
+}

--- a/spark/core/src/main/scala/org/elasticsearch/spark/rdd/AbstractEsRDD.scala
+++ b/spark/core/src/main/scala/org/elasticsearch/spark/rdd/AbstractEsRDD.scala
@@ -19,6 +19,7 @@
 package org.elasticsearch.spark.rdd;
 
 import JDKCollectionConvertersCompat.Converters._
+
 import scala.reflect.ClassTag
 import org.apache.commons.logging.LogFactory
 import org.apache.spark.Partition
@@ -31,6 +32,7 @@ import org.elasticsearch.hadoop.rest.PartitionDefinition
 import org.elasticsearch.hadoop.util.ObjectUtils
 import org.elasticsearch.spark.cfg.SparkSettingsManager
 import org.elasticsearch.hadoop.rest.RestRepository
+import org.elasticsearch.spark.acc.EsSparkAccumulators
 
 import scala.annotation.meta.param
 
@@ -66,6 +68,8 @@ private[spark] abstract class AbstractEsRDD[T: ClassTag](
       repo.close()
     }
   }
+
+  EsSparkAccumulators.build(sc, esCfg.getMetricsPrefix)
 
   @transient private[spark] lazy val esCfg = {
     val cfg = new SparkSettingsManager().load(sc.getConf).copy();

--- a/spark/core/src/main/scala/org/elasticsearch/spark/rdd/EsRDDWriter.scala
+++ b/spark/core/src/main/scala/org/elasticsearch/spark/rdd/EsRDDWriter.scala
@@ -21,7 +21,7 @@ package org.elasticsearch.spark.rdd
 import org.apache.commons.logging.Log
 import org.apache.commons.logging.LogFactory
 import org.apache.spark.TaskContext
-import org.apache.spark.util.TaskCompletionListener
+import org.apache.spark.util.{LongAccumulator, TaskCompletionListener}
 import org.elasticsearch.hadoop.cfg.PropertiesSettings
 import org.elasticsearch.hadoop.cfg.Settings
 import org.elasticsearch.hadoop.mr.security.HadoopUserProvider
@@ -35,6 +35,7 @@ import org.elasticsearch.hadoop.serialization.field.FieldExtractor
 import org.elasticsearch.hadoop.serialization.bulk.MetadataExtractor
 import org.elasticsearch.hadoop.serialization.bulk.PerEntityPoolingMetadataExtractor
 import org.elasticsearch.hadoop.util.ObjectUtils
+import org.elasticsearch.spark.acc.EsSparkAccumulators
 import org.elasticsearch.spark.serialization.ScalaMapFieldExtractor
 import org.elasticsearch.spark.serialization.ScalaMetadataExtractor
 import org.elasticsearch.spark.serialization.ScalaValueWriter
@@ -71,7 +72,10 @@ private[spark] class EsRDDWriter[T: ClassTag](val serializedSettings: String,
     val writer = RestService.createWriter(settings, taskContext.partitionId.toLong, -1, log)
 
     val listener = new TaskCompletionListener {
-      override def onTaskCompletion(context: TaskContext): Unit = writer.close()
+      override def onTaskCompletion(context: TaskContext): Unit = {
+        EsSparkAccumulators.add(writer.repository.stats(), settings.getMetricsPrefix)
+        writer.close()
+      }
     }
     taskContext.addTaskCompletionListener(listener)
 

--- a/spark/core/src/main/scala/org/elasticsearch/spark/rdd/EsRDDWriter.scala
+++ b/spark/core/src/main/scala/org/elasticsearch/spark/rdd/EsRDDWriter.scala
@@ -21,7 +21,7 @@ package org.elasticsearch.spark.rdd
 import org.apache.commons.logging.Log
 import org.apache.commons.logging.LogFactory
 import org.apache.spark.TaskContext
-import org.apache.spark.util.{LongAccumulator, TaskCompletionListener}
+import org.apache.spark.util.TaskCompletionListener
 import org.elasticsearch.hadoop.cfg.PropertiesSettings
 import org.elasticsearch.hadoop.cfg.Settings
 import org.elasticsearch.hadoop.mr.security.HadoopUserProvider

--- a/spark/core/src/main/scala/org/elasticsearch/spark/rdd/EsSpark.scala
+++ b/spark/core/src/main/scala/org/elasticsearch/spark/rdd/EsSpark.scala
@@ -32,6 +32,7 @@ import org.elasticsearch.hadoop.cfg.PropertiesSettings
 import org.elasticsearch.hadoop.mr.security.HadoopUserProvider
 import org.elasticsearch.spark.cfg.SparkSettingsManager
 import org.elasticsearch.hadoop.rest.InitializationUtils
+import org.elasticsearch.spark.acc.EsSparkAccumulators
 
 object EsSpark {
 
@@ -94,10 +95,12 @@ object EsSpark {
     if (rdd == null || rdd.partitions.length == 0) {
       return
     }
-    
-    val sparkCfg = new SparkSettingsManager().load(rdd.sparkContext.getConf)
+
+    val sc = rdd.sparkContext
+    val sparkCfg = new SparkSettingsManager().load(sc.getConf)
     val config = new PropertiesSettings().load(sparkCfg.save())
     config.merge(cfg.asJava)
+    EsSparkAccumulators.build(sc, config.getMetricsPrefix)
 
     // Need to discover the EsVersion here before checking if the index exists
     InitializationUtils.setUserProviderIfNotSet(config, classOf[HadoopUserProvider], LOG)

--- a/spark/sql-20/src/itest/scala/org/elasticsearch/spark/integration/AbstractScalaEsSparkSQL.scala
+++ b/spark/sql-20/src/itest/scala/org/elasticsearch/spark/integration/AbstractScalaEsSparkSQL.scala
@@ -53,7 +53,8 @@ import org.elasticsearch.hadoop.cfg.ConfigurationOptions._
 import org.elasticsearch.hadoop.util.StringUtils
 import org.elasticsearch.hadoop.util.TestSettings
 import org.elasticsearch.hadoop.util.TestUtils
-import org.elasticsearch.hadoop.util.TestUtils.{docEndpoint, resource}
+import org.elasticsearch.hadoop.util.TestUtils.resource
+import org.elasticsearch.hadoop.util.TestUtils.docEndpoint
 import org.elasticsearch.spark.cfg.SparkSettingsManager
 import org.elasticsearch.spark.sparkRDDFunctions
 import org.elasticsearch.spark.sparkStringJsonRDDFunctions
@@ -87,6 +88,7 @@ import org.apache.spark.rdd.RDD
 import org.elasticsearch.spark.acc.EsSparkAccumulators
 
 import javax.xml.bind.DatatypeConverter
+import org.apache.spark.sql.SparkSession
 import org.elasticsearch.hadoop.EsAssume
 import org.elasticsearch.hadoop.TestData
 import org.elasticsearch.hadoop.cfg.ConfigurationOptions

--- a/spark/sql-20/src/main/scala/org/elasticsearch/spark/sql/EsSparkSQL.scala
+++ b/spark/sql-20/src/main/scala/org/elasticsearch/spark/sql/EsSparkSQL.scala
@@ -31,6 +31,7 @@ import org.elasticsearch.hadoop.cfg.PropertiesSettings
 import org.elasticsearch.hadoop.mr.security.HadoopUserProvider
 import org.elasticsearch.hadoop.rest.InitializationUtils
 import org.elasticsearch.hadoop.util.ObjectUtils
+import org.elasticsearch.spark.acc.EsSparkAccumulators
 import org.elasticsearch.spark.cfg.SparkSettingsManager
 
 import scala.collection.JavaConverters.mapAsJavaMapConverter
@@ -93,6 +94,7 @@ object EsSparkSQL {
       val sparkCfg = new SparkSettingsManager().load(sparkCtx.getConf)
       val esCfg = new PropertiesSettings().load(sparkCfg.save())
       esCfg.merge(cfg.asJava)
+      EsSparkAccumulators.build(sparkCtx, esCfg.getMetricsPrefix)
 
       // Need to discover ES Version before checking index existence
       InitializationUtils.setUserProviderIfNotSet(esCfg, classOf[HadoopUserProvider], LOG)

--- a/spark/sql-30/src/itest/scala/org/elasticsearch/spark/integration/AbstractScalaEsSparkSQL.scala
+++ b/spark/sql-30/src/itest/scala/org/elasticsearch/spark/integration/AbstractScalaEsSparkSQL.scala
@@ -98,6 +98,7 @@ import org.elasticsearch.hadoop.serialization.JsonUtils
 import org.elasticsearch.hadoop.util.EsMajorVersion
 import org.junit.Assert._
 import org.junit.ClassRule
+import org.elasticsearch.spark.acc.EsSparkAccumulators
 
 object AbstractScalaEsScalaSparkSQL {
 
@@ -2554,6 +2555,49 @@ class AbstractScalaEsScalaSparkSQL(prefix: String, readMetadata: jl.Boolean, pus
     val df = sqc.read.format("es").load(index)
     RestUtils.refresh(index)
     df.count()
+  }
+
+  @Test
+  def testSparkAccumulators() = {
+    def config(metricsPrefix: String): Map[String, String] = {
+      val index = wrapIndex(s"spark-test-accumulators-${metricsPrefix}")
+      val typename = "data"
+      val target = resource(index, typename, version)
+      Map[String, String](
+        ES_RESOURCE_READ -> target,
+        ES_RESOURCE_WRITE -> target,
+        ES_METRICS_PREFIX -> metricsPrefix
+      )
+    }
+
+    val data = Seq(
+      Row("doc1"),
+      Row("doc2"),
+      Row("doc3")
+    )
+    val inputRdd = sc.makeRDD(data)
+    val schema = new StructType()
+      .add("field1", StringType, nullable = false)
+    val df = sqc.createDataFrame(inputRdd, schema)
+
+    df.saveToEs(config("single-write"))
+
+    val doubleWritesConfig = config("double-write")
+    df.saveToEs(doubleWritesConfig)
+    df.saveToEs(doubleWritesConfig)
+
+    val readWriteConfig = config("read-write")
+    df.saveToEs(readWriteConfig)
+    val outputDf = sqc.esDF(readWriteConfig)
+
+    import org.elasticsearch.hadoop.mr.Counter._
+    assertEquals(inputRdd.count(), EsSparkAccumulators.get("single-write", DOCS_SENT))
+    assertEquals(inputRdd.count() * 2, EsSparkAccumulators.get("double-write", DOCS_SENT))
+    assertEquals(inputRdd.count(), EsSparkAccumulators.get("read-write", DOCS_SENT))
+    assertEquals(0, EsSparkAccumulators.get("read-write", DOCS_RECEIVED)) // lazy reads before the action count
+    assertEquals(outputDf.count(), EsSparkAccumulators.get("read-write", DOCS_RECEIVED))
+    assertEquals(outputDf.count() * 2, EsSparkAccumulators.get("read-write", DOCS_RECEIVED))
+    EsSparkAccumulators.clear()
   }
 
   /**

--- a/spark/sql-30/src/main/scala/org/elasticsearch/spark/sql/EsSparkSQL.scala
+++ b/spark/sql-30/src/main/scala/org/elasticsearch/spark/sql/EsSparkSQL.scala
@@ -32,6 +32,7 @@ import org.elasticsearch.hadoop.mr.security.HadoopUserProvider
 import org.elasticsearch.hadoop.rest.InitializationUtils
 import org.elasticsearch.hadoop.util.ObjectUtils
 import org.elasticsearch.spark.cfg.SparkSettingsManager
+import org.elasticsearch.spark.acc.EsSparkAccumulators
 
 import scala.collection.JavaConverters.mapAsJavaMapConverter
 import scala.collection.JavaConverters.propertiesAsScalaMapConverter
@@ -93,6 +94,7 @@ object EsSparkSQL {
       val sparkCfg = new SparkSettingsManager().load(sparkCtx.getConf)
       val esCfg = new PropertiesSettings().load(sparkCfg.save())
       esCfg.merge(cfg.asJava)
+      EsSparkAccumulators.build(sparkCtx, esCfg.getMetricsPrefix)
 
       // Need to discover ES Version before checking index existence
       InitializationUtils.setUserProviderIfNotSet(esCfg, classOf[HadoopUserProvider], LOG)


### PR DESCRIPTION
Counters was present for Hadoop Map Reduce, but Accumulators for Spark
not.

The goal of this pull request is to add it.
