### PR TITLE
[8.14] [DOCS] Add 8.14.0 release notes (#2233)

### DIFF
--- a/docs/src/reference/asciidoc/appendix/release-notes/8.14.0.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/8.14.0.adoc
@@ -1,0 +1,13 @@
+[[eshadoop-8.14.0]]
+== Elasticsearch for Apache Hadoop version 8.14.0
+
+[[enhancements-5.3.1]]
+=== Enhancements
+* Updating scala, spark, and hadoop to supported versions
+https://github.com/elastic/elasticsearch-hadoop/pull/2215[#2215]
+
+[[bugs-5.3.1]]
+=== Bug Fixes
+REST::
+* Handling a race condition that can happen during index creation
+https://github.com/elastic/elasticsearch-hadoop/pull/2216[#2216]

--- a/docs/src/reference/asciidoc/appendix/release.adoc
+++ b/docs/src/reference/asciidoc/appendix/release.adoc
@@ -9,6 +9,7 @@ This section summarizes the changes in each release.
 [[release-notes-8]]
 ===== 8.x
 
+* <<eshadoop-8.14.0>>
 * <<eshadoop-8.13.4>>
 * <<eshadoop-8.13.3>>
 * <<eshadoop-8.13.2>>
@@ -107,6 +108,7 @@ Elasticsearch 5.3.1.
 
 ////////////////////////
 
+include::release-notes/8.14.0.adoc[]
 include::release-notes/8.13.4.adoc[]
 include::release-notes/8.13.3.adoc[]
 include::release-notes/8.13.2.adoc[]


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.14`:
 - [[DOCS] Add 8.14.0 release notes (#2233)](https://github.com/elastic/elasticsearch-hadoop/pull/2233)

<!--- Backport version: 8.4.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)