### PR TITLE
[8.18] [DOCS] Add 8.17.7 release notes (#2390)

### DIFF
--- a/docs/src/reference/asciidoc/appendix/release-notes/8.17.7.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/8.17.7.adoc
@@ -1,0 +1,5 @@
+[[eshadoop-8.17.7]]
+== Elasticsearch for Apache Hadoop version 8.17.7
+
+ES-Hadoop 8.17.7 is a version compatibility release, tested specifically against
+Elasticsearch 8.17.7.

--- a/docs/src/reference/asciidoc/appendix/release.adoc
+++ b/docs/src/reference/asciidoc/appendix/release.adoc
@@ -12,6 +12,7 @@ This section summarizes the changes in each release.
 * <<eshadoop-8.18.2>>
 * <<eshadoop-8.18.1>>
 * <<eshadoop-8.18.0>>
+* <<eshadoop-8.17.7>>
 * <<eshadoop-8.17.6>>
 * <<eshadoop-8.17.5>>
 * <<eshadoop-8.17.4>>
@@ -135,6 +136,7 @@ Elasticsearch 5.3.1.
 include::release-notes/8.18.2.adoc[]
 include::release-notes/8.18.1.adoc[]
 include::release-notes/8.18.0.adoc[]
+include::release-notes/8.17.7.adoc[]
 include::release-notes/8.17.6.adoc[]
 include::release-notes/8.17.5.adoc[]
 include::release-notes/8.17.4.adoc[]


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.19` to `8.18`:
 - [[DOCS] Add 8.17.7 release notes (#2390)](https://github.com/elastic/elasticsearch-hadoop/pull/2390)

<!--- Backport version: 8.4.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)