### PR TITLE
[7.17] Fix incompatibility to TestClusterAware api change (#2163)

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/fixture/hadoop/tasks/DfsCopy.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/fixture/hadoop/tasks/DfsCopy.groovy
@@ -27,7 +27,7 @@ import org.gradle.api.file.CopySpec
 import org.gradle.api.tasks.TaskAction
 import org.gradle.process.ExecSpec
 
-class DfsCopy extends AbstractClusterTask {
+abstract class DfsCopy extends AbstractClusterTask {
 
     File dfsSource
     File localSource

--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/fixture/hadoop/tasks/HadoopMRJob.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/fixture/hadoop/tasks/HadoopMRJob.groovy
@@ -28,7 +28,7 @@ import org.gradle.process.ExecSpec
 
 import static org.elasticsearch.hadoop.gradle.util.ObjectUtil.unapplyString
 
-class HadoopMRJob extends AbstractClusterTask {
+abstract class HadoopMRJob extends AbstractClusterTask {
 
     String jobClass
     File jobJar

--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/fixture/hadoop/tasks/HiveBeeline.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/fixture/hadoop/tasks/HiveBeeline.groovy
@@ -28,7 +28,7 @@ import org.gradle.process.ExecSpec
 
 import static org.elasticsearch.hadoop.gradle.fixture.hadoop.conf.SettingsContainer.FileSettings
 
-class HiveBeeline extends AbstractClusterTask {
+abstract class HiveBeeline extends AbstractClusterTask {
 
     File script
     List<File> libJars = []

--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/fixture/hadoop/tasks/SparkApp.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/fixture/hadoop/tasks/SparkApp.groovy
@@ -28,7 +28,7 @@ import org.gradle.process.ExecSpec
 
 import static org.elasticsearch.hadoop.gradle.util.ObjectUtil.unapplyString
 
-class SparkApp extends AbstractClusterTask {
+abstract class SparkApp extends AbstractClusterTask {
 
     enum Master {
         LOCAL, YARN, STANDALONE


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [Fix incompatibility to TestClusterAware api change (#2163)](https://github.com/elastic/elasticsearch-hadoop/pull/2163)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)