### PR TITLE
[8.18] [DOCS] Add 8.17.5 release notes (#2374)

### DIFF
--- a/docs/src/reference/asciidoc/appendix/release-notes/8.17.4.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/8.17.4.adoc
@@ -1,0 +1,5 @@
+[[eshadoop-8.17.4]]
+== Elasticsearch for Apache Hadoop version 8.17.4
+
+ES-Hadoop 8.17.4 is a version compatibility release, tested specifically against
+Elasticsearch 8.17.4.

--- a/docs/src/reference/asciidoc/appendix/release-notes/8.17.5.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/8.17.5.adoc
@@ -1,0 +1,5 @@
+[[eshadoop-8.17.5]]
+== Elasticsearch for Apache Hadoop version 8.17.5
+
+ES-Hadoop 8.17.5 is a version compatibility release, tested specifically against
+Elasticsearch 8.17.5.

--- a/docs/src/reference/asciidoc/appendix/release.adoc
+++ b/docs/src/reference/asciidoc/appendix/release.adoc
@@ -9,6 +9,8 @@ This section summarizes the changes in each release.
 [[release-notes-8]]
 ===== 8.x
 
+* <<eshadoop-8.17.5>>
+* <<eshadoop-8.17.4>>
 * <<eshadoop-8.17.3>>
 * <<eshadoop-8.17.2>>
 * <<eshadoop-8.17.1>>
@@ -126,6 +128,8 @@ Elasticsearch 5.3.1.
 
 ////////////////////////
 
+include::release-notes/8.17.5.adoc[]
+include::release-notes/8.17.4.adoc[]
 include::release-notes/8.17.3.adoc[]
 include::release-notes/8.17.2.adoc[]
 include::release-notes/8.17.1.adoc[]


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.x` to `8.18`:
 - [[DOCS] Add 8.17.5 release notes (#2374)](https://github.com/elastic/elasticsearch-hadoop/pull/2374)

<!--- Backport version: 8.4.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)