### PR TITLE
Update Delivery team label to Core/Infra in renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,7 @@
   "labels": [
     ">non-issue",
     ":Delivery/Build",
-    "Team:Delivery"
+    "Team:Core/Infra"
   ],
   "baseBranches": [
     "main"


### PR DESCRIPTION
Due to the recent re-org, the Delivery team transitioned into the Core/Infra team. The goal of this change is to address usages of the Delivery team label in this repo.