### PR TITLE
[8.12] [DOCS] Add 8.12.0 release notes (#2192)

### DIFF
--- a/docs/src/reference/asciidoc/appendix/release-notes/8.12.0.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/8.12.0.adoc
@@ -1,0 +1,13 @@
+[[eshadoop-8.12.0]]
+== Elasticsearch for Apache Hadoop version 8.12.0
+
+[[bugs-8.12.0]]
+=== Bug Fixes
+Core::
+* Correctly handling EsHadoopException in TransportPool.validate()
+https://github.com/elastic/elasticsearch-hadoop/pull/2150[#2150]
+Spark::
+* Nested objects fail parsing in Spark SQL when empty objects present
+https://github.com/elastic/elasticsearch-hadoop/issues/2157[#2157]
+* Always resolve current field name in SparkSQL when creating Row objects inside of arrays
+https://github.com/elastic/elasticsearch-hadoop/pull/2158[#2158]

--- a/docs/src/reference/asciidoc/appendix/release.adoc
+++ b/docs/src/reference/asciidoc/appendix/release.adoc
@@ -9,6 +9,7 @@ This section summarizes the changes in each release.
 [[release-notes-8]]
 ===== 8.x
 
+* <<eshadoop-8.12.0>>
 * <<eshadoop-8.11.4>>
 * <<eshadoop-8.11.3>>
 * <<eshadoop-8.11.2>>
@@ -99,6 +100,7 @@ Elasticsearch 5.3.1.
 
 ////////////////////////
 
+include::release-notes/8.12.0.adoc[]
 include::release-notes/8.11.4.adoc[]
 include::release-notes/8.11.3.adoc[]
 include::release-notes/8.11.2.adoc[]


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.12`:
 - [[DOCS] Add 8.12.0 release notes (#2192)](https://github.com/elastic/elasticsearch-hadoop/pull/2192)

<!--- Backport version: 8.4.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)