### PR TITLE
[8.x] [DOCS] Add 8.17.1 release notes (#2333)

### DIFF
--- a/docs/src/reference/asciidoc/appendix/release-notes/8.17.1.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/8.17.1.adoc
@@ -1,0 +1,5 @@
+[[eshadoop-8.17.1]]
+== Elasticsearch for Apache Hadoop version 8.17.1
+
+ES-Hadoop 8.17.1 is a version compatibility release, tested specifically against
+Elasticsearch 8.17.1.

--- a/docs/src/reference/asciidoc/appendix/release.adoc
+++ b/docs/src/reference/asciidoc/appendix/release.adoc
@@ -9,6 +9,7 @@ This section summarizes the changes in each release.
 [[release-notes-8]]
 ===== 8.x
 
+* <<eshadoop-8.17.1>>
 * <<eshadoop-8.17.0>>
 * <<eshadoop-8.16.3>>
 * <<eshadoop-8.16.2>>
@@ -121,6 +122,7 @@ Elasticsearch 5.3.1.
 
 ////////////////////////
 
+include::release-notes/8.17.1.adoc[]
 include::release-notes/8.17.0.adoc[]
 include::release-notes/8.16.3.adoc[]
 include::release-notes/8.16.2.adoc[]


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[DOCS] Add 8.17.1 release notes (#2333)](https://github.com/elastic/elasticsearch-hadoop/pull/2333)

<!--- Backport version: 8.4.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)