### PR TITLE
[8.11] [DOCS] Add 8.11.2 release notes (#2180)

### DIFF
--- a/docs/src/reference/asciidoc/appendix/release-notes/8.11.2.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/8.11.2.adoc
@@ -1,0 +1,9 @@
+[[eshadoop-8.11.2]]
+== Elasticsearch for Apache Hadoop version 8.11.2
+
+[[bugs-8.11.2]]
+=== Bug Fixes
+Spark::
+* Nested objects fail parsing in Spark SQL when empty objects present
+https://github.com/elastic/elasticsearch-hadoop/issues/2157[#2157]
+https://github.com/elastic/elasticsearch-hadoop/pull/2158[#2158]

--- a/docs/src/reference/asciidoc/appendix/release.adoc
+++ b/docs/src/reference/asciidoc/appendix/release.adoc
@@ -9,6 +9,7 @@ This section summarizes the changes in each release.
 [[release-notes-8]]
 ===== 8.x
 
+* <<eshadoop-8.11.2>>
 * <<eshadoop-8.11.1>>
 * <<eshadoop-8.11.0>>
 * <<eshadoop-8.10.4>>
@@ -96,6 +97,7 @@ Elasticsearch 5.3.1.
 
 ////////////////////////
 
+include::release-notes/8.11.2.adoc[]
 include::release-notes/8.11.1.adoc[]
 include::release-notes/8.11.0.adoc[]
 include::release-notes/8.10.4.adoc[]


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.11`:
 - [[DOCS] Add 8.11.2 release notes (#2180)](https://github.com/elastic/elasticsearch-hadoop/pull/2180)

<!--- Backport version: 8.4.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)