### PR TITLE
[7.17] Update Gradle wrapper to 8.8 (#2232)

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/BuildPlugin.groovy
@@ -70,6 +70,15 @@ import javax.inject.Inject
 
 import static org.elasticsearch.hadoop.gradle.scala.SparkVariantPlugin.SparkVariantPluginExtension
 import static org.elasticsearch.hadoop.gradle.scala.SparkVariantPlugin.SparkVariant
+import org.gradle.api.artifacts.ResolvableDependencies;
+import org.gradle.api.artifacts.component.ComponentIdentifier;
+import org.gradle.api.artifacts.result.ResolvedComponentResult;
+import org.gradle.api.artifacts.result.ResolvedDependencyResult;
+import org.gradle.api.file.FileCollection;
+import org.gradle.api.specs.AndSpec;
+import org.gradle.api.specs.Spec;
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
+import java.util.stream.Collectors;
 
 class BuildPlugin implements Plugin<Project> {
 
@@ -853,10 +862,8 @@ class BuildPlugin implements Plugin<Project> {
         precommitTasks.add(licenseHeaders)
 
         if (!project.path.startsWith(":qa")) {
-            TaskProvider<DependencyLicensesTask> dependencyLicenses = project.tasks.register('dependencyLicenses', DependencyLicensesTask.class) {
-                dependencies = project.configurations.runtimeClasspath.fileCollection {
-                    !(it instanceof ProjectDependency)
-                }
+            TaskProvider<DependencyLicensesTask> dependencyLicenses = project.tasks.register('dependencyLicenses', DependencyLicensesTask.class) {                
+                dependencies = project.configurations.runtimeClasspath
                 mapping from: /hadoop-.*/, to: 'hadoop'
                 mapping from: /hive-.*/, to: 'hive'
                 mapping from: /jackson-.*/, to: 'jackson'

--- a/buildSrc/src/main/java/org/elasticsearch/hadoop/gradle/buildtools/info/GlobalBuildInfoPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/hadoop/gradle/buildtools/info/GlobalBuildInfoPlugin.java
@@ -200,7 +200,7 @@ public class GlobalBuildInfoPlugin implements Plugin<Project> {
     private Stream<InstallationLocation> getAvailableJavaInstallationLocationSteam() {
         return Stream.concat(
             javaInstallationRegistry.toolchains().stream().map(metadata -> metadata.location),
-            Stream.of(new InstallationLocation(Jvm.current().getJavaHome(), "Current JVM"))
+            Stream.of(InstallationLocation.userDefined(Jvm.current().getJavaHome(), "Current JVM"))
         );
     }
 

--- a/dist/build.gradle
+++ b/dist/build.gradle
@@ -200,7 +200,5 @@ task generateDependenciesReport(type: ConcatFilesTask) { concatDepsTask ->
 }
 
 project.tasks.named('dependencyLicenses', DependencyLicensesTask) {
-    it.dependencies = project.configurations.licenseChecks.fileCollection {
-        !(it instanceof ProjectDependency)
-    }
+    it.dependencies = project.configurations.licenseChecks
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=9d926787066a081739e8200858338b4a69e837c3a821a33aca9db09dd4a41026
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+distributionSha256Sum=a4b4158601f8636cdeeab09bd76afb640030bb5b144aafe261a5e8af027dc612
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/gradlew
+++ b/gradlew
@@ -55,7 +55,7 @@
 #       Darwin, MinGW, and NonStop.
 #
 #   (3) This script is generated from the Groovy template
-#       https://github.com/gradle/gradle/blob/HEAD/subprojects/plugins/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
+#       https://github.com/gradle/gradle/blob/HEAD/platforms/jvm/plugins-application/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
 #       within the Gradle project.
 #
 #       You can find Gradle at https://github.com/gradle/gradle/.

--- a/thirdparty/build.gradle
+++ b/thirdparty/build.gradle
@@ -1,9 +1,25 @@
 import org.elasticsearch.hadoop.gradle.BuildPlugin
 
+
+
+buildscript {
+  repositories {
+    maven {
+      url 'https://jitpack.io'
+    }
+    mavenCentral()
+  }
+  dependencies {
+    classpath 'com.github.breskeby:shadow:3b035f2'
+  }
+}
+
 plugins {
-    id 'com.github.johnrengelman.shadow'
     id 'es.hadoop.build'
 }
+
+apply plugin: 'com.github.johnrengelman.shadow'
+
 
 description = "Elasticsearch Hadoop Shaded Third-Party Libraries"
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [Update Gradle wrapper to 8.8 (#2232)](https://github.com/elastic/elasticsearch-hadoop/pull/2232)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)