### PR TITLE
Fix dist maven artifactId to elasticsearch-hadoop

### DIFF
--- a/dist/build.gradle
+++ b/dist/build.gradle
@@ -167,6 +167,7 @@ distribution {
 publishing {
     publications {
         main {
+            artifactId = 'elasticsearch-hadoop'
             artifact tasks.named('distZip')
             getPom().withXml { XmlProvider xml ->
                 Node root = xml.asNode()


### PR DESCRIPTION
## Summary

The `:dist` project was being published to maven with `artifactId=dist` instead of `elasticsearch-hadoop`, causing DRA builds to upload artifacts to `org/elasticsearch/dist/` instead of the correct `org/elasticsearch/elasticsearch-hadoop/`.

Root cause: the Maven publication `artifactId` defaults to the Gradle project name (`dist`). Even though `:dist` already sets `archivesName = 'elasticsearch-hadoop'`, that only affects archive file names, not the publication coordinates used by the NMCP aggregation zip.

The fix sets the `artifactId` directly on the `:dist` main publication:

```groovy
publications {
    main {
        artifactId = 'elasticsearch-hadoop'
        ...
    }
}
```

An earlier attempt renamed the Gradle project in `settings.gradle` (`project(":dist").name = "elasticsearch-hadoop"`), but that changed the project **path** to `:elasticsearch-hadoop`, breaking the `project(":dist")` reference in the root `build.gradle` and colliding with `rootProject.name = "elasticsearch-hadoop"`. Setting the publication `artifactId` avoids both problems.

## Verification

Built the aggregation zip locally (`./gradlew zipAggregation`); it now contains:

```
org/elasticsearch/elasticsearch-hadoop/9.6.0-SNAPSHOT/elasticsearch-hadoop-*.jar (+ pom, module, sources, javadoc, checksums)
```

alongside the other correctly-named artifacts, and the generated POM has `<artifactId>elasticsearch-hadoop</artifactId>`.

Spotted while reviewing DRA maven snapshot output in [#2559](https://github.com/elastic/elasticsearch-hadoop/pull/2559).
