### PR TITLE
[Build} Ensure deterministic task execution ordering in DRA

### DIFF
--- a/dist/build.gradle
+++ b/dist/build.gradle
@@ -199,12 +199,19 @@ project.tasks.named('dependencyLicenses', DependencyLicensesTask) {
     it.dependencies = project.configurations.licenseChecks
 }
 
-
 tasks.register('copyPoms', Copy) {
     BasePluginExtension baseExtension = project.getExtensions().getByType(BasePluginExtension.class);
     from(tasks.named('generatePomFileForMainPublication'))
     into(new File(project.buildDir, 'distributions'))
     rename 'pom-default.xml', "${baseExtension.archivesName.get()}-${project.getVersion()}.pom"
+}
+
+tasks.named('collectArtifacts') {
+    mustRunAfter 'publishMainPublicationToNmcpMainRepository'
+}
+
+tasks.named('publishMainPublicationToNmcpMainRepository') {
+    mustRunAfter 'copyPoms'
 }
 
 tasks.named('distribution').configure {


### PR DESCRIPTION
- we push different tasks output into build/distribution
- should be not necessary ones we remove osshr compliant maven dra artifacts
