### PR TITLE
[Docs] Adding auth header as an authentication method

### DIFF
--- a/docs/reference/security.md
+++ b/docs/reference/security.md
@@ -49,11 +49,11 @@ API key authentication
         "es.port": es_port,
         "es.net.ssl": "true",
         "es.nodes.wan.only": "true",
-        "es.net.http.header.Authorization": f"ApiKey {es_api_key}",
+        "es.net.http.header.Authorization": f"ApiKey <es_api_key>", <1>
         "es.resource": es_index,
     }
     ```
-
+    1. Substitute `<es_api_key>` with your API key.
 
 PKI/X.509
 :   Use X.509 certificates to authenticate elasticsearch-hadoop to elasticsearch-hadoop. For this, one would need to setup the `keystore` containing the private key and certificate to the appropriate user (configured in {{es}}) and the `truststore` with the CA certificate used to sign the SSL/TLS certificates in the {{es}} cluster. That is one setup the key to authenticate elasticsearch-hadoop and also to verify that is the right one. To do so, one should setup the `es.net.ssl.keystore.location` and `es.net.ssl.truststore.location` properties to indicate the `keystore` and `truststore` to use. It is recommended to have these secured through a password in which case `es.net.ssl.keystore.pass` and `es.net.ssl.truststore.pass` properties are required.


### PR DESCRIPTION
Adds missing information about passing an API Key as an authentication mechanism for elasticsearch-hadoop.

Fixes [#61](https://github.com/elastic/docs-content-internal/issues/62) (examples were provided in the issue)


The [docs preview is here](https://docs-v3-preview.elastic.dev/elastic/elasticsearch-hadoop/pull/2486/reference/security#_authentication)

- [x] I have signed the [Contributor License Agreement (CLA)][]

[Contributor License Agreement (CLA)]: https://www.elastic.co/contributor-agreement/
