### PR TITLE
[7.17] Fix Gradle 8 deprecation warnings (#2071)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,12 +43,3 @@ if (project.hasProperty("find-artifact")) {
         }
     }
 }
-
-// Add a task in the project that collects all the dependencyReport data for each project
-// Concatenates the dependencies CSV files into a single file
-// usage: ./gradlew :dist:generateDependenciesReport -Dcsv=/tmp/deps.csv
-task generateDependenciesReport(type: ConcatFilesTask) {
-    files = fileTree(dir: project.rootDir,  include: '**/dependencies.csv' )
-    headerLine = "name,version,url,license"
-    target = new File(System.getProperty('csv')?: "${project.buildDir}/reports/dependencies/es-hadoop-dependencies.csv")
-}

--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/BuildPlugin.groovy
@@ -512,18 +512,12 @@ class BuildPlugin implements Plugin<Project> {
         pack.dependsOn(project.tasks.jar)
         pack.dependsOn(project.tasks.javadocJar)
         pack.dependsOn(project.tasks.sourcesJar)
-        pack.outputs.files(project.tasks.jar.getArchiveFile(), project.tasks.javadocJar.getArchiveFile(), project.tasks.sourcesJar.getArchiveFile().get().getAsFile())
         project.getPlugins().withType(SparkVariantPlugin).whenPluginAdded {
             SparkVariantPluginExtension sparkVariants = project.getExtensions().getByType(SparkVariantPluginExtension.class)
             sparkVariants.featureVariants { SparkVariant variant ->
                 pack.dependsOn(project.tasks.getByName(variant.taskName('jar')))
                 pack.dependsOn(project.tasks.getByName(variant.taskName('javadocJar')))
                 pack.dependsOn(project.tasks.getByName(variant.taskName('sourcesJar')))
-                pack.outputs.files(
-                        project.tasks.getByName(variant.taskName('jar')).getArchiveFile().get().getAsFile(),
-                        project.tasks.getByName(variant.taskName('javadocJar')).getArchiveFile().get().getAsFile(),
-                        project.tasks.getByName(variant.taskName('sourcesJar')).getArchiveFile().get().getAsFile()
-                )
             }
         }
 

--- a/buildSrc/src/main/java/org/elasticsearch/hadoop/gradle/buildtools/ConcatFilesTask.java
+++ b/buildSrc/src/main/java/org/elasticsearch/hadoop/gradle/buildtools/ConcatFilesTask.java
@@ -25,6 +25,7 @@ import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction;
+import org.gradle.api.file.ConfigurableFileCollection;
 
 import java.io.File;
 import java.io.IOException;
@@ -38,14 +39,11 @@ import java.util.List;
 /**
  * Concatenates a list of files into one and removes duplicate lines.
  */
-public class ConcatFilesTask extends DefaultTask {
+public abstract class ConcatFilesTask extends DefaultTask {
 
     public ConcatFilesTask() {
         setDescription("Concat a list of files into one.");
     }
-
-    /** List of files to concatenate */
-    private FileTree files;
 
     /** line to add at the top of the target file */
     private String headerLine;
@@ -54,14 +52,9 @@ public class ConcatFilesTask extends DefaultTask {
 
     private List<String> additionalLines = new ArrayList<>();
 
-    public void setFiles(FileTree files) {
-        this.files = files;
-    }
-
+    /** List of files to concatenate */
     @InputFiles
-    public FileTree getFiles() {
-        return files;
-    }
+    public abstract ConfigurableFileCollection getFiles();
 
     public void setHeaderLine(String headerLine) {
         this.headerLine = headerLine;

--- a/dist/build.gradle
+++ b/dist/build.gradle
@@ -183,9 +183,13 @@ distribution {
 
 // Add a task in the root project that collects all the dependencyReport data for each project
 // Concatenates the dependencies CSV files into a single file
-task generateDependenciesReport(type: ConcatFilesTask) {
-    dependsOn rootProject.allprojects.collect { it.tasks.withType(DependenciesInfoTask) }
-    files = fileTree(dir: project.rootDir,  include: '**/dependencies.csv' )
+task generateDependenciesReport(type: ConcatFilesTask) { concatDepsTask ->
+    rootProject.allprojects.collect { 
+        it.tasks.withType(DependenciesInfoTask) { depTask ->
+            concatDepsTask.dependsOn depTask
+            concatDepsTask.getFiles().from(depTask.outputFile)
+        }
+    }
     headerLine = "name,version,url,license"
     target = new File(System.getProperty('csv')?: "${project.buildDir}/reports/dependencies/es-hadoop-dependencies.csv")
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [Fix Gradle 8 deprecation warnings (#2071)](https://github.com/elastic/elasticsearch-hadoop/pull/2071)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)