### PR TITLE
[8.17] [Gradle] Remove deprecated gradle api usage (#2321)

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/buildtools/AntFixture.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/buildtools/AntFixture.groovy
@@ -239,7 +239,7 @@ class AntFixture extends AntTask implements Fixture {
      */
     @Internal
     protected File getBaseDir() {
-        return new File(project.buildDir, "fixtures/${name}")
+        return new File(getProjectLayout().buildDirectory.getAsFile().get(), "fixtures/${name}")
     }
 
     /** Returns the working directory for the process. Defaults to "cwd" inside baseDir. */

--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/buildtools/AntTask.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/buildtools/AntTask.groovy
@@ -25,6 +25,7 @@ import org.apache.tools.ant.DefaultLogger
 import org.apache.tools.ant.Project
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.FileSystemOperations
+import org.gradle.api.file.ProjectLayout
 import org.gradle.api.tasks.TaskAction
 
 import javax.inject.Inject
@@ -45,6 +46,11 @@ abstract class AntTask extends DefaultTask {
 
     @Inject
     protected FileSystemOperations getFileSystemOperations() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Inject
+    protected ProjectLayout getProjectLayout() {
         throw new UnsupportedOperationException();
     }
 

--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/fixture/hadoop/tasks/HadoopMRJob.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/fixture/hadoop/tasks/HadoopMRJob.groovy
@@ -26,8 +26,12 @@ import org.gradle.api.GradleException
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskAction
+import org.gradle.process.ExecOperations
 import org.gradle.process.ExecSpec
+
+import javax.inject.Inject
 
 import static org.elasticsearch.hadoop.gradle.util.ObjectUtil.unapplyString
 
@@ -45,6 +49,14 @@ abstract class HadoopMRJob extends AbstractClusterTask {
     List<String> args = []
     @Input
     Map<String, String> systemProperties = [:]
+
+    @Internal
+    ExecOperations execOperations
+
+    @Inject
+    HadoopMRJob(ExecOperations execOperations) {
+        this.execOperations = execOperations
+    }
 
     void jobSetting(String key, Object value) {
         jobSettings.put(key, value)
@@ -152,9 +164,9 @@ abstract class HadoopMRJob extends AbstractClusterTask {
         Map<String, String> finalEnv = collectEnvVars()
 
         // Do command
-        project.logger.info("Executing Command: " + commandLine)
-        project.logger.info("Command Env: " + finalEnv)
-        project.exec { ExecSpec spec ->
+        logger.info("Executing Command: " + commandLine)
+        logger.info("Command Env: " + finalEnv)
+        execOperations.exec { ExecSpec spec ->
             spec.commandLine(commandLine)
             spec.environment(finalEnv)
         }

--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/fixture/hadoop/tasks/HiveBeeline.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/fixture/hadoop/tasks/HiveBeeline.groovy
@@ -26,8 +26,12 @@ import org.gradle.api.GradleException
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskAction
+import org.gradle.process.ExecOperations
 import org.gradle.process.ExecSpec
+
+import javax.inject.Inject
 
 import static org.elasticsearch.hadoop.gradle.fixture.hadoop.conf.SettingsContainer.FileSettings
 
@@ -39,6 +43,14 @@ abstract class HiveBeeline extends AbstractClusterTask {
     List<File> libJars = []
     @Input
     String hivePrincipal
+
+    @Internal
+    ExecOperations execOperations
+
+    @Inject
+    HiveBeeline(ExecOperations execOperations) {
+        this.execOperations = execOperations
+    }
 
     void libJars(File... files) {
         libJars.addAll(files)
@@ -86,8 +98,8 @@ abstract class HiveBeeline extends AbstractClusterTask {
 
         Map<String, String> environment = collectEnvVars()
 
-        project.logger.info("Using Environment: $environment")
-        project.exec { ExecSpec spec ->
+        logger.info("Using Environment: $environment")
+        execOperations.exec { ExecSpec spec ->
             spec.setCommandLine(commandLine)
             spec.environment(environment)
         }

--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/fixture/hadoop/tasks/SparkApp.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/fixture/hadoop/tasks/SparkApp.groovy
@@ -29,7 +29,10 @@ import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.TaskAction
+import org.gradle.process.ExecOperations
 import org.gradle.process.ExecSpec
+
+import javax.inject.Inject
 
 import static org.elasticsearch.hadoop.gradle.util.ObjectUtil.unapplyString
 
@@ -61,6 +64,14 @@ abstract class SparkApp extends AbstractClusterTask {
     List<File> libJars = []
     @Input
     List<String> args = []
+
+    @Internal
+    ExecOperations execOperations
+
+    @Inject
+    SparkApp(ExecOperations execOperations) {
+        this.execOperations = execOperations
+    }
 
     void deployMode(DeployMode mode) {
         deployMode = mode
@@ -159,8 +170,8 @@ abstract class SparkApp extends AbstractClusterTask {
         Map<String, String> finalEnv = collectEnvVars()
 
         // Do command
-        project.logger.info("Command Env: " + finalEnv)
-        project.exec { ExecSpec spec ->
+        logger.info("Command Env: " + finalEnv)
+        execOperations.exec { ExecSpec spec ->
             spec.commandLine(commandLine)
             spec.environment(finalEnv)
         }

--- a/qa/kerberos/build.gradle
+++ b/qa/kerberos/build.gradle
@@ -30,6 +30,8 @@ import org.elasticsearch.hadoop.gradle.fixture.hadoop.tasks.HadoopMRJob
 import org.elasticsearch.hadoop.gradle.fixture.hadoop.tasks.HiveBeeline
 import org.elasticsearch.hadoop.gradle.fixture.hadoop.tasks.SparkApp
 
+import javax.inject.Inject
+
 apply plugin: 'es.hadoop.build'
 apply plugin: 'scala'
 apply plugin: HadoopFixturePlugin
@@ -88,6 +90,11 @@ dependencies {
 // Testing jars
 // =============================================================================
 
+interface InjectedExecOps {
+    @Inject //@javax.inject.Inject
+    ExecOperations getExecOps()
+}
+
 // Disable the integration tests for Kerberos until we can find a solution to the failures due to + sign 
 // in the file path on CI.
 boolean disableTests = false
@@ -142,7 +149,9 @@ if (disableTests) {
     AntFixture kdcFixture = project.tasks.create('kdcFixture', AntFixture) {
         dependsOn project.configurations.kdcFixture
         executable = new File(project.runtimeJavaHome, 'bin/java')
-        env 'CLASSPATH', "${ -> project.configurations.kdcFixture.asPath }"
+
+        def fixturefileCollection = project.configurations.kdcFixture
+        env 'CLASSPATH', "${ -> fixturefileCollection.asPath }"
         waitCondition = { fixture, ant ->
             // the kdc wrapper writes the ports file when
             // it's ready, so we can just wait for the file to exist
@@ -235,10 +244,13 @@ if (disableTests) {
     File itestResourceDir = project.sourceSets.itest.resources.getSrcDirs().head()
 
     Task setupUsers = project.tasks.create("setupUsers", DefaultTestClustersTask) {
+        def injected = project.objects.newInstance(InjectedExecOps)
+
         useCluster(testClusters.integTest)
+        def executablePath = project.runtimeJavaHome.toString() + "/bin/java"
         doLast {
-            project.javaexec {
-                executable = project.runtimeJavaHome.toString() + "/bin/java"
+            injected.getExecOps().javaexec {
+                executable = executablePath
                 mainClass = 'org.elasticsearch.hadoop.qa.kerberos.setup.SetupKerberosUsers'
                 classpath = sourceSets.main.runtimeClasspath
                 systemProperty('es.nodes', esAddress)


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [[Gradle] Remove deprecated gradle api usage (#2321)](https://github.com/elastic/elasticsearch-hadoop/pull/2321)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)