### PR TITLE
[9.5] [CI] Publish maven artifacts directly to snapshots.elastic.co via DRA (#2559)

### DIFF
--- a/.buildkite/dra-maven-publish.sh
+++ b/.buildkite/dra-maven-publish.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+# Publishes the exploded maven tree produced by :prepareDraSnapshotMavenAggregation
+# straight into the consumer-facing root prefixes on snapshots.elastic.co
+# (snapshot workflow) or artifacts.elastic.co (staging workflow):
+#
+#   s3://<bucket>/maven/<groupPath>/<artifact>/<version>/<file>
+#   s3://<bucket>/javadoc/<groupPath>/<artifact>/<version>/<html-tree>
+#
+# For each `*-javadoc.jar` in the maven tree we also unpack the browsable HTML
+# tree under `javadoc/<groupPath>/<artifact>/<version>/`.
+#
+# The version is already encoded in the exploded maven tree's directory layout
+# and the S3 target is the root `maven/` prefix, so no version env var is needed.
+# `MAVEN_AGGREGATION_DIR` overrides the source location for standalone use.
+#
+# Required environment:
+#   DRA_WORKFLOW           snapshot|staging (default: snapshot)
+#   AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY [/ AWS_SESSION_TOKEN]
+#                          exported via USE_MAVEN_S3_CREDENTIALS in pre-command
+
+set -euo pipefail
+
+DRA_WORKFLOW="${DRA_WORKFLOW:-snapshot}"
+
+case "$DRA_WORKFLOW" in
+  snapshot) BUCKET="snapshots.elastic.co" ;;
+  staging)  BUCKET="artifacts.elastic.co" ;;
+  *) echo "unsupported DRA_WORKFLOW='$DRA_WORKFLOW'" >&2; exit 2 ;;
+esac
+
+MAVEN_DIR="${MAVEN_AGGREGATION_DIR:-build/dra-maven-aggregation}"
+
+# Sanity guard: snapshot-versioned artifacts must not land in the staging bucket.
+if [[ "$DRA_WORKFLOW" == "staging" ]] && find "$MAVEN_DIR" -name '*-SNAPSHOT*' -maxdepth 4 -print -quit 2>/dev/null | grep -q .; then
+  echo "ERROR: staging workflow but SNAPSHOT artifacts found in $MAVEN_DIR — aborting." >&2
+  exit 2
+fi
+
+if [[ ! -d "$MAVEN_DIR" ]]; then
+  echo "DRA maven aggregation tree not found: $MAVEN_DIR" >&2
+  echo "  (produced by :prepareDraSnapshotMavenAggregation)" >&2
+  exit 1
+fi
+
+WORK_DIR="$(mktemp -d -t esh-maven-publish.XXXXXX)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+JAVADOC_DIR="$WORK_DIR/javadoc"
+mkdir -p "$JAVADOC_DIR"
+
+echo "--- Expanding javadoc jars"
+find "$MAVEN_DIR" -type f -name '*-javadoc.jar' -print0 | while IFS= read -r -d '' jar; do
+  rel="${jar#"$MAVEN_DIR/"}"
+  dir="$(dirname "$rel")"
+  target="$JAVADOC_DIR/$dir"
+  mkdir -p "$target"
+  unzip -q -o "$jar" -d "$target"
+done
+
+echo "--- Publishing to s3://$BUCKET/{maven,javadoc}/"
+# Use `cp --recursive` rather than `sync`: sync needs s3:ListBucket to diff the
+# remote against the local tree, which the `unified-release-maven` role does
+# not grant (only object-level Put/Get on `maven/*` and `javadoc/*`).
+aws s3 cp --recursive --no-progress --only-show-errors \
+  "$MAVEN_DIR/"   "s3://$BUCKET/maven/"
+aws s3 cp --recursive --no-progress --only-show-errors \
+  "$JAVADOC_DIR/" "s3://$BUCKET/javadoc/"
+
+echo "Published to:"
+echo "  https://$BUCKET/maven/"
+echo "  https://$BUCKET/javadoc/"

