### PR TITLE
[8.18] [DOCS] Add 8.18.0+1 release notes (#2383)

### DIFF
--- a/docs/src/reference/asciidoc/appendix/release-notes/8.18.0.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/8.18.0.adoc
@@ -1,0 +1,7 @@
+[[eshadoop-8.18.0]]
+== Elasticsearch for Apache Hadoop version 8.18.0
+
+[[deprecation-8.18.0]]
+=== Deprecations
+* Deprecate Spark 2.x
+http://github.com/elastic/elasticsearch-hadoop/issues/2305[#2305]

--- a/docs/src/reference/asciidoc/appendix/release-notes/8.18.1.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/8.18.1.adoc
@@ -1,0 +1,5 @@
+[[eshadoop-8.18.1]]
+== Elasticsearch for Apache Hadoop version 8.18.1
+
+ES-Hadoop 8.18.1 is a version compatibility release, tested specifically against
+Elasticsearch 8.18.1.

--- a/docs/src/reference/asciidoc/appendix/release.adoc
+++ b/docs/src/reference/asciidoc/appendix/release.adoc
@@ -9,6 +9,8 @@ This section summarizes the changes in each release.
 [[release-notes-8]]
 ===== 8.x
 
+* <<eshadoop-8.18.1>>
+* <<eshadoop-8.18.0>>
 * <<eshadoop-8.17.6>>
 * <<eshadoop-8.17.5>>
 * <<eshadoop-8.17.4>>
@@ -129,6 +131,8 @@ Elasticsearch 5.3.1.
 
 ////////////////////////
 
+include::release-notes/8.18.1.adoc[]
+include::release-notes/8.18.0.adoc[]
 include::release-notes/8.17.6.adoc[]
 include::release-notes/8.17.5.adoc[]
 include::release-notes/8.17.4.adoc[]


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.19` to `8.18`:
 - [[DOCS] Add 8.18.0+1 release notes (#2383)](https://github.com/elastic/elasticsearch-hadoop/pull/2383)

<!--- Backport version: 8.4.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)