### PR TITLE
[8.17] [DOCS] Add 8.15.5 release notes (#2292)

### DIFF
--- a/docs/src/reference/asciidoc/appendix/release-notes/8.15.5.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/8.15.5.adoc
@@ -1,0 +1,5 @@
+[[eshadoop-8.15.5]]
+== Elasticsearch for Apache Hadoop version 8.15.5
+
+ES-Hadoop 8.15.5 is a version compatibility release, tested specifically against
+Elasticsearch 8.15.5.

--- a/docs/src/reference/asciidoc/appendix/release.adoc
+++ b/docs/src/reference/asciidoc/appendix/release.adoc
@@ -11,6 +11,7 @@ This section summarizes the changes in each release.
 
 * <<eshadoop-8.16.1>>
 * <<eshadoop-8.16.0>>
+* <<eshadoop-8.15.5>>
 * <<eshadoop-8.15.4>>
 * <<eshadoop-8.15.3>>
 * <<eshadoop-8.15.1>>
@@ -119,6 +120,7 @@ Elasticsearch 5.3.1.
 
 include::release-notes/8.16.1.adoc[]
 include::release-notes/8.16.0.adoc[]
+include::release-notes/8.15.5.adoc[]
 include::release-notes/8.15.4.adoc[]
 include::release-notes/8.15.3.adoc[]
 include::release-notes/8.15.1.adoc[]


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [[DOCS] Add 8.15.5 release notes (#2292)](https://github.com/elastic/elasticsearch-hadoop/pull/2292)

<!--- Backport version: 8.4.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)