--- a/.buildkite/dra-workflow.yml
+++ b/.buildkite/dra-workflow.yml
@@ -5,6 +5,7 @@ steps:
     env:
       USE_DRA_CREDENTIALS: true
       USE_MAVEN_GPG: true
+      USE_MAVEN_S3_CREDENTIALS: true
     agents:
       provider: gcp
       image: family/elasticsearch-ubuntu-2404

--- a/.buildkite/dra.sh
+++ b/.buildkite/dra.sh
@@ -22,8 +22,10 @@ if [[ "$DRA_WORKFLOW" == "snapshot" ]]; then
   BUILD_ARGS[0]="-Dbuild.snapshot=true"
 fi
 
-RM_BRANCH="$BUILDKITE_BRANCH"
-if [[ "$BUILDKITE_BRANCH" == "main" ]]; then
+# Allow RM_BRANCH override so feature branches can resolve real DRA manifests
+# by passing RM_BRANCH=main (or a release branch) when testing.
+RM_BRANCH="${RM_BRANCH:-$BUILDKITE_BRANCH}"
+if [[ "$RM_BRANCH" == "main" ]]; then
   RM_BRANCH=master
 fi
 
@@ -45,13 +47,17 @@ mkdir localRepo
 wget --quiet "https://artifacts-$DRA_WORKFLOW.elastic.co/elasticsearch/${ES_BUILD_ID}/maven/org/elasticsearch/gradle/build-tools/${HADOOP_VERSION}${VERSION_SUFFIX}/build-tools-${HADOOP_VERSION}${VERSION_SUFFIX}.jar" \
   -O "localRepo/build-tools-${HADOOP_VERSION}${VERSION_SUFFIX}.jar"
 
-./gradlew -S -PlocalRepo=true "${BUILD_ARGS[@]}" -Dorg.gradle.warning.mode=summary -Dcsv="$WORKSPACE/build/distributions/dependencies-${HADOOP_VERSION}${VERSION_SUFFIX}.csv" :dist:generateDependenciesReport distribution zipAggregation
+./gradlew -S -PlocalRepo=true "${BUILD_ARGS[@]}" -Dorg.gradle.warning.mode=summary -Dcsv="$WORKSPACE/build/distributions/dependencies-${HADOOP_VERSION}${VERSION_SUFFIX}.csv" :dist:generateDependenciesReport distribution zipAggregation prepareDraSnapshotMavenAggregation
 
 # Allow other users access to read the artifacts so they are readable in the container
 find "$WORKSPACE" -type f -path "*/build/distributions/*" -exec chmod a+r {} \;
 
 # Allow other users write access to create checksum files
 find "$WORKSPACE" -type d -path "*/build/distributions" -exec chmod a+w {} \;
+
+echo --- Publishing maven artifacts to S3
+
+.buildkite/dra-maven-publish.sh
 
 echo --- Running release-manager
 

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -44,6 +44,18 @@ if [[ "${USE_MAVEN_GPG:-}" == "true" ]]; then
   export ORG_GRADLE_PROJECT_signingPassword
 fi
 
+if [[ "${USE_MAVEN_S3_CREDENTIALS:-}" == "true" ]]; then
+  aws_creds=$(vault read -format=json aws-elastic-ci-prod/creds/unified-release-maven)
+  AWS_ACCESS_KEY_ID=$(echo "$aws_creds" | jq -r .data.access_key)
+  AWS_SECRET_ACCESS_KEY=$(echo "$aws_creds" | jq -r .data.secret_key)
+  AWS_SESSION_TOKEN=$(echo "$aws_creds" | jq -r '.data.security_token // empty')
+  export AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
+  if [[ -n "$AWS_SESSION_TOKEN" ]]; then
+    export AWS_SESSION_TOKEN
+  fi
+  unset aws_creds
+fi
+
 if [[ "$USE_DRA_CREDENTIALS" == "true" ]]; then
   DRA_VAULT_ROLE_ID_SECRET=$(vault read -field=role-id secret/ci/elastic-elasticsearch-hadoop/legacy-vault-credentials)
   export DRA_VAULT_ROLE_ID_SECRET

