### PR TITLE
[8.15] [DOCS] Add 8.15.0 release notes (#2253)

### DIFF
--- a/docs/src/reference/asciidoc/appendix/release-notes/8.15.0.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/8.15.0.adoc
@@ -1,0 +1,11 @@
+[[eshadoop-8.15.0]]
+== Elasticsearch for Apache Hadoop version 8.15.0
+
+[[enhancements-8.15.0]]
+=== Enhancements
+Build::
+* Upgrade Spark to 3.4.3 and Hive to 3.1.3
+https://github.com/elastic/elasticsearch-hadoop/pull/2231[#2231]
+Spark::
+* Clean up Spark dependency lists
+https://github.com/elastic/elasticsearch-hadoop/pull/2217[#2217]

--- a/docs/src/reference/asciidoc/appendix/release.adoc
+++ b/docs/src/reference/asciidoc/appendix/release.adoc
@@ -9,6 +9,7 @@ This section summarizes the changes in each release.
 [[release-notes-8]]
 ===== 8.x
 
+* <<eshadoop-8.15.0>>
 * <<eshadoop-8.14.3>>
 * <<eshadoop-8.14.2>>
 * <<eshadoop-8.14.1>>
@@ -111,6 +112,7 @@ Elasticsearch 5.3.1.
 
 ////////////////////////
 
+include::release-notes/8.15.0.adoc[]
 include::release-notes/8.14.3.adoc[]
 include::release-notes/8.14.2.adoc[]
 include::release-notes/8.14.1.adoc[]


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.15`:
 - [[DOCS] Add 8.15.0 release notes (#2253)](https://github.com/elastic/elasticsearch-hadoop/pull/2253)

<!--- Backport version: 8.4.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)