### PR TITLE
Update Slack references: #es-delivery-alerts -> #es-core-infra-alerts and user group

### DIFF
--- a/.buildkite/version-bump-pipeline.yml
+++ b/.buildkite/version-bump-pipeline.yml
@@ -1,14 +1,14 @@
 notify:
   - slack:
       channels:
-        - "#es-delivery-alerts"
-      message: "<!subteam^S08QCN4G2N4|es-delivery-team> Version bump to ${NEW_VERSION} — ${BUILDKITE_BUILD_URL}"
+        - "#es-core-infra-alerts"
+      message: "<!subteam^S0BHJLCCDQX|es-core-infra-team> Version bump to ${NEW_VERSION} — ${BUILDKITE_BUILD_URL}"
     if: (build.branch == 'main' || build.branch =~ /^[0-9]+\.[0-9x]+\$/) && (build.state == 'passed' || build.state == 'failed')
   - slack:
       channels:
-        - "#es-delivery-alerts"
+        - "#es-core-infra-alerts"
       message: |
-        <!subteam^S08QCN4G2N4|es-delivery-team>
+        <!subteam^S0BHJLCCDQX|es-core-infra-team>
         🚦 Pipeline waiting for approval 🚦
         Repo: `${REPO}`
 


### PR DESCRIPTION
Updates Slack references in the version-bump pipeline as part of consolidating team channels:
- `#es-delivery-alerts` -> `#es-core-infra-alerts` (channel rename; Slack channel ID unchanged).
- Slack user group `@es-delivery-team` (S08QCN4G2N4) -> `@es-core-infra-team` (S0BHJLCCDQX).