--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,7 @@ description = 'Elasticsearch for Apache Hadoop'
 
 apply plugin: 'es.hadoop.build.root'
 apply plugin: 'com.gradleup.nmcp.aggregation'
+apply plugin: 'es.hadoop.dra-maven-aggregation'
 
 defaultTasks 'build'
 

--- a/buildSrc/src/main/java/org/elasticsearch/hadoop/gradle/DraMavenAggregationPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/hadoop/gradle/DraMavenAggregationPlugin.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.hadoop.gradle;
+
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.tasks.bundling.Zip;
+
+/**
+ * Registers the {@code prepareDraSnapshotMavenAggregation} task, which produces a
+ * DRA-shaped copy of the Central Portal aggregation built by
+ * {@code com.gradleup.nmcp.aggregation}.
+ *
+ * <p>The applying project is expected to have {@code com.gradleup.nmcp.aggregation}
+ * applied so the upstream {@code zipAggregation} task exists. This plugin
+ * intentionally does not touch {@code zipAggregation}; that task's output must
+ * remain Sonatype Central Portal compliant.
+ *
+ * <p>The task emits an <em>exploded</em> maven tree under
+ * {@code build/dra-maven-aggregation/} rather than a zip: the DRA publish step
+ * ({@code .buildkite/dra-maven-publish.sh}) runs inline in the
+ * same workspace and uploads the tree straight to S3, so re-zipping here just to
+ * unzip it again there would be wasted work.
+ *
+ * <p>To avoid zipping on the DRA path entirely, the task consumes
+ * {@code zipAggregation}'s copy-spec source (the already-extracted per-project
+ * publications) instead of the {@code aggregation.zip} archive, so that zip is
+ * never built for DRA. See {@link PrepareDraSnapshotMavenAggregation}.
+ */
+public class DraMavenAggregationPlugin implements Plugin<Project> {
+
+    @Override
+    public void apply(Project project) {
+        Provider<String> version = project.provider(() -> project.getVersion().toString());
+
+        project.getTasks().register(
+            "prepareDraSnapshotMavenAggregation",
+            PrepareDraSnapshotMavenAggregation.class,
+            task -> {
+                task.setGroup("dra");
+                task.setDescription(
+                    "Copies the maven aggregation content into the DRA snapshot layout: "
+                        + "renames Maven-timestamped snapshot filenames back to -SNAPSHOT "
+                        + "and generates per-version maven-metadata.xml."
+                );
+                // Reuse zipAggregation's copy-spec source (the extracted
+                // per-project publications) rather than its archive output, so
+                // the aggregation zip is never built on the DRA path. The
+                // lookup is deferred inside a plain provider (rather than
+                // resolved eagerly here, or mapped off the TaskProvider):
+                //  - TaskProvider.map would add a dependency on zipAggregation
+                //    itself, forcing the zip to build;
+                //  - resolving named("zipAggregation") eagerly at apply() time
+                //    would couple this plugin to being applied *after*
+                //    nmcp.aggregation.
+                // getSource()'s FileTree already carries the build dependencies
+                // of the underlying publication tasks, so @InputFiles
+                // establishes the correct task ordering on its own.
+                task.getSource().from(
+                    project.provider(() -> project.getTasks().named("zipAggregation", Zip.class).get().getSource())
+                );
+                task.getVersion().set(version);
+                task.getOutputDir().set(project.getLayout().getBuildDirectory().dir("dra-maven-aggregation"));
+            }
+        );
+    }
+}

