### PR TITLE
Fix test trigger pipeline for 9.0 branch

### DIFF
--- a/.buildkite/tests.trigger.sh
+++ b/.buildkite/tests.trigger.sh
@@ -12,7 +12,7 @@ for BRANCH in "${BRANCHES[@]}"; do
     label: Trigger tests pipeline for $BRANCH
     async: true
     build:
-      branch: $BRANCH
+      branch: "$BRANCH"
 EOF
 done
 


### PR DESCRIPTION
This fixes the branch selection for 9.0. without usage of quotes this would evaluate to 9 which is not a valid branch.