### PR TITLE
[8.17] [Build] Support publishing maven artifacts directly to maven central (#2397)

### DIFF
--- a/.buildkite/dra.sh
+++ b/.buildkite/dra.sh
@@ -38,7 +38,7 @@ mkdir localRepo
 wget --quiet "https://artifacts-$DRA_WORKFLOW.elastic.co/elasticsearch/${ES_BUILD_ID}/maven/org/elasticsearch/gradle/build-tools/${HADOOP_VERSION}${VERSION_SUFFIX}/build-tools-${HADOOP_VERSION}${VERSION_SUFFIX}.jar" \
   -O "localRepo/build-tools-${HADOOP_VERSION}${VERSION_SUFFIX}.jar"
 
-./gradlew -S -PlocalRepo=true "${BUILD_ARGS}" -Dorg.gradle.warning.mode=summary -Dcsv="$WORKSPACE/build/distributions/dependencies-${HADOOP_VERSION}${VERSION_SUFFIX}.csv" :dist:generateDependenciesReport distribution
+./gradlew -S -PlocalRepo=true "${BUILD_ARGS}" -Dorg.gradle.warning.mode=summary -Dcsv="$WORKSPACE/build/distributions/dependencies-${HADOOP_VERSION}${VERSION_SUFFIX}.csv" :dist:generateDependenciesReport distribution zipAggregation
 
 # Allow other users access to read the artifacts so they are readable in the container
 find "$WORKSPACE" -type f -path "*/build/distributions/*" -exec chmod a+r {} \;

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 import org.elasticsearch.hadoop.gradle.buildtools.ConcatFilesTask
 import java.lang.management.ManagementFactory;
 import java.time.LocalDateTime;
+import org.elasticsearch.gradle.VersionProperties
 
 import org.elasticsearch.gradle.Architecture
 import org.elasticsearch.gradle.OS
@@ -11,8 +12,22 @@ import java.time.LocalDateTime
 description = 'Elasticsearch for Apache Hadoop'
 
 apply plugin: 'es.hadoop.build.root'
+apply plugin: 'com.gradleup.nmcp.aggregation'
 
 defaultTasks 'build'
+
+dependencies {
+    nmcpAggregation(project(":dist"))
+    nmcpAggregation(project(":elasticsearch-hadoop-mr"))
+    nmcpAggregation(project(":elasticsearch-hadoop-hive"))
+    nmcpAggregation(project(":elasticsearch-spark-30"))
+}
+
+tasks.named('zipAggregation').configure {
+    archiveFileName.unset();
+    archiveBaseName.set("elasticsearch-maven-aggregration")
+    archiveVersion.set(VersionProperties.elasticsearch)
+}
 
 allprojects {
     group = "org.elasticsearch"

--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ dependencies {
     nmcpAggregation(project(":dist"))
     nmcpAggregation(project(":elasticsearch-hadoop-mr"))
     nmcpAggregation(project(":elasticsearch-hadoop-hive"))
+    nmcpAggregation(project(":elasticsearch-spark-20"))
     nmcpAggregation(project(":elasticsearch-spark-30"))
 }
 

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -72,6 +72,7 @@ dependencies {
     // Required for dependency licenses task
     implementation 'org.apache.rat:apache-rat:0.11'
     implementation 'commons-codec:commons-codec:1.12'
+    implementation 'com.gradleup.nmcp:nmcp:0.1.4'
 
     if (localRepo) {
         implementation name: "build-tools-${buildToolsVersion}"

--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/BuildPlugin.groovy
@@ -602,7 +602,6 @@ class BuildPlugin implements Plugin<Project>  {
 
             // Main variant needs the least configuration on its own, since it is the default publication created above.
             sparkVariants.defaultVariant { SparkVariant variant ->
-                project.publishing.publications.main.setAlias(true)
                 updateVariantArtifactId(project, project.publishing.publications.main, variant)
             }
 
@@ -653,6 +652,7 @@ class BuildPlugin implements Plugin<Project>  {
                             from variantComponent
                             suppressAllPomMetadataWarnings() // We get it. Gradle metadata is better than Maven Poms
                         }
+                        variantPublication.setAlias(true)
                         configurePom(project, variantPublication)
                         updateVariantArtifactId(project, variantPublication, variant)
                     }

--- a/dist/build.gradle
+++ b/dist/build.gradle
@@ -1,3 +1,4 @@
+import jdk.internal.foreign.abi.Binding
 import org.elasticsearch.hadoop.gradle.buildtools.ConcatFilesTask
 import org.elasticsearch.hadoop.gradle.buildtools.DependenciesInfoTask
 import org.elasticsearch.hadoop.gradle.buildtools.DependencyLicensesTask
@@ -132,26 +133,6 @@ javadoc {
     }
 }
 
-publishing {
-    publications {
-        main {
-            getPom().withXml { XmlProvider xml ->
-                Node root = xml.asNode()
-
-                // add clojars repo to pom
-                Node repositories = root.appendNode('repositories')
-                Node repository = repositories.appendNode('repository')
-                repository.appendNode('id', 'clojars.org')
-                repository.appendNode('url', 'https://clojars.org/repo')
-                BasePluginExtension baseExtension = project.getExtensions().getByType(BasePluginExtension.class)
-
-                // Correct the artifact Id, otherwise it is listed as 'dist'
-                root.get('artifactId').get(0).setValue(baseExtension.archivesName.get())
-            }
-        }
-    }
-}
-
 // Name of the directory under the root of the zip file that will contain the zip contents
 String zipContentDir = "elasticsearch-hadoop-${project.version}"
 
@@ -179,7 +160,27 @@ task('distZip', type: Zip) {
 
 distribution {
     dependsOn(distZip)
+
 }
+
+
+publishing {
+    publications {
+        main {
+            artifact tasks.named('distZip')
+            getPom().withXml { XmlProvider xml ->
+                Node root = xml.asNode()
+
+                // add clojars repo to pom
+                Node repositories = root.appendNode('repositories')
+                Node repository = repositories.appendNode('repository')
+                repository.appendNode('id', 'clojars.org')
+                repository.appendNode('url', 'https://clojars.org/repo')
+            }
+        }
+    }
+}
+
 
 // Add a task in the root project that collects all the dependencyReport data for each project
 // Concatenates the dependencies CSV files into a single file
@@ -196,4 +197,16 @@ task generateDependenciesReport(type: ConcatFilesTask) { concatDepsTask ->
 
 project.tasks.named('dependencyLicenses', DependencyLicensesTask) {
     it.dependencies = project.configurations.licenseChecks
+}
+
+
+tasks.register('copyPoms', Copy) {
+    BasePluginExtension baseExtension = project.getExtensions().getByType(BasePluginExtension.class);
+    from(tasks.named('generatePomFileForMainPublication'))
+    into(new File(project.buildDir, 'distributions'))
+    rename 'pom-default.xml', "${baseExtension.archivesName.get()}-${project.getVersion()}.pom"
+}
+
+tasks.named('distribution').configure {
+    dependsOn 'copyPoms'
 }

--- a/dist/build.gradle
+++ b/dist/build.gradle
@@ -1,4 +1,3 @@
-import jdk.internal.foreign.abi.Binding
 import org.elasticsearch.hadoop.gradle.buildtools.ConcatFilesTask
 import org.elasticsearch.hadoop.gradle.buildtools.DependenciesInfoTask
 import org.elasticsearch.hadoop.gradle.buildtools.DependencyLicensesTask

--- a/hive/build.gradle
+++ b/hive/build.gradle
@@ -88,3 +88,15 @@ itestJar {
         include "META-INF/services/*"
     }
 }
+
+
+tasks.register('copyPoms', Copy) {
+    BasePluginExtension baseExtension = project.getExtensions().getByType(BasePluginExtension.class);
+    from(tasks.named('generatePomFileForMainPublication'))
+    into(new File(project.buildDir, 'distributions'))
+    rename 'pom-default.xml', "${baseExtension.archivesName.get()}-${project.getVersion()}.pom"
+}
+
+tasks.named('distribution').configure {
+    dependsOn 'copyPoms'
+}

--- a/mr/build.gradle
+++ b/mr/build.gradle
@@ -137,3 +137,14 @@ eclipse.classpath.file {
         }
     }
 }
+
+tasks.register('copyPoms', Copy) {
+    BasePluginExtension baseExtension = project.getExtensions().getByType(BasePluginExtension.class);
+    from(tasks.named('generatePomFileForMainPublication'))
+    into(new File(project.buildDir, 'distributions'))
+    rename 'pom-default.xml', "${baseExtension.archivesName.get()}-${project.getVersion()}.pom"
+}
+
+tasks.named('distribution').configure {
+    dependsOn 'copyPoms'
+}

--- a/spark/sql-20/build.gradle
+++ b/spark/sql-20/build.gradle
@@ -217,3 +217,17 @@ sparkVariants {
         }
     }
 }
