### PR TITLE
[8.16] Fix download url of archived hive (#2291)

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/fixture/hadoop/HadoopFixturePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/fixture/hadoop/HadoopFixturePlugin.groovy
@@ -32,7 +32,7 @@ import org.gradle.api.publish.ivy.IvyArtifact
 
 class HadoopFixturePlugin implements Plugin<Project> {
 
-    private static final String APACHE_MIRROR = "https://apache.osuosl.org/"
+    private static final String APACHE_MIRROR = "https://archive.apache.org/dist/"
 
     static class HadoopFixturePluginExtension {
         private NamedDomainObjectContainer<HadoopClusterConfiguration> clusters


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.16`:
 - [Fix download url of archived hive (#2291)](https://github.com/elastic/elasticsearch-hadoop/pull/2291)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)