### PR TITLE
[8.x] [DOCS] Add 8.16.0 release notes (#2283)

### DIFF
--- a/docs/src/reference/asciidoc/appendix/release-notes/8.16.0.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/8.16.0.adoc
@@ -1,0 +1,5 @@
+[[eshadoop-8.16.0]]
+== Elasticsearch for Apache Hadoop version 8.16.0
+
+ES-Hadoop 8.16.0 is a version compatibility release, tested specifically against
+Elasticsearch 8.16.0.

--- a/docs/src/reference/asciidoc/appendix/release.adoc
+++ b/docs/src/reference/asciidoc/appendix/release.adoc
@@ -9,6 +9,7 @@ This section summarizes the changes in each release.
 [[release-notes-8]]
 ===== 8.x
 
+* <<eshadoop-8.16.0>>
 * <<eshadoop-8.15.4>>
 * <<eshadoop-8.15.3>>
 * <<eshadoop-8.15.1>>
@@ -115,6 +116,7 @@ Elasticsearch 5.3.1.
 
 ////////////////////////
 
+include::release-notes/8.16.0.adoc[]
 include::release-notes/8.15.4.adoc[]
 include::release-notes/8.15.3.adoc[]
 include::release-notes/8.15.1.adoc[]


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[DOCS] Add 8.16.0 release notes (#2283)](https://github.com/elastic/elasticsearch-hadoop/pull/2283)

<!--- Backport version: 8.4.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)