### PR TITLE
[8.19] Update gradle shadow plugin to 9.0.1 (#2433)

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,6 @@
 pluginManagement {
   plugins {
-    id 'com.github.johnrengelman.shadow' version "8.1.1"
+    id 'com.gradleup.shadow' version "9.0.1"
   }
 }
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Update gradle shadow plugin to 9.0.1 (#2433)](https://github.com/elastic/elasticsearch-hadoop/pull/2433)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)