### PR TITLE
[9.2] [Build] Update develocity plugin to 4.2.2 (#2481)

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -5,7 +5,7 @@ pluginManagement {
 }
 
 plugins {
-  id "com.gradle.develocity" version "3.18.1"
+  id "com.gradle.develocity" version "4.2.2"
 }
 
 rootProject.name = "elasticsearch-hadoop"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[Build] Update develocity plugin to 4.2.2 (#2481)](https://github.com/elastic/elasticsearch-hadoop/pull/2481)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)