### PR TITLE
[9.5] Fix dist maven artifactId to elasticsearch-hadoop (#2560)

### DIFF
--- a/dist/build.gradle
+++ b/dist/build.gradle
@@ -167,6 +167,7 @@ distribution {
 publishing {
     publications {
         main {
+            artifactId = 'elasticsearch-hadoop'
             artifact tasks.named('distZip')
             getPom().withXml { XmlProvider xml ->
                 Node root = xml.asNode()


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [Fix dist maven artifactId to elasticsearch-hadoop (#2560)](https://github.com/elastic/elasticsearch-hadoop/pull/2560)

<!--- Backport version: 12.0.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)