### PR TITLE
[8.17] Make aggregation zip compatible with release manager (#2398)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,8 @@ dependencies {
 
 tasks.named('zipAggregation').configure {
     archiveFileName.unset();
-    archiveBaseName.set("elasticsearch-maven-aggregration")
+    archiveBaseName.set("elasticsearch-hadoop-maven-aggregation")
+    destinationDirectory.set(layout.buildDirectory.dir("distributions"));
     archiveVersion.set(VersionProperties.elasticsearch)
 }
 

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -72,7 +72,7 @@ dependencies {
     // Required for dependency licenses task
     implementation 'org.apache.rat:apache-rat:0.11'
     implementation 'commons-codec:commons-codec:1.12'
-    implementation 'com.gradleup.nmcp:nmcp:0.1.4'
+    implementation 'com.gradleup.nmcp:nmcp:0.1.5'
 
     if (localRepo) {
         implementation name: "build-tools-${buildToolsVersion}"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [Make aggregation zip compatible with release manager (#2398)](https://github.com/elastic/elasticsearch-hadoop/pull/2398)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)