+
+tasks.register('copyPoms', Copy) {
+    from(tasks.named('generatePomFileForMainPublication')) {
+        rename 'pom-default.xml', "elasticsearch-spark-20_2.12-${project.getVersion()}.pom"
+    }
+    from(tasks.named('generatePomFileForSpark20scala211Publication')) {
+        rename 'pom-default.xml', "elasticsearch-spark-20_2.11-${project.getVersion()}.pom"
+    }
+    into(new File(project.buildDir, 'distributions'))
+}
+
+tasks.named('distribution').configure {
+    dependsOn 'copyPoms'
+}

--- a/spark/sql-30/build.gradle
+++ b/spark/sql-30/build.gradle
@@ -189,3 +189,18 @@ sparkVariants {
         }
     }
 }
+
+
+tasks.register('copyPoms', Copy) {
+    from(tasks.named('generatePomFileForMainPublication')) {
+        rename 'pom-default.xml', "elasticsearch-spark-30_2.13-${project.getVersion()}.pom"
+    }
+    from(tasks.named('generatePomFileForSpark30scala212Publication')) {
+        rename 'pom-default.xml', "elasticsearch-spark-30_2.12-${project.getVersion()}.pom"
+    }
+    into(new File(project.buildDir, 'distributions'))
+}
+
+tasks.named('distribution').configure {
+    dependsOn 'copyPoms'
+}

--- a/spark/sql-30/build.gradle
+++ b/spark/sql-30/build.gradle
@@ -193,10 +193,10 @@ sparkVariants {
 
 tasks.register('copyPoms', Copy) {
     from(tasks.named('generatePomFileForMainPublication')) {
-        rename 'pom-default.xml', "elasticsearch-spark-30_2.13-${project.getVersion()}.pom"
-    }
-    from(tasks.named('generatePomFileForSpark30scala212Publication')) {
         rename 'pom-default.xml', "elasticsearch-spark-30_2.12-${project.getVersion()}.pom"
+    }
+    from(tasks.named('generatePomFileForSpark30scala213Publication')) {
+        rename 'pom-default.xml', "elasticsearch-spark-30_2.13-${project.getVersion()}.pom"
     }
     into(new File(project.buildDir, 'distributions'))
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [[Build] Support publishing maven artifacts directly to maven central (#2397)](https://github.com/elastic/elasticsearch-hadoop/pull/2397)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)