### PR TITLE
[9.2] [DOCS] Add 9.2.0 release notes (#2468)

### DIFF
--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -20,8 +20,8 @@ To check for security updates, go to [Security announcements for the Elastic sta
 % ### Fixes [elasticsearch-apache-hadoop-next-fixes]
 % * 
 
-## 9.1.0 [elasticsearch-apache-hadoop-900-release-notes]
+## 9.2.0 [elasticsearch-apache-hadoop-900-release-notes]
 
 ### Features and enhancements [elasticsearch-apache-hadoop-900-features-enhancements]
 
-* Set Spark 3.x support now defaults to Scala 2.13 ([PR #2328](https://github.com/elastic/elasticsearch-hadoop/pull/2328))
+### Fixes [elasticsearch-apache-hadoop-900-fixes]


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[DOCS] Add 9.2.0 release notes (#2468)](https://github.com/elastic/elasticsearch-hadoop/pull/2468)

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)