### PR TITLE
[8.14] [DOCS] Add 8.14.1 release notes (#2239)

### DIFF
--- a/docs/src/reference/asciidoc/appendix/release-notes/8.14.1.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/8.14.1.adoc
@@ -1,0 +1,5 @@
+[[eshadoop-8.14.1]]
+== Elasticsearch for Apache Hadoop version 8.14.1
+
+ES-Hadoop 8.14.1 is a version compatibility release, tested specifically against
+Elasticsearch 8.14.1.

--- a/docs/src/reference/asciidoc/appendix/release.adoc
+++ b/docs/src/reference/asciidoc/appendix/release.adoc
@@ -9,6 +9,7 @@ This section summarizes the changes in each release.
 [[release-notes-8]]
 ===== 8.x
 
+* <<eshadoop-8.14.1>>
 * <<eshadoop-8.14.0>>
 * <<eshadoop-8.13.4>>
 * <<eshadoop-8.13.3>>
@@ -108,6 +109,7 @@ Elasticsearch 5.3.1.
 
 ////////////////////////
 
+include::release-notes/8.14.1.adoc[]
 include::release-notes/8.14.0.adoc[]
 include::release-notes/8.13.4.adoc[]
 include::release-notes/8.13.3.adoc[]


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.14`:
 - [[DOCS] Add 8.14.1 release notes (#2239)](https://github.com/elastic/elasticsearch-hadoop/pull/2239)

<!--- Backport version: 8.4.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)