### PR TITLE
[7.17] Update gradle wrapper to 8.2 (#2109)

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/BuildPlugin.groovy
@@ -330,8 +330,8 @@ class BuildPlugin implements Plugin<Project> {
      */
     private static void configureBuildTasks(Project project) {
         // Target Java 1.8 compilation
-        project.sourceCompatibility = '1.8'
-        project.targetCompatibility = '1.8'
+        project.java.sourceCompatibility = '1.8'
+        project.java.targetCompatibility = '1.8'
 
         // TODO: Remove all root project distribution logic. It should exist in a separate dist project.
         if (project != project.rootProject) {
@@ -737,7 +737,7 @@ class BuildPlugin implements Plugin<Project> {
     private static void updateVariantPomLocationAndArtifactId(Project project, MavenPublication publication, SparkVariant variant) {
         // Add variant classifier to the pom file name if required
         String classifier = variant.shouldClassifySparkVersion() && variant.isDefaultVariant() == false ? "-${variant.getName()}" : ''
-        String filename = "${project.archivesBaseName}_${variant.scalaMajorVersion}-${project.getVersion()}${classifier}"
+        String filename = "${project.base.archivesName}_${variant.scalaMajorVersion}-${project.getVersion()}${classifier}"
         // Fix the pom name
         project.tasks.withType(GenerateMavenPom).all { GenerateMavenPom pom ->
             if (pom.name == "generatePomFileFor${publication.name.capitalize()}Publication") {

--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/fixture/hadoop/conf/HadoopClusterConfiguration.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/fixture/hadoop/conf/HadoopClusterConfiguration.groovy
@@ -27,7 +27,7 @@ import org.elasticsearch.hadoop.gradle.fixture.hadoop.services.SparkYarnServiceD
 import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.api.Task
-import org.gradle.util.ConfigureUtil
+import org.elasticsearch.hadoop.gradle.util.ConfigureUtil
 
 /**
  * Configuration for a Hadoop cluster, used for integration tests.

--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/fixture/hadoop/conf/ProcessConfiguration.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/fixture/hadoop/conf/ProcessConfiguration.groovy
@@ -23,7 +23,7 @@ import org.elasticsearch.gradle.testclusters.ElasticsearchCluster
 import org.gradle.api.InvalidUserDataException
 import org.gradle.api.Project
 import org.gradle.api.Task
-import org.gradle.util.ConfigureUtil
+import org.elasticsearch.hadoop.gradle.util.ConfigureUtil
 
 /**
  * All the configurations that can be set hierarchically for a cluster.

--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/fixture/hadoop/conf/RoleConfiguration.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/fixture/hadoop/conf/RoleConfiguration.groovy
@@ -23,7 +23,7 @@ import org.elasticsearch.hadoop.gradle.fixture.hadoop.RoleDescriptor
 import org.gradle.api.GradleException
 import org.gradle.api.GradleScriptException
 import org.gradle.api.Project
-import org.gradle.util.ConfigureUtil
+import org.elasticsearch.hadoop.gradle.util.ConfigureUtil
 
 /**
  * Shared configurations for all instances of a role within a Hadoop service.

--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/fixture/hadoop/conf/ServiceConfiguration.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/fixture/hadoop/conf/ServiceConfiguration.groovy
@@ -24,7 +24,7 @@ import org.elasticsearch.hadoop.gradle.fixture.hadoop.RoleDescriptor
 import org.elasticsearch.hadoop.gradle.fixture.hadoop.ServiceDescriptor
 import org.gradle.api.GradleException
 import org.gradle.api.Project
-import org.gradle.util.ConfigureUtil
+import org.elasticsearch.hadoop.gradle.util.ConfigureUtil
 
 /**
  * Handles configurations for a sub-cluster of services within the larger Hadoop cluster.

--- a/buildSrc/src/main/java/org/elasticsearch/hadoop/gradle/buildtools/info/GlobalBuildInfoPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/hadoop/gradle/buildtools/info/GlobalBuildInfoPlugin.java
@@ -29,11 +29,17 @@ import org.gradle.api.logging.Logging;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderFactory;
 import org.gradle.internal.jvm.Jvm;
+import org.gradle.internal.jvm.inspection.JavaInstallationRegistry;
 import org.gradle.internal.jvm.inspection.JvmInstallationMetadata;
 import org.gradle.internal.jvm.inspection.JvmMetadataDetector;
 import org.gradle.internal.jvm.inspection.JvmVendor;
+import org.gradle.jvm.toolchain.JavaLanguageVersion;
+import org.gradle.jvm.toolchain.JavaLauncher;
+import org.gradle.jvm.toolchain.JavaToolchainService;
+import org.gradle.jvm.toolchain.JavaToolchainSpec;
+import org.gradle.jvm.toolchain.JvmVendorSpec;
 import org.gradle.jvm.toolchain.internal.InstallationLocation;
-import org.gradle.jvm.toolchain.internal.JavaInstallationRegistry;
+
 import org.gradle.util.GradleVersion;
 
 import javax.inject.Inject;
@@ -193,7 +199,7 @@ public class GlobalBuildInfoPlugin implements Plugin<Project> {
 
     private Stream<InstallationLocation> getAvailableJavaInstallationLocationSteam() {
         return Stream.concat(
-            javaInstallationRegistry.listInstallations().stream(),
+            javaInstallationRegistry.toolchains().stream().map(metadata -> metadata.location),
             Stream.of(new InstallationLocation(Jvm.current().getJavaHome(), "Current JVM"))
         );
     }

--- a/dist/build.gradle
+++ b/dist/build.gradle
@@ -6,7 +6,10 @@ import org.elasticsearch.hadoop.gradle.BuildPlugin
 apply plugin: 'es.hadoop.build'
 
 description = "Elasticsearch for Apache Hadoop"
-project.archivesBaseName = 'elasticsearch-hadoop'
+
+base {
+  archivesName = 'elasticsearch-hadoop'
+}
 
 def sparkVariantIncluded = 'spark20scala211'
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=a62c5f99585dd9e1f95dab7b9415a0e698fa9dd1e6c38537faa81ac078f4d23e
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.1-bin.zip
+distributionSha256Sum=38f66cd6eef217b4c35855bb11ea4e9fbc53594ccccb5fb82dfd317ef8c2c5a3
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,6 @@
 pluginManagement {
   plugins {
-    id 'com.github.johnrengelman.shadow' version "8.1.0"
+    id 'com.github.johnrengelman.shadow' version "8.1.1"
   }
 }
 

--- a/test/fixtures/minikdc/build.gradle
+++ b/test/fixtures/minikdc/build.gradle
@@ -33,8 +33,10 @@ dependencies {
 }
 
 // Target Java 1.8 compilation
-sourceCompatibility = '1.8'
-targetCompatibility = '1.8'
+java {
+    sourceCompatibility = '1.8'
+    targetCompatibility = '1.8'
+}
 
 // for testing, until fixture are actually debuggable.
 // gradle hides EVERYTHING so you have no clue what went wrong.


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [Update gradle wrapper to 8.2 (#2109)](https://github.com/elastic/elasticsearch-hadoop/pull/2109)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)