### PR TITLE
[8.11] [DOCS] Add 8.11.1 release notes (#2160)

### DIFF
--- a/docs/src/reference/asciidoc/appendix/release-notes/8.11.1.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/8.11.1.adoc
@@ -1,0 +1,8 @@
+[[eshadoop-8.11.1]]
+== Elasticsearch for Apache Hadoop version 8.11.1
+
+[[enhancements-8.11.1]]
+=== Enhancements
+Spark::
+* Upgrade to Spark 3.3.3
+https://github.com/elastic/elasticsearch-hadoop/pull/2148[#2148]

--- a/docs/src/reference/asciidoc/appendix/release.adoc
+++ b/docs/src/reference/asciidoc/appendix/release.adoc
@@ -9,6 +9,7 @@ This section summarizes the changes in each release.
 [[release-notes-8]]
 ===== 8.x
 
+* <<eshadoop-8.11.1>>
 * <<eshadoop-8.11.0>>
 * <<eshadoop-8.10.4>>
 * <<eshadoop-8.10.3>>
@@ -95,6 +96,7 @@ Elasticsearch 5.3.1.
 
 ////////////////////////
 
+include::release-notes/8.11.1.adoc[]
 include::release-notes/8.11.0.adoc[]
 include::release-notes/8.10.4.adoc[]
 include::release-notes/8.10.3.adoc[]


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.11`:
 - [[DOCS] Add 8.11.1 release notes (#2160)](https://github.com/elastic/elasticsearch-hadoop/pull/2160)

<!--- Backport version: 8.4.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)