### PR TITLE
Update java build and runtime from 17 to 21

### DIFF
--- a/.ci/java-versions.properties
+++ b/.ci/java-versions.properties
@@ -6,5 +6,5 @@
 # build and test Elasticsearch for this branch. Valid Java versions
 # are 'java' or 'openjdk' followed by the major release number.
 
-ESH_BUILD_JAVA=openjdk17
-ESH_RUNTIME_JAVA=openjdk17
+ESH_BUILD_JAVA=openjdk21
+ESH_RUNTIME_JAVA=openjdk21

--- a/mr/src/main/java/org/elasticsearch/hadoop/util/EsMajorVersion.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/util/EsMajorVersion.java
@@ -36,7 +36,8 @@ public class EsMajorVersion implements Serializable {
     public static final EsMajorVersion V_6_X = new EsMajorVersion((byte) 6, "6.x");
     public static final EsMajorVersion V_7_X = new EsMajorVersion((byte) 7, "7.x");
     public static final EsMajorVersion V_8_X = new EsMajorVersion((byte) 8, "8.x");
-    public static final EsMajorVersion LATEST = V_8_X;
+    public static final EsMajorVersion V_9_X = new EsMajorVersion((byte) 9, "9.x");
+    public static final EsMajorVersion LATEST = V_9_X;
 
     public final byte major;
     private final String version;
@@ -91,6 +92,9 @@ public class EsMajorVersion implements Serializable {
         }
         if (version.startsWith("8.")) {
             return new EsMajorVersion((byte) 8, version);
+        }
+        if (version.startsWith("9.")) {
+            return new EsMajorVersion((byte) 9, version);
         }
         throw new EsHadoopIllegalArgumentException("Unsupported/Unknown Elasticsearch version [" + version + "]." +
                 "Highest supported version is [" + LATEST.version + "]. You may need to upgrade ES-Hadoop.");

--- a/mr/src/test/java/org/elasticsearch/hadoop/serialization/CommandTest.java
+++ b/mr/src/test/java/org/elasticsearch/hadoop/serialization/CommandTest.java
@@ -59,7 +59,7 @@ public class CommandTest {
     public static Collection<Object[]> data() {
 
         // make sure all versions are tested. Throw if a new one is seen:
-        if (EsMajorVersion.LATEST != EsMajorVersion.V_8_X) {
+        if (EsMajorVersion.LATEST != EsMajorVersion.V_9_X) {
             throw new IllegalStateException("CommandTest needs new version updates.");
         }
 
@@ -76,7 +76,8 @@ public class CommandTest {
                 EsMajorVersion.V_5_X,
                 EsMajorVersion.V_6_X,
                 EsMajorVersion.V_7_X,
-                EsMajorVersion.V_8_X};
+                EsMajorVersion.V_8_X,
+                EsMajorVersion.V_9_X};
 
         for (EsMajorVersion version : versions) {
             for (boolean asJson : asJsons) {


### PR DESCRIPTION
stay in sync with minimum java version used by elasticsearch