### PR TITLE
[8.19] Update Gradle wrapper to 9.7.1 (#2554)

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=87a2216cc1f9122192d4e0fe905ffdf1b4c72cff797e9f733b174e157cadd396
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.0-all.zip
+distributionSha256Sum=acd53f1edaf02f1a8ff99879f8a34b302661a057d9b063ae9e35b552f804d20a
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.1-bin.zip
 networkTimeout=10000
 retries=0
 retryBackOffMs=500


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Update Gradle wrapper to 9.7.1 (#2554)](https://github.com/elastic/elasticsearch-hadoop/pull/2554)

<!--- Backport version: 12.0.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)