### PR TITLE
[8.17] [DOCS] Add 8.17.6 release notes (#2380)

### DIFF
--- a/docs/src/reference/asciidoc/appendix/release-notes/8.17.6.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/8.17.6.adoc
@@ -1,0 +1,5 @@
+[[eshadoop-8.17.6]]
+== Elasticsearch for Apache Hadoop version 8.17.6
+
+ES-Hadoop 8.17.6 is a version compatibility release, tested specifically against
+Elasticsearch 8.17.6.

--- a/docs/src/reference/asciidoc/appendix/release.adoc
+++ b/docs/src/reference/asciidoc/appendix/release.adoc
@@ -9,6 +9,7 @@ This section summarizes the changes in each release.
 [[release-notes-8]]
 ===== 8.x
 
+* <<eshadoop-8.17.6>>
 * <<eshadoop-8.17.5>>
 * <<eshadoop-8.17.4>>
 * <<eshadoop-8.17.3>>
@@ -128,6 +129,7 @@ Elasticsearch 5.3.1.
 
 ////////////////////////
 
+include::release-notes/8.17.6.adoc[]
 include::release-notes/8.17.5.adoc[]
 include::release-notes/8.17.4.adoc[]
 include::release-notes/8.17.3.adoc[]


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.19` to `8.17`:
 - [[DOCS] Add 8.17.6 release notes (#2380)](https://github.com/elastic/elasticsearch-hadoop/pull/2380)

<!--- Backport version: 8.4.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)