### PR TITLE
[8.17] [DOCS] Add 8.17.10 release notes (#2444)

### DIFF
--- a/docs/src/reference/asciidoc/appendix/release-notes/8.17.10.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/8.17.10.adoc
@@ -1,0 +1,5 @@
+[[eshadoop-8.17.10]]
+== Elasticsearch for Apache Hadoop version 8.17.10
+
+ES-Hadoop 8.17.10 is a version compatibility release, tested specifically against
+Elasticsearch 8.17.10.

--- a/docs/src/reference/asciidoc/appendix/release-notes/8.17.8.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/8.17.8.adoc
@@ -1,0 +1,5 @@
+[[eshadoop-8.17.8]]
+== Elasticsearch for Apache Hadoop version 8.17.8
+
+ES-Hadoop 8.17.8 is a version compatibility release, tested specifically against
+Elasticsearch 8.17.8.

--- a/docs/src/reference/asciidoc/appendix/release-notes/8.17.9.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/8.17.9.adoc
@@ -1,0 +1,5 @@
+[[eshadoop-8.17.9]]
+== Elasticsearch for Apache Hadoop version 8.17.9
+
+ES-Hadoop 8.17.9 is a version compatibility release, tested specifically against
+Elasticsearch 8.17.9.

--- a/docs/src/reference/asciidoc/appendix/release.adoc
+++ b/docs/src/reference/asciidoc/appendix/release.adoc
@@ -9,6 +9,9 @@ This section summarizes the changes in each release.
 [[release-notes-8]]
 ===== 8.x
 
+* <<eshadoop-8.17.10>>
+* <<eshadoop-8.17.9>>
+* <<eshadoop-8.17.8>>
 * <<eshadoop-8.17.7>>
 * <<eshadoop-8.17.6>>
 * <<eshadoop-8.17.5>>
@@ -130,6 +133,9 @@ Elasticsearch 5.3.1.
 
 ////////////////////////
 
+include::release-notes/8.17.10.adoc[]
+include::release-notes/8.17.9.adoc[]
+include::release-notes/8.17.8.adoc[]
 include::release-notes/8.17.7.adoc[]
 include::release-notes/8.17.6.adoc[]
 include::release-notes/8.17.5.adoc[]


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.19` to `8.17`:
 - [[DOCS] Add 8.17.10 release notes (#2444)](https://github.com/elastic/elasticsearch-hadoop/pull/2444)

<!--- Backport version: 8.4.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)