--- a/buildSrc/src/main/java/org/elasticsearch/hadoop/gradle/PrepareDraSnapshotMavenAggregation.java
+++ b/buildSrc/src/main/java/org/elasticsearch/hadoop/gradle/PrepareDraSnapshotMavenAggregation.java
@@ -1,0 +1,216 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.hadoop.gradle;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.file.FileSystemOperations;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.IgnoreEmptyDirectories;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.InputFiles;
+import org.gradle.api.tasks.OutputDirectory;
+import org.gradle.api.tasks.PathSensitive;
+import org.gradle.api.tasks.PathSensitivity;
+import org.gradle.api.tasks.TaskAction;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Locale;
+import java.util.stream.Stream;
+
+import javax.inject.Inject;
+
+/**
+ * Repackages the Maven Central compliant aggregation zip produced by
+ * {@code com.gradleup.nmcp.aggregation} into the layout the DRA snapshot repo
+ * ({@code snapshots.elastic.co/maven/}) expects.
+ *
+ * <p>Rather than depend on the {@code aggregation.zip} archive and unpack it,
+ * this task reuses {@code zipAggregation}'s copy-spec source directly (the
+ * already-extracted per-project publications). That avoids materializing the
+ * DRA-side zip only to unzip it again in the publish step — nothing is zipped
+ * on the DRA path at all.
+ *
+ * <p>For snapshot versions this task:
+ * <ol>
+ *   <li>Sync-copies the aggregation source into an output directory, renaming
+ *       {@code -<yyyyMMdd.HHmmss>-<n>} segments to {@code -SNAPSHOT}.
+ *       Per-file checksum sidecars (.md5/.sha1/.sha*) hash the file bytes so
+ *       renaming them alongside their jar/pom is byte-safe.</li>
+ *   <li>Emits a minimal {@code maven-metadata.xml} per version directory
+ *       (with {@code <snapshot><localCopy>true</localCopy></snapshot>}), plus
+ *       checksum sidecars, so Gradle/Maven consumers can resolve
+ *       {@code <version>-SNAPSHOT} against the literal filenames.</li>
+ * </ol>
+ *
+ * <p>For non-snapshot (release) versions the extract is a plain sync and no
+ * metadata is generated.
+ *
+ * <p>See <a href="https://github.com/elastic/elasticsearch-team/issues/4297">
+ * elasticsearch-team#4297</a>.
+ */
+public abstract class PrepareDraSnapshotMavenAggregation extends DefaultTask {
+
+    // Match the timestamp + build-number segment that maven-publish emits for
+    // snapshot deploys, e.g. `-20260824.075015-1`. The trailing `\d+` is
+    // digit-only so classifier suffixes like `-sources` / `-javadoc` are
+    // preserved by the rename.
+    private static final String TIMESTAMP_REGEX = "-\\d{8}\\.\\d{6}-\\d+";
+
+    /**
+     * The already-extracted maven aggregation content, wired from
+     * {@code zipAggregation}'s copy-spec source so the DRA path never builds
+     * (or unpacks) the aggregation zip.
+     */
+    @InputFiles
+    @PathSensitive(PathSensitivity.RELATIVE)
+    @IgnoreEmptyDirectories
+    public abstract ConfigurableFileCollection getSource();
+
+    @Input
+    public abstract Property<String> getVersion();
+
+    @OutputDirectory
+    public abstract DirectoryProperty getOutputDir();
+
+    @Inject
+    protected abstract FileSystemOperations getFileSystemOperations();
+
+    @TaskAction
+    public void prepare() throws IOException {
+        String version = getVersion().get();
+        boolean snapshot = version.endsWith("-SNAPSHOT");
+        File outDir = getOutputDir().get().getAsFile();
+
+        getFileSystemOperations().sync(spec -> {
+            spec.from(getSource());
+            spec.into(outDir);
+            if (snapshot) {
+                spec.rename(TIMESTAMP_REGEX, "-SNAPSHOT");
+            }
+        });
+
+        if (snapshot == false) {
+            // Release (staging) path: plain sync with no rename or metadata.
+            // Artifact-level maven-metadata.xml is intentionally omitted: DRA
+            // consumers always resolve pinned coordinates and never need version
+            // discovery from the repo index.
+            return;
+        }
+
+        String lastUpdated = ZonedDateTime.now(ZoneOffset.UTC)
+            .format(DateTimeFormatter.ofPattern("yyyyMMddHHmmss"));
+        Path root = outDir.toPath();
+        // Collect the version directories eagerly before writing anything: we
+        // mutate each directory (adding maven-metadata.xml + sidecars) and must
+        // not do so while the lazy Files.walk directory stream is still open.
+        List<Path> versionDirs;
+        try (Stream<Path> stream = Files.walk(root)) {
+            versionDirs = stream.filter(Files::isDirectory)
+                .filter(PrepareDraSnapshotMavenAggregation::isVersionDirectory)
+                .toList();
+        }
+        versionDirs.forEach(versionDir -> writeSnapshotMetadata(root, versionDir, lastUpdated));
+    }
+
+    private static boolean isVersionDirectory(Path dir) {
+        // A version directory is `<groupPath>/<artifactId>/<version>/` and by
+        // convention contains at least one `.pom`. Using the pom presence as
+        // the marker avoids parsing filenames.
+        try (Stream<Path> s = Files.list(dir)) {
+            return s.anyMatch(p -> p.getFileName().toString().endsWith(".pom"));
+        } catch (IOException e) {
+            return false;
+        }
+    }
+
+    private static void writeSnapshotMetadata(Path root, Path versionDir, String lastUpdated) {
+        Path artifactDir = versionDir.getParent();
+        Path groupDir = artifactDir.getParent();
+
+        String version = versionDir.getFileName().toString();
+        String artifactId = artifactDir.getFileName().toString();
+
+        StringBuilder groupBuilder = new StringBuilder();
+        for (Path segment : root.relativize(groupDir)) {
+            if (groupBuilder.length() > 0) {
+                groupBuilder.append('.');
+            }
+            groupBuilder.append(segment.toString());
+        }
+        String groupId = groupBuilder.toString();
+
+        // <localCopy>true</localCopy> tells Maven/Gradle to resolve the literal
+        // "-SNAPSHOT" filename rather than looking for a timestamped version.
+        // This is correct here because dra-maven-publish.sh uploads files
+        // with the -SNAPSHOT suffix (not -yyyyMMdd.HHmmss-N).
+        String xml = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <metadata>
+              <groupId>%s</groupId>
+              <artifactId>%s</artifactId>
+              <version>%s</version>
+              <versioning>
+                <snapshot>
+                  <localCopy>true</localCopy>
+                </snapshot>
+                <lastUpdated>%s</lastUpdated>
+              </versioning>
+            </metadata>
+            """.formatted(groupId, artifactId, version, lastUpdated);
+
+        try {
+            Path metadata = versionDir.resolve("maven-metadata.xml");
+            Files.writeString(metadata, xml, StandardCharsets.UTF_8);
+            writeChecksumSidecars(metadata);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private static void writeChecksumSidecars(Path file) throws IOException {
+        byte[] bytes = Files.readAllBytes(file);
+        // Match the sidecar set nmcp already emits for the other artifacts in
+        // the zip; keeping them symmetric avoids surprise on the S3 side.
+        for (String algorithm : new String[] { "MD5", "SHA-1", "SHA-256", "SHA-512" }) {
+            try {
+                MessageDigest digest = MessageDigest.getInstance(algorithm);
+                String hex = HexFormat.of().formatHex(digest.digest(bytes));
+                String extension = "." + algorithm.toLowerCase(Locale.ROOT).replace("-", "");
+                Files.writeString(file.resolveSibling(file.getFileName() + extension), hex, StandardCharsets.UTF_8);
+            } catch (NoSuchAlgorithmException e) {
+                throw new IllegalStateException("Missing required digest " + algorithm, e);
+            }
+        }
+    }
+}

--- a/buildSrc/src/main/resources/META-INF/gradle-plugins/es.hadoop.dra-maven-aggregation.properties
+++ b/buildSrc/src/main/resources/META-INF/gradle-plugins/es.hadoop.dra-maven-aggregation.properties
@@ -1,0 +1,1 @@
+implementation-class=org.elasticsearch.hadoop.gradle.DraMavenAggregationPlugin


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [[CI] Publish maven artifacts directly to snapshots.elastic.co via DRA (#2559)](https://github.com/elastic/elasticsearch-hadoop/pull/2559)

<!--- Backport version: 12.0.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)