### PR TITLE
[8.x] Update Gradle wrapper to 8.12 (#2306)

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -60,8 +60,8 @@ repositories {
         // For some reason the root dirs all point to the buildSrc folder. The local Repo will be one above that.
         flatDir { dirs new File(project.rootDir, "../localRepo") }
     } else {
-        maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
-        maven { url "https://artifacts-snapshot.elastic.co/elasticsearch/${esVersion}/maven" }
+        maven { url = "https://oss.sonatype.org/content/repositories/snapshots" }
+        maven { url = "https://artifacts-snapshot.elastic.co/elasticsearch/${esVersion}/maven" }
     }
 }
 

--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/BaseBuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/BaseBuildPlugin.groovy
@@ -163,20 +163,20 @@ class BaseBuildPlugin implements Plugin<Project> {
      */
     private static void configureRepositories(Project project) {
         project.repositories.mavenCentral()
-        project.repositories.maven { url "https://clojars.org/repo" }
+        project.repositories.maven { url = "https://clojars.org/repo" }
 
         // For Elasticsearch snapshots.
-        project.repositories.maven { url "https://snapshots.elastic.co/maven/" } // default
-        project.repositories.maven { url "https://oss.sonatype.org/content/repositories/snapshots" } // oss-only
+        project.repositories.maven { url = "https://snapshots.elastic.co/maven/" } // default
+        project.repositories.maven { url = "https://oss.sonatype.org/content/repositories/snapshots" } // oss-only
 
         // Elastic artifacts
-        project.repositories.maven { url "https://artifacts.elastic.co/maven/" } // default
-        project.repositories.maven { url "https://oss.sonatype.org/content/groups/public/" } // oss-only
+        project.repositories.maven { url = "https://artifacts.elastic.co/maven/" } // default
+        project.repositories.maven { url = "https://oss.sonatype.org/content/groups/public/" } // oss-only
 
         // Add Ivy repos in order to pull Elasticsearch distributions that have bundled JDKs
         for (String repo : ['snapshots', 'artifacts']) {
             project.repositories.ivy {
-                url "https://${repo}.elastic.co/downloads"
+                url = "https://${repo}.elastic.co/downloads"
                 patternLayout {
                     artifact "elasticsearch/[module]-[revision](-[classifier]).[ext]"
                 }
@@ -188,8 +188,8 @@ class BaseBuildPlugin implements Plugin<Project> {
             // Extract the revision number of the snapshot via regex:
             String revision = (project.ext.luceneVersion =~ /\w+-snapshot-([a-z0-9]+)/)[0][1]
             project.repositories.maven {
-                name 'lucene-snapshots'
-                url "https://s3.amazonaws.com/download.elasticsearch.org/lucenesnapshots/${revision}"
+                name = 'lucene-snapshots'
+                url = "https://s3.amazonaws.com/download.elasticsearch.org/lucenesnapshots/${revision}"
             }
         }
     }

--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/BuildPlugin.groovy
@@ -834,15 +834,15 @@ class BuildPlugin implements Plugin<Project>  {
         integrationTest.maxHeapSize = "2g"
 
         integrationTest.testLogging {
-            displayGranularity 0
+            displayGranularity = 0
             events "started", "failed" //, "standardOut", "standardError"
-            exceptionFormat "full"
-            showCauses true
-            showExceptions true
-            showStackTraces true
+            exceptionFormat = "full"
+            showCauses = true
+            showExceptions = true
+            showStackTraces = true
             stackTraceFilters "groovy"
-            minGranularity 2
-            maxGranularity 2
+            minGranularity = 2
+            maxGranularity = 2
         }
 
         integrationTest.reports.html.required = false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=2ab88d6de2c23e6adae7363ae6e29cbdd2a709e992929b48b6530fd0c7133bd6
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-all.zip
+distributionSha256Sum=7ebdac923867a3cec0098302416d1e3c6c0c729fc4e2e05c10637a8af33a76c5
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/qa/build.gradle
+++ b/qa/build.gradle
@@ -39,8 +39,8 @@ subprojects {
                 // For some reason the root dirs all point to the buildSrc folder. The local Repo will be one above that.
                 flatDir { dirs new File(project.rootProject.rootDir, "localRepo") }
             } else {
-                maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
-                maven { url "https://artifacts-snapshot.elastic.co/elasticsearch/${version}/maven" }
+                maven { url = "https://oss.sonatype.org/content/repositories/snapshots" }
+                maven { url = "https://artifacts-snapshot.elastic.co/elasticsearch/${version}/maven" }
             }
         }
         dependencies {

--- a/thirdparty/build.gradle
+++ b/thirdparty/build.gradle
@@ -5,7 +5,7 @@ import org.elasticsearch.hadoop.gradle.BuildPlugin
 buildscript {
   repositories {
     maven {
-      url 'https://jitpack.io'
+      url = 'https://jitpack.io'
     }
     mavenCentral()
   }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Update Gradle wrapper to 8.12 (#2306)](https://github.com/elastic/elasticsearch-hadoop/pull/2306)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)