### PR TITLE
[9.3] Fix DRA build deprecation warning (#2509)

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/BuildPlugin.groovy
@@ -106,28 +106,15 @@ class BuildPlugin implements Plugin<Project> {
         project.getPluginManager().apply(EclipsePlugin.class)
     }
 
-    /** Return the configuration name used for finding transitive deps of the given dependency. */
-    private static String transitiveDepConfigName(String groupId, String artifactId, String version) {
-        return "_transitive_${groupId}_${artifactId}_${version}"
-    }
-
     /**
      * Applies a closure to all dependencies in a configuration (currently or in the future) that disables the
      * resolution of transitive dependencies except for projects in the group <code>org.elasticsearch</code>.
      * @param configuration to disable transitive dependencies on
      */
     static void disableTransitiveDependencies(Project project, Configuration configuration) {
-        configuration.dependencies.all { Dependency dep ->
+        configuration.dependencies.whenObjectAdded { Dependency dep ->
             if (dep instanceof ModuleDependency && !(dep instanceof ProjectDependency) && dep.group.startsWith('org.elasticsearch') == false) {
                 dep.transitive = false
-
-                // also create a configuration just for this dependency version, so that later
-                // we can determine which transitive dependencies it has
-                String depConfig = transitiveDepConfigName(dep.group, dep.name, dep.version)
-                if (project.configurations.findByName(depConfig) == null) {
-                    project.configurations.create(depConfig)
-                    project.dependencies.add(depConfig, "${dep.group}:${dep.name}:${dep.version}")
-                }
             }
         }
     }
@@ -676,7 +663,8 @@ class BuildPlugin implements Plugin<Project> {
 
     private static void configurePom(Project project, MavenPublication publication) {
         // add all items necessary for publication
-        Provider<String> descriptionProvider = project.provider({ project.getDescription() })
+        String projectDescription = project.getDescription()
+        Provider<String> descriptionProvider = project.provider({ projectDescription })
         MavenPom pom = publication.getPom()
         pom.name = descriptionProvider
         pom.description = descriptionProvider
@@ -704,24 +692,27 @@ class BuildPlugin implements Plugin<Project> {
             }
         }
 
+        // Capture embedded dependency names eagerly as plain strings to avoid referencing
+        // Project or Configuration objects inside the withXml closure (configuration cache compatibility).
+        Configuration embedded = project.getConfigurations().findByName('embedded')
+        List<String> embeddedDepNames = embedded != null
+            ? embedded.getAllDependencies().collect { it.getName() }
+            : []
         publication.getPom().withXml { XmlProvider xml ->
             // add all items necessary for publication
             Node root = xml.asNode()
 
             // If we have embedded configuration on the project, remove its dependencies from the dependency nodes
             NodeList dependenciesNode = root.get("dependencies") as NodeList
-            Configuration embedded = project.getConfigurations().findByName('embedded')
-            if (embedded != null) {
-                embedded.getAllDependencies().all { Dependency dependency ->
-                    Iterator<Node> dependenciesIterator = dependenciesNode.get(0).children().iterator()
-                    while (dependenciesIterator.hasNext()) {
-                        Node dependencyNode = dependenciesIterator.next()
-                        String artifact = dependencyNode.get("artifactId").text()
-                        // handle scala variants by splitting via "_" and checking the first part
-                        if (artifact =~ dependency.getName().split('_')[0]) {
-                            dependenciesIterator.remove()
-                            break
-                        }
+            embeddedDepNames.each { String depName ->
+                Iterator<Node> dependenciesIterator = dependenciesNode.get(0).children().iterator()
+                while (dependenciesIterator.hasNext()) {
+                    Node dependencyNode = dependenciesIterator.next()
+                    String artifact = dependencyNode.get("artifactId").text()
+                    // handle scala variants by splitting via "_" and checking the first part
+                    if (artifact =~ depName.split('_')[0]) {
+                        dependenciesIterator.remove()
+                        break
                     }
                 }
             }

--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/IntegrationBuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/IntegrationBuildPlugin.groovy
@@ -60,15 +60,16 @@ class IntegrationBuildPlugin implements Plugin<Project> {
     private static void configureProjectZip(Project project) {
         // We do this after evaluation since the scala projects may change around what the final archive name is.
         // TODO: Swap this out with exposing those jars as artifacts to be consumed in a dist project.
+        Zip rootDistZip = project.rootProject.getTasks().getByName('distZip') as Zip
+        String folderName = project.rootProject.ext.folderName
         project.afterEvaluate {
-            Zip rootDistZip = project.rootProject.getTasks().getByName('distZip') as Zip
             rootDistZip.dependsOn(project.getTasks().pack)
 
             project.getTasks().withType(Jar.class) { Jar jarTask ->
                 // Add jar output under the dist directory
                 if (jarTask.name != "itestJar") {
                     rootDistZip.from(jarTask.archiveFile) { CopySpec copySpecification ->
-                        copySpecification.into("${project.rootProject.ext.folderName}/dist")
+                        copySpecification.into("${folderName}/dist")
                         copySpecification.setDuplicatesStrategy(DuplicatesStrategy.WARN)
                     }
                 }
@@ -81,15 +82,17 @@ class IntegrationBuildPlugin implements Plugin<Project> {
      * @param project to be configured
      */
     private static void configureRootProjectDependencies(Project project) {
-        project.getConfigurations().getByName('api').getAllDependencies()
-                .withType(ExternalDependency.class) { Dependency dependency ->
-                    // Set API dependencies as implementation in the uberjar so that not everything is compile scope
-                    project.rootProject.getDependencies().add('implementation', dependency)
-                }
+        project.afterEvaluate {
+            project.getConfigurations().getByName('api').getAllDependencies()
+                    .withType(ExternalDependency.class).each { Dependency dependency ->
+                        // Set API dependencies as implementation in the uberjar so that not everything is compile scope
+                        project.rootProject.getDependencies().add('implementation', dependency)
+                    }
 
-        project.getConfigurations().getByName('implementation').getAllDependencies()
-                .withType(ExternalDependency.class) { Dependency dependency ->
-                    project.rootProject.getDependencies().add('implementation', dependency)
-                }
+            project.getConfigurations().getByName('implementation').getAllDependencies()
+                    .withType(ExternalDependency.class).each { Dependency dependency ->
+                        project.rootProject.getDependencies().add('implementation', dependency)
+                    }
+        }
     }
 }

--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/RootBuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/RootBuildPlugin.groovy
@@ -73,7 +73,7 @@ class RootBuildPlugin implements Plugin<Project> {
 
         if (project.logger.isDebugEnabled()) {
             jar.doLast {
-                jar.getInputs().getFiles().each { project.logger.debug(":jar - Adding: $it") }
+                jar.getInputs().getFiles().each { jar.logger.debug(":jar - Adding: $it") }
             }
         }
     }
@@ -93,14 +93,16 @@ class RootBuildPlugin implements Plugin<Project> {
         distribution.dependsOn(distZip)
 
         // Location of the zip dir
-        project.rootProject.ext.folderName = "${distZip.archiveBaseName.get()}" + "-" + "${project.version}"
+        String folderName = "${distZip.archiveBaseName.get()}" + "-" + "${project.version}"
+        project.rootProject.ext.folderName = folderName
 
         // Copy root directory files to zip
-        distZip.from(project.rootDir) { CopySpec spec ->
+        File rootDir = project.rootDir
+        distZip.from(rootDir) { CopySpec spec ->
             spec.include("README.md")
             spec.include("LICENSE.txt")
             spec.include("NOTICE.txt")
-            spec.into("${project.rootProject.ext.folderName}")
+            spec.into("${folderName}")
         }
 
         // Copy master jar, sourceJar, and javadocJar to zip
@@ -108,14 +110,14 @@ class RootBuildPlugin implements Plugin<Project> {
             // Do not copy the hadoop testing jar
             project.getTasks().withType(Jar.class) { Jar jarTask ->
                 distZip.from(jarTask.archiveFile) { CopySpec spec ->
-                    spec.into("${project.rootProject.ext.folderName}/dist")
+                    spec.into("${folderName}/dist")
                 }
             }
         }
 
         // Log dist artifacts
         distZip.doLast {
-            distZip.getInputs().getFiles().each { project.logger.info(":distZip - Adding: $it")}
+            distZip.getInputs().getFiles().each { distZip.logger.info(":distZip - Adding: $it")}
         }
     }
 }

--- a/mr/build.gradle
+++ b/mr/build.gradle
@@ -85,12 +85,13 @@ sourceSets {
 }
 
 task generateGitHash {
+    def projectVersion = version
     inputs.property "revision", BuildParams.gitRevision
     outputs.dir generatedResources
 
     doLast {
         Properties props = new Properties()
-        props.put("version", version)
+        props.put("version", projectVersion)
         props.put("hash", BuildParams.gitRevision)
         File output = new File(generatedResources, "esh-build.properties")
         new File(generatedResources).mkdirs()


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [Fix DRA build deprecation warning (#2509)](https://github.com/elastic/elasticsearch-hadoop/pull/2509)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)