### PR TITLE
[8.x] [DOCS] Add 8.16.4 release notes (#2337)

### DIFF
--- a/docs/src/reference/asciidoc/appendix/release-notes/8.16.4.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/8.16.4.adoc
@@ -1,0 +1,5 @@
+[[eshadoop-8.16.4]]
+== Elasticsearch for Apache Hadoop version 8.16.4
+
+ES-Hadoop 8.16.4 is a version compatibility release, tested specifically against
+Elasticsearch 8.16.4.

--- a/docs/src/reference/asciidoc/appendix/release.adoc
+++ b/docs/src/reference/asciidoc/appendix/release.adoc
@@ -11,6 +11,7 @@ This section summarizes the changes in each release.
 
 * <<eshadoop-8.17.1>>
 * <<eshadoop-8.17.0>>
+* <<eshadoop-8.16.4>>
 * <<eshadoop-8.16.3>>
 * <<eshadoop-8.16.2>>
 * <<eshadoop-8.16.1>>
@@ -124,6 +125,7 @@ Elasticsearch 5.3.1.
 
 include::release-notes/8.17.1.adoc[]
 include::release-notes/8.17.0.adoc[]
+include::release-notes/8.16.4.adoc[]
 include::release-notes/8.16.3.adoc[]
 include::release-notes/8.16.2.adoc[]
 include::release-notes/8.16.1.adoc[]


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[DOCS] Add 8.16.4 release notes (#2337)](https://github.com/elastic/elasticsearch-hadoop/pull/2337)

<!--- Backport version: 8.4.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)