### PR TITLE
[8.18] Ensure deterministic task execution ordering in DRA (#2413)

### DIFF
--- a/dist/build.gradle
+++ b/dist/build.gradle
@@ -198,12 +198,19 @@ project.tasks.named('dependencyLicenses', DependencyLicensesTask) {
     it.dependencies = project.configurations.licenseChecks
 }
 
-
 tasks.register('copyPoms', Copy) {
     BasePluginExtension baseExtension = project.getExtensions().getByType(BasePluginExtension.class);
     from(tasks.named('generatePomFileForMainPublication'))
     into(new File(project.buildDir, 'distributions'))
     rename 'pom-default.xml', "${baseExtension.archivesName.get()}-${project.getVersion()}.pom"
+}
+
+tasks.named('collectArtifacts') {
+    mustRunAfter 'publishMainPublicationToNmcpMainRepository'
+}
+
+tasks.named('publishMainPublicationToNmcpMainRepository') {
+    mustRunAfter 'copyPoms'
 }
 
 tasks.named('distribution').configure {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [Ensure deterministic task execution ordering in DRA (#2413)](https://github.com/elastic/elasticsearch-hadoop/pull/2413)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)