### PR TITLE
[9.0] [DOCS] Add 9.0.0 release notes (#2373)

### DIFF
--- a/docs/release-notes/breaking-changes.md
+++ b/docs/release-notes/breaking-changes.md
@@ -26,3 +26,10 @@ To learn how to upgrade, check out <uprade docs>.
 % **Impact**<br> Impact of the breaking change.
 % **Action**<br> Steps for mitigating deprecation impact.
 % ::::
+## 9.0.0 [elasticsearch-hadoop-900-breaking-changes]
+::::{dropdown} Spark 2.x is no longer supported in 9.0+
+Development for Apache Spark's 2.x version line has concluded. As such, we have removed support for this version in the Spark connector in 9.0. Spark 3.x is now the default supported version of Spark. 
+For more information, check [#2316](https://github.com/elastic/elasticsearch-hadoop/pull/2316).
+**Impact**<br> Deployments on Spark 2.x are no longer supported and will need to be updated.
+**Action**<br> Any integrations using the Spark connector on a version of Spark before 3.x should update their version of Spark to a compatible version before upgrading Elasticsearch for Apache Hadoop/Spark.
+::::


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [[DOCS] Add 9.0.0 release notes (#2373)](https://github.com/elastic/elasticsearch-hadoop/pull/2373)

<!--- Backport version: 8.4.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)