### PR TITLE
[9.3] Update Gradle wrapper to 9.3.1 (#2489)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ org.gradle.jvmargs=-Xmx4g
 
 # java homes resolved by environment variables
 org.gradle.java.installations.auto-detect=false
-org.gradle.java.installations.fromEnv=JAVA_HOME,RUNTIME_JAVA_HOME,JAVA15_HOME,JAVA14_HOME,JAVA13_HOME,JAVA12_HOME,JAVA11_HOME,JAVA8_HOME
+org.gradle.java.installations.fromEnv=JAVA_HOME,RUNTIME_JAVA_HOME,JAVA8_HOME
 
 ## Dependecies Version
 # Logging

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=f86344275d1b194688dd330abf9f6f2344cd02872ffee035f2d1ea2fd60cf7f3
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-all.zip
+distributionSha256Sum=17f277867f6914d61b1aa02efab1ba7bb439ad652ca485cd8ca6842fccec6e43
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [Update Gradle wrapper to 9.3.1 (#2489)](https://github.com/elastic/elasticsearch-hadoop/pull/2489)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)