### PR TITLE
[8.18] [DOCS] Add 8.18.7 release notes (#2452)

### DIFF
--- a/docs/src/reference/asciidoc/appendix/release-notes/8.18.7.adoc
+++ b/docs/src/reference/asciidoc/appendix/release-notes/8.18.7.adoc
@@ -1,0 +1,5 @@
+[[eshadoop-8.18.7]]
+== Elasticsearch for Apache Hadoop version 8.18.7
+
+ES-Hadoop 8.18.7 is a version compatibility release, tested specifically against
+Elasticsearch 8.18.7.

--- a/docs/src/reference/asciidoc/appendix/release.adoc
+++ b/docs/src/reference/asciidoc/appendix/release.adoc
@@ -9,6 +9,7 @@ This section summarizes the changes in each release.
 [[release-notes-8]]
 ===== 8.x
 
+* <<eshadoop-8.18.7>>
 * <<eshadoop-8.18.6>>
 * <<eshadoop-8.18.5>>
 * <<eshadoop-8.18.4>>
@@ -140,6 +141,7 @@ Elasticsearch 5.3.1.
 
 ////////////////////////
 
+include::release-notes/8.18.7.adoc[]
 include::release-notes/8.18.6.adoc[]
 include::release-notes/8.18.5.adoc[]
 include::release-notes/8.18.4.adoc[]


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.19` to `8.18`:
 - [[DOCS] Add 8.18.7 release notes (#2452)](https://github.com/elastic/elasticsearch-hadoop/pull/2452)

<!--- Backport version: 8.4.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)