### PR TITLE
[9.2] [CI] Resolve pom name and description fields lazy (#2514)

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/hadoop/gradle/BuildPlugin.groovy
@@ -663,8 +663,7 @@ class BuildPlugin implements Plugin<Project> {
 
     private static void configurePom(Project project, MavenPublication publication) {
         // add all items necessary for publication
-        String projectDescription = project.getDescription()
-        Provider<String> descriptionProvider = project.provider({ projectDescription })
+        Provider<String> descriptionProvider = project.provider({ project.getDescription() })
         MavenPom pom = publication.getPom()
         pom.name = descriptionProvider
         pom.description = descriptionProvider


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[CI] Resolve pom name and description fields lazy (#2514)](https://github.com/elastic/elasticsearch-hadoop/pull/2514)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)