### PR TITLE
[8.18] [DOCS] Add 8.18.6 release notes (#2448)

### DIFF
--- a/docs/src/reference/asciidoc/appendix/release-notes/8.18.3.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/8.18.3.adoc
@@ -1,0 +1,5 @@
+[[eshadoop-8.18.3]]
+== Elasticsearch for Apache Hadoop version 8.18.3
+
+ES-Hadoop 8.18.3 is a version compatibility release, tested specifically against
+Elasticsearch 8.18.3.

--- a/docs/src/reference/asciidoc/appendix/release-notes/8.18.4.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/8.18.4.adoc
@@ -1,0 +1,5 @@
+[[eshadoop-8.18.4]]
+== Elasticsearch for Apache Hadoop version 8.18.4
+
+ES-Hadoop 8.18.4 is a version compatibility release, tested specifically against
+Elasticsearch 8.18.4.

--- a/docs/src/reference/asciidoc/appendix/release-notes/8.18.5.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/8.18.5.adoc
@@ -1,0 +1,5 @@
+[[eshadoop-8.18.5]]
+== Elasticsearch for Apache Hadoop version 8.18.5
+
+ES-Hadoop 8.18.5 is a version compatibility release, tested specifically against
+Elasticsearch 8.18.5.

--- a/docs/src/reference/asciidoc/appendix/release-notes/8.18.6.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/8.18.6.adoc
@@ -1,0 +1,5 @@
+[[eshadoop-8.18.6]]
+== Elasticsearch for Apache Hadoop version 8.18.6
+
+ES-Hadoop 8.18.6 is a version compatibility release, tested specifically against
+Elasticsearch 8.18.6.

--- a/docs/src/reference/asciidoc/appendix/release.adoc
+++ b/docs/src/reference/asciidoc/appendix/release.adoc
@@ -9,6 +9,10 @@ This section summarizes the changes in each release.
 [[release-notes-8]]
 ===== 8.x
 
+* <<eshadoop-8.18.6>>
+* <<eshadoop-8.18.5>>
+* <<eshadoop-8.18.4>>
+* <<eshadoop-8.18.3>>
 * <<eshadoop-8.18.2>>
 * <<eshadoop-8.18.1>>
 * <<eshadoop-8.18.0>>
@@ -136,6 +140,10 @@ Elasticsearch 5.3.1.
 
 ////////////////////////
 
+include::release-notes/8.18.6.adoc[]
+include::release-notes/8.18.5.adoc[]
+include::release-notes/8.18.4.adoc[]
+include::release-notes/8.18.3.adoc[]
 include::release-notes/8.18.2.adoc[]
 include::release-notes/8.18.1.adoc[]
 include::release-notes/8.18.0.adoc[]


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.19` to `8.18`:
 - [[DOCS] Add 8.18.6 release notes (#2448)](https://github.com/elastic/elasticsearch-hadoop/pull/2448)

<!--- Backport version: 8.4.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)