### PR TITLE
Note the maturity and increasingly predominent use of Apache Spark

### DIFF
--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -13,7 +13,7 @@ applies_to:
 {{esh-full}} is an umbrella project consisting of two similar, yet independent sub-projects: `elasticsearch-hadoop` and `repository-hdfs`.
 This documentation pertains to `elasticsearch-hadoop`. For information about `repository-hdfs` and using HDFS as a back-end repository for doing snapshot or restore from or to {{es}}, go to [Hadoop HDFS repository plugin](elasticsearch://reference/elasticsearch-plugins/repository-hdfs.md).
 
-{{esh-full}} is an [open-source](./license.md), stand-alone, self-contained, small library that allows big data processing frameworks (specifically Apache Hadoop Map/Reduce and Apache SPark) to *interact* with {{es}}. One can think of it as a *connector* that allows data to flow *bi-directionaly* so that applications can leverage transparently the {{es}} engine capabilities to significantly enrich their capabilities and improve performance.
+{{esh-full}} is an [open-source](./license.md), stand-alone, self-contained, small library that allows big data processing frameworks (specifically Apache Hadoop Map/Reduce and Apache Spark) to *interact* with {{es}}. One can think of it as a *connector* that allows data to flow *bi-directionaly* so that applications can leverage transparently the {{es}} engine capabilities to significantly enrich their capabilities and improve performance.
 
 {{esh-full}} provides native integration for Map/Reduce, Spark, and Hive, making {{es}} accessible as if it were a native resource within your data processing cluster. As such, {{esh-full}} operates as a library that processing jobs import and use through its APIs to read from and write to {{es}}.
 


### PR DESCRIPTION
Updated to note the maturity and increasingly predominent use of Apache Spark 😄 
Addresses https://github.com/elastic/docs-content-internal/issues/556

Thank you for submitting a pull request! 

Please make sure you have signed our [Contributor License Agreement (CLA)][].  
We are not asking you to assign copyright to us, but to give us the right to distribute your code without restriction. We ask this of all contributors in order to assure our users of the origin and continuing existence of the code.  
You only need to sign the CLA once.

- [x] I have signed the [Contributor License Agreement (CLA)][]

[Contributor License Agreement (CLA)]: https://www.elastic.co/contributor-agreement/
