### PR TITLE
[7.17] Fix pom file naming after Gradle update (#2115)

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/BuildPlugin.groovy
@@ -62,6 +62,8 @@ import org.gradle.external.javadoc.JavadocOutputLevel
 import org.gradle.external.javadoc.MinimalJavadocOptions
 import org.gradle.plugins.ide.eclipse.EclipsePlugin
 import org.gradle.plugins.ide.idea.IdeaPlugin
+import org.gradle.api.plugins.BasePluginExtension
+
 import org.w3c.dom.NodeList
 
 import javax.inject.Inject
@@ -678,7 +680,8 @@ class BuildPlugin implements Plugin<Project> {
         // Set the pom's destination to the distribution directory
         project.tasks.withType(GenerateMavenPom).all { GenerateMavenPom pom ->
             if (pom.name == "generatePomFileFor${publication.name.capitalize()}Publication") {
-                pom.destination = project.provider({"${project.buildDir}/distributions/${project.archivesBaseName}-${project.getVersion()}.pom"})
+                BasePluginExtension baseExtension = project.getExtensions().getByType(BasePluginExtension.class);
+                pom.destination = project.provider({"${project.buildDir}/distributions/${baseExtension.archivesName.get()}-${project.getVersion()}.pom"})
             }
         }
 
@@ -737,7 +740,8 @@ class BuildPlugin implements Plugin<Project> {
     private static void updateVariantPomLocationAndArtifactId(Project project, MavenPublication publication, SparkVariant variant) {
         // Add variant classifier to the pom file name if required
         String classifier = variant.shouldClassifySparkVersion() && variant.isDefaultVariant() == false ? "-${variant.getName()}" : ''
-        String filename = "${project.base.archivesName}_${variant.scalaMajorVersion}-${project.getVersion()}${classifier}"
+        BasePluginExtension baseExtension = project.getExtensions().getByType(BasePluginExtension.class);
+        String filename = "${baseExtension.archivesName.get()}_${variant.scalaMajorVersion}-${project.getVersion()}${classifier}"
         // Fix the pom name
         project.tasks.withType(GenerateMavenPom).all { GenerateMavenPom pom ->
             if (pom.name == "generatePomFileFor${publication.name.capitalize()}Publication") {
@@ -748,7 +752,7 @@ class BuildPlugin implements Plugin<Project> {
         publication.getPom().withXml { XmlProvider xml ->
             Node root = xml.asNode()
             Node artifactId = (root.get('artifactId') as NodeList).get(0) as Node
-            artifactId.setValue("${project.archivesBaseName}_${variant.scalaMajorVersion}")
+            artifactId.setValue("${baseExtension.archivesName.get()}_${variant.scalaMajorVersion}")
         }
     }
 

--- a/dist/build.gradle
+++ b/dist/build.gradle
@@ -2,6 +2,7 @@ import org.elasticsearch.hadoop.gradle.buildtools.ConcatFilesTask
 import org.elasticsearch.hadoop.gradle.buildtools.DependenciesInfoTask
 import org.elasticsearch.hadoop.gradle.buildtools.DependencyLicensesTask
 import org.elasticsearch.hadoop.gradle.BuildPlugin
+import org.gradle.api.plugins.BasePluginExtension
 
 apply plugin: 'es.hadoop.build'
 
@@ -147,9 +148,10 @@ publishing {
                 Node repository = repositories.appendNode('repository')
                 repository.appendNode('id', 'clojars.org')
                 repository.appendNode('url', 'https://clojars.org/repo')
+                BasePluginExtension baseExtension = project.getExtensions().getByType(BasePluginExtension.class)
 
                 // Correct the artifact Id, otherwise it is listed as 'dist'
-                root.get('artifactId').get(0).setValue(project.archivesBaseName)
+                root.get('artifactId').get(0).setValue(baseExtension.archivesName.get())
             }
         }
     }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [Fix pom file naming after Gradle update (#2115)](https://github.com/elastic/elasticsearch-hadoop/pull/2115)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)