### PR TITLE
[Docs] Updating the page to add applies_to tags

### DIFF
--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -4,6 +4,9 @@ mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/hadoop/current/index.html
   - https://www.elastic.co/guide/en/elasticsearch/hadoop/current/doc-sections.html
   - https://www.elastic.co/guide/en/elasticsearch/hadoop/current/reference.html
+applies_to:
+  stack: ga
+  serverless: unavailable
 ---
 # {{esh-full}}
 


### PR DESCRIPTION
Adding the Serverless unavailable tag, as per the [Elasticsearch table](https://www.elastic.co/docs/deploy-manage/deploy/elastic-cloud/differences-from-other-elasticsearch-offerings#elasticsearch) in the comparison doc.

Relates to https://github.com/elastic/docs-content/issues/1198

- [x] I have signed the [Contributor License Agreement (CLA)][]

